### PR TITLE
Change AutoParallel API to accept only 'meta' initialized model

### DIFF
--- a/examples/example_autoparallel.py
+++ b/examples/example_autoparallel.py
@@ -72,7 +72,7 @@ dim2 = dim1 * 4
 
 
 def model_fn():
-    return Block(nheads, dim1, dim2).cuda()
+    return Block(nheads, dim1, dim2)
 
 
 def input_fn():
@@ -80,7 +80,9 @@ def input_fn():
 
 
 # parallelize the model
-autop = AutoParallel(model_fn, input_fn, mesh)
+with torch.device("meta"):
+    model = model_fn()
+autop = AutoParallel(model, input_fn, mesh, device="cuda")
 autop.add_parameter_memory_constraint(low=None, high=None)
 
 x_sharding = (Shard(0), Replicate())


### PR DESCRIPTION
Move the model from meta to FakeTensor inside AutoParallel.
- replaces the existing model parameters, which could be dangerous if an optimizer already referenced them, but since AutoParallel is changing the parameters (sizes) anyway, we already require that optimizers are created afterwards
- does not nicely support a model already initialized on an existing FakeTensorMode, which could be supported in principle but seems OK to skip