### PR TITLE
Add profiling-based functions for compute runtime estimation

### DIFF
--- a/autoparallel/compute_estimation.py
+++ b/autoparallel/compute_estimation.py
@@ -334,11 +334,9 @@ def benchmark_strategy_runtime_cost(node, strategy):
 
 
 def benchmark_fn(fn, *args, **kwargs):
-    torch.cuda.synchronize()
     n_warmup = 3
     for _ in range(n_warmup):
         fn(*args, **kwargs)
-    torch.cuda.synchronize()
 
     num_iters = 10
     start_event = torch.cuda.Event(enable_timing=True)


### PR DESCRIPTION
This will allow us to validate our cost models for compute ops, and potentially create better models in the future