### PR TITLE
Fix for invalid sharding and add self-contained example for Llama3 model from TorchTitan

### DIFF
--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -262,7 +262,6 @@ class ShardingOptimizer:
                                 if shape[dim] % mesh_shape == 0:
                                     shape[dim] /= mesh_shape
                                 else:
-                                    # print(f"adding constraint {node}, {str(spec.placements)}, {str(curr_spec.placements)}, {shape}, {mesh_shape}")
                                     self.prob += (
                                         self.ds[(s_i, counter, oi, ii)]["va"] == 0,
                                         _get_next_name("invalid_view"),

--- a/autoparallel/utils.py
+++ b/autoparallel/utils.py
@@ -131,7 +131,6 @@ def get_placement_options(mesh, op, specs, user_args):
                     if shape[dim] % mesh_shape == 0:
                         shape[dim] /= mesh_shape
                     else:
-                        print(f"removing invalid config {strategy} for {op}")
                         is_valid = False
                         break
         if is_valid:


### PR DESCRIPTION
This makes it easier to experiment with Llama3, as it doesn't require installing TorchTitan.

Also adds an example of how to add node constraints, and 1d mesh.

The example for the node constraint was necessary for now as the solution proposed was to all-gather the whole set of embeddings + inputs (which is small), and then shard it afterwards (which is free wrt comms as it would start from a replicate tensor). This is actually bad because the whole activation after the embedding is massive, but given that our solver doesn't take activation memory into account (only runtime and input memory), it thought it was fine to do it as is.

As a next step I'll look into adding some activation memory constraint, so that this type of behavior gets forbidden. Another solution would be to add a compute cost to embedding-bag, which for now has 0 compute cost as only gemm flops are taken into account.

# Fix for smaller batch size

This PR uncovered a bug in the sharding schemes for a number of ops. Indeed, the sharding schemes would allow to shard tensors on a dimension which was smaller than the world size. As an example, a tensor of shape `[32, 4096, 4096]` could previously be sharded as `S(0),S(0)` on a mesh of size `(32, 8)`. This case is now forbidden.

This should ideally be fixed upstream I believe.