### PR TITLE
Make some progress on OmniFMv2 autoparallel

### DIFF
--- a/autoparallel/export_module.py
+++ b/autoparallel/export_module.py
@@ -134,13 +134,8 @@ def aot_export_module(
             output_gradients = []
             for a, grad in zip(args, gradients):
                 if isinstance(a, torch.Tensor) and a.requires_grad:
-                    assert (
-                        grad is not None
-                    ), """\
-Found a parameter that did not receive a gradient.
-"This is most likely a bug, but if this needs to be supported please comment on this Github issue:
-https://github.com/pytorch/pytorch/issues/101192
-"""
+                    if grad is None:
+                        grad = torch.zeros_like(a)
                     output_gradients.append(grad)
                 else:
                     assert grad is None


### PR DESCRIPTION
Summary:
- Don't run the eager validation by default as it's slow to compile all Triton kernels
- Do tracing under correct autocast context so we don't have type errors in
  Triton
- Support unused parameter by zero-filling its gradients

```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/data/users/ezyang/fbsource/buck-out/v2/gen/fbcode/79edfec43235a7de/pytorch/autoparallel/fb/__example_omnifmv2_uniarch_small__/example_omnifmv2_uniarch_small#link-tree/__run_lpar_main__.py", line 39, in <module>
[rank0]:     __invoke_main()
[rank0]:   File "/data/users/ezyang/fbsource/buck-out/v2/gen/fbcode/79edfec43235a7de/pytorch/autoparallel/fb/__example_omnifmv2_uniarch_small__/example_omnifmv2_uniarch_small#link-tree/__run_lpar_main__.py", line 36, in __invoke_main
[rank0]:     run_as_main(module, main_function)
[rank0]:   File "/data/users/ezyang/fbsource/buck-out/v2/gen/fbcode/79edfec43235a7de/pytorch/autoparallel/fb/__example_omnifmv2_uniarch_small__/example_omnifmv2_uniarch_small#link-tree/__par__/meta_only/bootstrap.py", line 99, in run_as_main
[rank0]:     oss_run_as_main(
[rank0]:   File "/data/users/ezyang/fbsource/buck-out/v2/gen/fbcode/79edfec43235a7de/pytorch/autoparallel/fb/__example_omnifmv2_uniarch_small__/example_omnifmv2_uniarch_small#link-tree/__par__/bootstrap.py", line 70, in run_as_main
[rank0]:     runpy._run_module_as_main(main_module, alter_argv=False)
[rank0]:   File "<frozen runpy>", line 198, in _run_module_as_main
[rank0]:   File "<frozen runpy>", line 88, in _run_code
[rank0]:   File "/data/users/ezyang/fbsource/buck-out/v2/gen/fbcode/79edfec43235a7de/pytorch/autoparallel/fb/__example_omnifmv2_uniarch_small__/example_omnifmv2_uniarch_small#link-tree/pytorch/autoparallel/fb/example_omnifmv2_uniarch_small.py", line 4391, in <module>
[rank0]:     autop = AutoParallel(model, input_fn, mesh)
[rank0]:             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/data/users/ezyang/fbsource/buck-out/v2/gen/fbcode/79edfec43235a7de/pytorch/autoparallel/fb/__example_omnifmv2_uniarch_small__/example_omnifmv2_uniarch_small#link-tree/autoparallel/api.py", line 246, in __init__
[rank0]:     self.build_model_graph()
[rank0]:   File "/data/users/ezyang/fbsource/buck-out/v2/gen/fbcode/79edfec43235a7de/pytorch/autoparallel/fb/__example_omnifmv2_uniarch_small__/example_omnifmv2_uniarch_small#link-tree/autoparallel/api.py", line 289, in build_model_graph
[rank0]:     _add_alias(gm)
[rank0]:   File "/data/users/ezyang/fbsource/buck-out/v2/gen/fbcode/79edfec43235a7de/pytorch/autoparallel/fb/__example_omnifmv2_uniarch_small__/example_omnifmv2_uniarch_small#link-tree/autoparallel/api.py", line 40, in _add_alias
[rank0]:     first_user = nodes[min(node_map[n] for n in node.users)]
[rank0]:                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/data/users/ezyang/fbsource/buck-out/v2/gen/fbcode/79edfec43235a7de/pytorch/autoparallel/fb/__example_omnifmv2_uniarch_small__/example_omnifmv2_uniarch_small#link-tree/autoparallel/api.py", line 40, in <genexpr>
[rank0]:     first_user = nodes[min(node_map[n] for n in node.users)]
[rank0]:                            ~~~~~~~~^^^
[rank0]: KeyError: output
```

Reviewed By: bdhirsh

Differential Revision: D77868064


