### PR TITLE
Support tuple of tensors in estimate_strategy_runtime_cost

### DIFF
--- a/autoparallel/compute_estimation.py
+++ b/autoparallel/compute_estimation.py
@@ -228,7 +228,7 @@ def estimate_strategy_runtime_cost(node, strategy):
             sizes, strides = args_sizes_strides[counter]
             x = torch.empty_strided(sizes, strides, device=x.device, dtype=x.dtype)
             counter += 1
-            new_flat_args.append(x)
+        new_flat_args.append(x)
     args = treespec.unflatten(new_flat_args)
 
     # TODO: maybe cache the flop_counter to avoid recreating it


### PR DESCRIPTION
Previously, if we had tuple of tensors as an argument to a function, we wouldn't apply any sharding on it. This is split from https://github.com/meta-pytorch/autoparallel/pull/26 , where I originally found this issue