### PR TITLE
Fix computation cost to take number of arguments into account

### DIFF
--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -100,7 +100,7 @@ class ShardingOptimizer:
                         )
                         ds[(s_i, argi, ss, ii)] = {
                             "va": va,
-                            "cost": comm_cost + compute_cost,
+                            "cost": comm_cost + compute_cost / num_args[s_i],
                             "full_strat": ssi,
                             "out_strat": ssi.output_specs,
                             "inp_strat": ssi.input_specs[argi],


### PR DESCRIPTION
Previously, each argument would have the total computation cost for the operator, which would effectively lead to multiplying the computation cost by a factor of n_args.