### PR TITLE
Make it easier to see when redistributions happen in get_log

### DIFF
--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -651,11 +651,7 @@ class ShardingOptimizer:
                     )
             # this is an annoying special case
             if node.target == operator.getitem:
-                idx = node.args[1]
-                src_strat = d_inputs[0][0]["out_strat"][idx]
-                dst_strat = d[0]["inp_strat"]
                 redistributions = []
-                # redistributions.append((0, node.args[0], src_strat, dst_strat))
             preline = ""
             if redistributions:
                 preline += f"\n    # Redistributing for node {str(node)}:"
@@ -665,15 +661,12 @@ class ShardingOptimizer:
                     comment = f"# shape={str(tuple(src.shape))}, comm_cost={d[i]['comm_cost']}"
                     preline += f"\n    # {str(n)} = redistribute({str(n)}, src={src_s}, dst={dst_s})  {comment}"
             strat = str(d[0]["full_strat"])
-            costs = [x["compute_cost"] for x in d]
-            costs = sum(costs)
+            costs = sum(x["compute_cost"] for x in d)
             device_order = getattr(node.meta, "device_order", None)
+            device_order_str = ""
             if device_order:
-                line = f"  {plc_txt}{attr_color(strat)} device_order: {device_order} {cost_txt}{attr_color(str(costs))}"
-            else:
-                line = (
-                    f"  {plc_txt}{attr_color(strat)} {cost_txt}{attr_color(str(costs))}"
-                )
+                device_order_str = f" device_order={device_order} "
+            line = f"  {plc_txt}{attr_color(strat)}{device_order_str} {cost_txt}{attr_color(str(costs))}"
             if node.op == "placeholder":
                 line = f"    # {node.name}: {line}"
                 code.insert(l_id, line)


### PR DESCRIPTION
In the previous implementation of `get_log`, finding the src placement corresponding to a given redistribution cost was annoying, as it required looking at the placement for the input node of a given operation.
This lead to sometimes hard to understand costs, as situations like the following happened quite often
```python
x1 = op(x0)  # S(1) -> S(1), cost=[0]
x2 = alias(x1)   # S(0) -> S(0), cost=[10]
```
which could give the impression that there was a redistribution happening for the `alias` operator as `S(0) -> S(0)`, but in fact it's actually its input which is being redistributed from `S(1)` to `S(0)`.

This PR changes the representation to add additional comment lines, which explicitly mention the src and tgt placement for every redistribution.

The new implementation looks as follows:
```python
# Redistributing for node permute_7:
# dtype_cast_5 = redistribute(dtype_cast_5, src=S(0)S(0), dst=RR)  # shape=(4096, 4096), comm_cost=525.239242769773
```

One drawback of the current implementation is that now we might have more lines in the file for different sharding decisions, which might make it harder to compare two sharding decisions. I might change this behavior prior to merging this PR.