### PR TITLE
Only flatten DeviceMesh if it's not 1d

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -326,7 +326,11 @@ class AutoParallel:
         with unset_fake_temporarily():
             # creates a new mesh and caches it internally
             # we don't need to keep a reference to it
-            self.mesh._flatten()
+            # TODO: remove ndim == 1 special case once
+            # DeviceMesh._flatten is fixed
+            mesh = self.mesh
+            if mesh.ndim != 1:
+                mesh._flatten()
         with self.fake_mode:
             (
                 parallel_gm,

--- a/autoparallel/ordered_sharding.py
+++ b/autoparallel/ordered_sharding.py
@@ -36,7 +36,12 @@ def _optimize_same_nd_sharding_as_1d(
 
     print(f"Doing optimization for {str(curr_spec)} -> {str(tgt_spec)}")
     mesh = curr_spec.device_mesh
-    flat_mesh = mesh._flatten()
+    # TODO: remove ndim == 1 special case once
+    # DeviceMesh._flatten is fixed
+    if mesh.ndim != 1:
+        flat_mesh = mesh._flatten()
+    else:
+        flat_mesh = mesh
     flat_curr_spec = DTensorSpec(
         flat_mesh, (curr_spec_first,), tensor_meta=curr_spec.tensor_meta
     )


### PR DESCRIPTION
This fixes CI and I believe should be fixed in PyTorch itself