### PR TITLE
Fix layernorm duplicate rules and add layernorm_backward

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -173,7 +173,7 @@ def _get_decomp_table():
     decomp_table.pop(torch.ops.aten.threshold_backward.default)
     decomp_table.pop(torch.ops.aten.native_layer_norm.default)
     decomp_table.pop(torch.ops.aten.embedding_dense_backward.default)
-    # decomp_table.pop(torch.ops.aten.native_layer_norm_backward.default)
+    decomp_table.pop(torch.ops.aten.native_layer_norm_backward.default)
 
     # decompose addmm to allow for TP on mm
     decomp_table.pop(torch.ops.aten.addmm.default)

--- a/autoparallel/utils.py
+++ b/autoparallel/utils.py
@@ -34,7 +34,14 @@ def propagate_tensor_meta(op, user_args, out_strat):
         else:
             for ospec, tm in zip(strat.output_specs, new_tensor_meta):
                 if ospec is not None:
-                    ospec.tensor_meta = tm
+                    if ospec.tensor_meta != tm:
+                        # This is overcoming some limitations of the lack of
+                        # tensor_meta for sdpa which returns None
+                        # we should just fix this all across the board
+                        if ospec.tensor_meta is None:
+                            ospec.tensor_meta = tm
+                        else:
+                            assert tm is None
         if strat.input_specs is None:
             assert op in {
                 torch.ops.prims.convert_element_type.default,


### PR DESCRIPTION
This significantly reduces the number of nodes in the graph, leading to much faster execution for the solver