### PR TITLE
Only add alias ops to inputs and outputs

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -44,6 +44,7 @@ def _add_alias(gm):
 
             node.replace_all_uses_with(alias_node, delete_user_cb=delete_user_cb)
 
+    """
     for node in nodes:
         # skip ops which return tuple
         if not isinstance(node.meta["val"], torch.Tensor):
@@ -56,16 +57,19 @@ def _add_alias(gm):
                 return n != alias_node
 
             node.replace_all_uses_with(alias_node, delete_user_cb=delete_user_cb)
+
     """
 
     for node in graph.find_nodes(op="output")[0].all_input_nodes:
         with graph.inserting_after(node):
             alias_node = graph.call_function(torch.ops.aten.alias.default, args=(node,))
             alias_node.meta.update(node.meta)
+
             def delete_user_cb(n):
                 return n != alias_node
+
             node.replace_all_uses_with(alias_node, delete_user_cb=delete_user_cb)
-    """
+
     gm.recompile()
     return gm
 


### PR DESCRIPTION
In the current setting it doesn't look like adding aliases everywhere is needed anymore. Plus, it makes the optimization much faster as we have half the number of nodes in the graph