### PR TITLE
Strict mode export

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -217,7 +217,11 @@ class AutoParallel:
                 inputs = (inputs,)
 
         with set_dtype_cast(True):
-            ep = torch.export.export(self.model, inputs)
+            with torch._dynamo.config.patch(install_free_tensors=True):
+                # pre-dispatch graph
+                ep = torch.export.export(self.model, inputs, strict=True)
+
+            # post-dispatch graph
             self.joint_with_descriptors = aot_export_joint_with_descriptors(
                 self.stack,
                 ep.module(),

--- a/examples/example_autoparallel.py
+++ b/examples/example_autoparallel.py
@@ -134,10 +134,8 @@ mm_nodes = autop.gm.graph.find_nodes(
     op="call_function", target=torch.ops.aten.mm.default
 )
 
-# assert (
-#     mm_nodes[0].meta.get("recompute")
-#     == torch.utils.checkpoint.CheckpointPolicy.PREFER_RECOMPUTE
-# )
-
-# TODO: change this assert once we fix AC
-assert mm_nodes[0].meta.get("recompute") is None
+# Tags are on the graph, but won't recompute until we land the pre-dispatch AC HOP
+assert (
+    mm_nodes[0].meta.get("recompute")
+    == torch.utils.checkpoint.CheckpointPolicy.PREFER_RECOMPUTE
+)


### PR DESCRIPTION
https://github.com/meta-pytorch/autoparallel/pull/93#issuecomment-3211255910

`install_free_tensors=True` forces export into using unspecialized modules (for the param dtype casting), which Tugsuu tells me export wants to default on anyways