### PR TITLE
Fix examples and add them to CI test

### DIFF
--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -37,3 +37,5 @@ jobs:
         pip install --no-input --quiet --pre torch --index-url https://download.pytorch.org/whl/nightly/cu126
         pip install --quiet .
         pytest tests
+        python examples/example_autoparallel.py
+        python examples/example_llama3.py

--- a/examples/example_llama3.py
+++ b/examples/example_llama3.py
@@ -586,7 +586,7 @@ device = torch.device("cuda")
 
 def model_fn():
     model_args = TransformerModelArgs(
-        n_layers=32, vocab_size=vocab_size, max_seq_len=seqlen
+        n_layers=8, vocab_size=vocab_size, max_seq_len=seqlen
     )
     m = Transformer(model_args)
     return m
@@ -628,6 +628,7 @@ print(f"Took {time.time() - t:.2f} s")
 parallel_mod = autop.apply_placement(sharding_placement)
 
 # run weight init on our sharded DTensor params
+parallel_mod.to_empty(device="cuda")
 parallel_mod.init_weights()
 
 # now let's run it


### PR DESCRIPTION
also reduces size of examples_llama3.py to be 8 layers instead of 32, which works around an OOM in the small CI gpu