### PR TITLE
Update convert_element_type_rule to latest PyTorch signature

### DIFF
--- a/autoparallel/propagation_rules.py
+++ b/autoparallel/propagation_rules.py
@@ -535,8 +535,7 @@ def native_layer_norm_backward_rule(mesh, op_schema):
 def convert_element_type_rule(mesh, op_schema):
     from torch.distributed.tensor._ops._tensor_ops import default_strategy
 
-    # TODO: API has changed in latest main
-    out_strat = default_strategy(mesh, op_schema)
+    out_strat = default_strategy(op_schema)
     return out_strat
 
 


### PR DESCRIPTION
Taken from https://github.com/pytorch-labs/autoparallel/pull/29