### PR TITLE
Optimize nD collectives into 1d collective

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -309,6 +309,12 @@ class AutoParallel:
         #    - contains another instance of subclass info in self
         #    - quite a lot of use of runtime_metadata
         #
+        from torch._subclasses.fake_tensor import unset_fake_temporarily
+
+        with unset_fake_temporarily():
+            # creates a new mesh and caches it internally
+            # we don't need to keep a reference to it
+            self.mesh._flatten()
         with self.fake_mode:
             (
                 parallel_gm,


### PR DESCRIPTION
This optimizes cases like S(0)S(0)->RR, by instead of doing two collectives we perform a single one on a process group which encompasses both mesh dimensions.

We should generalize this to handle more cases. In particular, for 3d+ meshes we might want to create different variants of the flat mesh to handle `S(0)S(0)R -> RRR` for example.

On Llama8B 2d, this optimization brings 12% speedup with no change in memory.

```
tbm before:torchtitan-64-fmassa-pg6516 this_pr:torchtitan-64-fmassa-kgwhrzd
```