### PR TITLE
fix .sh format

### DIFF
--- a/mast/mount.sh
+++ b/mast/mount.sh
@@ -1,8 +1,3 @@
-# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
-# #
-# # This source code is licensed under the BSD license found in the
-# # LICENSE file in the root directory of this source tree.
-
 #!/bin/bash
 export PS4=' + [$(date +"%Y-%m-%d %H:%M:%S,%3N")] '
 set -eExu -o pipefail

--- a/mast/run_torchtitan.sh
+++ b/mast/run_torchtitan.sh
@@ -1,8 +1,3 @@
-# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
-# #
-# # This source code is licensed under the BSD license found in the
-# # LICENSE file in the root directory of this source tree.
-
 #!/bin/bash
 
 set -x


### PR DESCRIPTION
i added licenses to everything bc i thought linter cared, at least it cares about .py files.
https://www.internalfb.com/mlhub/pipelines/runs/mast/torchtitan-16-whc-p6jt5g6?version=0&env=PRODUCTION&referrer=MAST_JOB_NOTIFICATION_BOT&tab=debug&job_attempt=0

but in these .sh scripts it caused actual job failures.  maybe i can figure out a way to add the license below the #! and still satisfy linter? lets see if it still complains in this PR