### PR TITLE
Remove invalid S(2) rules from SDPA

### DIFF
--- a/autoparallel/propagation_rules.py
+++ b/autoparallel/propagation_rules.py
@@ -694,6 +694,22 @@ def _(mesh, op_schema):
     return sdpa_rule(op, mesh, op_schema)
 
 
+@register_opschema_rule(
+    torch.ops.aten._scaled_dot_product_flash_attention_backward.default
+)
+def _(mesh, op_schema):
+    op = torch.ops.aten._scaled_dot_product_flash_attention_backward.default
+    return sdpa_rule(op, mesh, op_schema)
+
+
+@register_opschema_rule(
+    torch.ops.aten._scaled_dot_product_efficient_attention_backward.default
+)
+def _(mesh, op_schema):
+    op = torch.ops.aten._scaled_dot_product_efficient_attention_backward.default
+    return sdpa_rule(op, mesh, op_schema)
+
+
 @register_opschema_rule(torch.ops.aten.reshape.default)
 def reshape_rule(mesh, op_schema):
     op = torch.ops.aten.reshape.default


### PR DESCRIPTION
I had removed the fwd rules but forgot the bwd rules. They showed up when working on the view->mm->view PR, so splitting them from https://github.com/meta-pytorch/autoparallel/pull/26