### PR TITLE
Enable 2d optim by default and fix refactoring bug

### DIFF
--- a/autoparallel/apply_sharding.py
+++ b/autoparallel/apply_sharding.py
@@ -28,7 +28,7 @@ from .ordered_sharding import (
 )
 from .propagation_rules import TENSOR_FACTORY_OPS
 
-_ENABLE_ORDERED_SHARDING_OPTIMIZATION = False
+_ENABLE_ORDERED_SHARDING_OPTIMIZATION = True
 
 
 class ApplyShardingInterpreter(torch.fx.Interpreter):

--- a/autoparallel/ordered_sharding.py
+++ b/autoparallel/ordered_sharding.py
@@ -106,7 +106,7 @@ def compute_optimal_placement_order_for_parameters(module, sharding_placement):
             # maybe?
             last_p = list(last_p.users.keys())[0]
         for p in p_chain:
-            param_and_grad_users[p] = grad
+            param_and_grad_users[p] = param
 
         last_g = grad
         g_chain = []


### PR DESCRIPTION
The bug was introduced during cleanup in https://github.com/meta-pytorch/autoparallel/pull/78/commits/bbaf1ea961589081abeb919aac3bddefdafd7d40 and effectively meant we were not applying the optimization

Here are a set of jobs showing that it works and shows roughly 2x speedup compared to without the optimization

```
tbm bs_1:torchtitan-64-fmassa-tbc9d5 bs_1_fix:torchtitan-64-fmassa-t6b70tb

tbm bs_2:torchtitan-64-fmassa-zgbbgtp bs_2_fix:torchtitan-64-fmassa-dnbdxcm

tbm bs_4:torchtitan-64-fmassa-td0zrvg1 bs_4_fix:torchtitan-64-fmassa-h9zgbpw1
```

One thing worth noticing is that for bs=8 (which is the configuration that is equivalent as the bs=1 case for 1d), the solver decided to go straight with FSDP, which is probably a reasonable thing to do here.