### PR TITLE
Remove python-3.11 constraint from black config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,6 @@ repos:
     rev: 22.3.0
     hooks:
     - id: black
-      language_version: python3.11
 
 -   repo: https://github.com/pycqa/flake8
     rev: 6.1.0


### PR DESCRIPTION
I happen to be using py=3.10 and I think its not necessary to specify strict 3.11 syntax checking.  For me, pre-commit hook fails to run becuase it can't find py-3.11 runtime.