### PR TITLE
Move compile into AutoParallel API

### DIFF
--- a/examples/example_llama3.py
+++ b/examples/example_llama3.py
@@ -605,7 +605,7 @@ with torch.device("meta"):
 mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16, reduce_dtype=torch.float32)
 
 # parallelize the model
-with AutoParallel(model, input_fn, mesh, mp_policy) as autop:
+with AutoParallel(model, input_fn, mesh, mp_policy, compile=True) as autop:
     autop.add_parameter_memory_constraint(low=None, high=None)
 
     x_sharding = (Shard(0),) + (Replicate(),) * (mesh.ndim - 1)


### PR DESCRIPTION
Requires upstream https://github.com/pytorch/pytorch/pull/159814 to land first. (done)

also updates joint_with_descriptors meta info to reflect that arg/placeholder shapes have changed (inputs and params are now sharded, not global, as they were when first traced). 

kicked off a verification run from this PR @ acaaf9c: https://www.internalfb.com/mlhub/pipelines/runs/mast/torchtitan-64-whc-kf1llhnr

tbm FSDP_eager:torchtitan-64-whc-p3s1bn compile_pr:torchtitan-64-whc-kf1llhnr compile_noac_from_update_post:torchtitan-64-fmassa-r4rvfnf6

hmm. this compile PR has higher memory usage than the compile_noac job we had last week.. what changed..
rerun w/ memory profiling: https://www.internalfb.com/mlhub/pipelines/runs/mast/torchtitan-64-whc-k3l2mcd
