### PR TITLE
Fix grouped_mm alignment issue

### DIFF
--- a/autoparallel/compute_estimation.py
+++ b/autoparallel/compute_estimation.py
@@ -206,16 +206,10 @@ def estimate_strategy_runtime_cost(node, strategy):
 
     # TODO: maybe cache the flop_counter to avoid recreating it
     # all the time
-    try:
-        with FlopCounterMode(display=False) as flop_counter:
-            node.target(*args, **kwargs)
+    with FlopCounterMode(display=False) as flop_counter:
+        node.target(*args, **kwargs)
 
-        flops = flop_counter.get_total_flops()
-    except RuntimeError as exc:
-        if node.target == torch.ops.aten._grouped_mm.default:
-            flops = float("inf")
-        else:
-            raise exc
+    flops = flop_counter.get_total_flops()
 
     # TODO: fix this
     dtype = strategy.input_specs[0].tensor_meta.dtype

--- a/autoparallel/propagation_rules.py
+++ b/autoparallel/propagation_rules.py
@@ -80,7 +80,7 @@ def _build_meta_tensor(tensor_meta):
     )
 
 
-def remove_invalid_configs(out_strat, mesh):
+def remove_invalid_configs(out_strat, mesh, required_alignment=1):
     kept = []
     for strategy in out_strat.strategies:
         is_valid = True
@@ -100,6 +100,13 @@ def remove_invalid_configs(out_strat, mesh):
                     else:
                         is_valid = False
                         break
+                    if required_alignment != 1:
+                        if shape[dim] % required_alignment != 0:
+                            is_valid = False
+                            print(
+                                f"Removing strategy due to alignment: {strategy} becuase of {dim=}, {shape[dim]=} {mesh_shape=}"
+                            )
+                            break
         if is_valid:
             kept.append(strategy)
 

--- a/autoparallel/utils.py
+++ b/autoparallel/utils.py
@@ -184,7 +184,13 @@ def get_placement_options(mesh, op, specs, user_args, user_kwargs):
 
     propagate_tensor_meta(op, user_args, user_kwargs, out_strat)
     fill_missing_redistribute_cost(op, specs, out_strat)
-    out_strat = remove_invalid_configs(out_strat, mesh)
+
+    required_alignment = 1
+    if op == torch.ops.aten._grouped_mm.default:
+        required_alignment = 16
+    out_strat = remove_invalid_configs(
+        out_strat, mesh, required_alignment=required_alignment
+    )
 
     return out_strat
 


### PR DESCRIPTION
Add 'required_alignment' kwarg to helper that removes invalid sharding configs.  Set 'required_alignment=16' for removal of invalid sharding for grouped_mm op, to remove shardings that would leave a local tensor with local dim size e.g. 44 that is otherwise valid but would result in a non-16-byte aligned mm.

Remove try/catch around compute-cost modeling of group_mm, since we now only call into it with valid tensor sizes.