### PR TITLE
Log to tlparse using GraphModule.print_readable for stack traces

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -283,8 +283,9 @@ class AutoParallel:
                 "name": "autoparallel_joint_graph",
                 "encoding": "string",
             },
-            # TODO: Use print_readable instead with useful options
-            payload_fn=lambda: str(gm.graph),
+            payload_fn=lambda: gm.print_readable(
+                print_output=False, include_stride=True, include_device=True
+            ),
         )
 
         self.gm = gm
@@ -384,7 +385,9 @@ class AutoParallel:
                 "name": "autoparallel_parallel_graph",
                 "encoding": "string",
             },
-            payload_fn=lambda: str(parallel_gm.graph),
+            payload_fn=lambda: parallel_gm.print_readable(
+                print_output=False, include_stride=True, include_device=True
+            ),
         )
         # now rename input/param/tangent/output/grad_param/grad_input nodes following
         # our convention


### PR DESCRIPTION
https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/xmfan/793f3e6d-d833-4d94-9e14-1a7a16ec0d6a/custom/rank_0/index.html?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000

Affected graphs:
- https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/xmfan/793f3e6d-d833-4d94-9e14-1a7a16ec0d6a/custom/rank_0/-_-_-_-/autoparallel_joint_graph_0.txt?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000
- https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/xmfan/793f3e6d-d833-4d94-9e14-1a7a16ec0d6a/custom/rank_0/-_-_-_-/autoparallel_parallel_graph_2.txt?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000