### PR TITLE
keep input mutations in the joint graph

### DIFF
--- a/autoparallel/export_module.py
+++ b/autoparallel/export_module.py
@@ -120,6 +120,7 @@ def aot_export_module(
             no_tangents=False,
             pre_dispatch=pre_dispatch,
             dynamic_shapes=dynamic_shapes,
+            keep_input_mutations=True,
             kwargs=kwargs,
         )
 


### PR DESCRIPTION
can't land until https://github.com/pytorch/pytorch/pull/157730 lands first.

After patching this into Francisco's deepseek example from https://github.com/pytorch-labs/autoparallel/pull/29, I hit:
```
[rank0]:   File "/data/users/hirsheybar/c/pytorch/autoparallel/autoparallel/utils.py", line 61, in propagate_tensor_meta
[rank0]:     assert op in supported_ops, (
[rank0]: AssertionError: aten.copy_.default strategy doesn't have input_specs, only harcoded {supported_ops} for now
```