### PR TITLE
Refactor ac_joint_pass to separate manual operator policy from automatic staging

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -206,7 +206,7 @@ class AutoParallel:
         compile: bool = False,
         enable_ac: bool = True,
         # None means 'auto'
-        ac_stage_size_in_GiB: Optional[float] = None,
+        ac_stage_size_in_GiB: Optional[Union[float, str]] = "auto",
     ):
         self.stack = ExitStack()
         self.fake_mode = (


### PR DESCRIPTION
This is a small refactoring so that we separate out the automatic AC part from the manual policy selection, so that it makes it easier to use one vs the other.

There are lots of line changes because I moved one function which was internal to the main scope, otherwise the changes are minor.

I've also added back support for not applying AC (through `None`),  and now enabling auto ac is done through `"auto"`.