### PR TITLE
Make pre-commit mypy match CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,12 @@ repos:
         additional_dependencies: [toml]
         args: ["--profile", "black"]
 
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.10.0'
+-   repo: local
     hooks:
     -   id: mypy
+        name: mypy
+        entry: mypy
+        language: system
+        types: [python]
+        exclude: (docs|examples)
+        args: ["--ignore-missing-imports", "--scripts-are-modules", "--pretty"]


### PR DESCRIPTION
Problem:
pre-commit runs mypy in its own virtual env. Before this PR, it had no other packages installed (e.g. torch, pulp, numpy) which prevented it from running mypy checking on things involving torch types.  CI's lint.yml runs mypy in the parent environment with nightly torch installed.  This meant CI complained about stuff that I couldn't repro by running pre-commit locally.

First try:
additional_dependencies can be specified to install necessary packages into the mypy-specific environment.  However, it is not possible to specify '--pre torch' to get the latest nightly automatically.  Using torch as a dep fails becuase some types (DTensor OpSpec for one) differ between older torch versions and the latest nightly.

This PR:
runs mypy in precommit in the outer environment.  This basically means, it is up to you to have a sane version of torch installed in your active env, but if you do then things will match CI.