### PR TITLE
Add manual constraints in Llama3 example

### DIFF
--- a/examples/example_llama3.py
+++ b/examples/example_llama3.py
@@ -636,6 +636,8 @@ def force_tp_constraints(autop, mm_nodes, feat_dim=1, bwd_constraint=False):
     add_node_constraint = autop.sharding_optimizer.add_node_constraint
     fwd_bwd_groups = group_mm_nodes_with_its_gradients(mm_nodes)
     fwd_nodes = list(fwd_bwd_groups.keys())
+    dim1 = 0 if feat_dim == 1 else 1
+    dim2 = 1 if feat_dim == 1 else 0
     # assume there are 7 mm nodes per transformer block
     # skip last mm as it's the final projection layer
     assert (
@@ -653,7 +655,7 @@ def force_tp_constraints(autop, mm_nodes, feat_dim=1, bwd_constraint=False):
             if bwd_constraint:
                 bwd_nodes = fwd_bwd_groups[n]
                 # first is g_w, second is g_x
-                add_node_constraint(bwd_nodes[0], (Partial(), Shard(1)))
+                add_node_constraint(bwd_nodes[0], (Partial(), Shard(dim1)))
                 add_node_constraint(bwd_nodes[1], (Shard(0), Partial()))
 
         # add reduction to finish TP, yielding S(0)P
@@ -666,7 +668,7 @@ def force_tp_constraints(autop, mm_nodes, feat_dim=1, bwd_constraint=False):
             if bwd_constraint:
                 bwd_nodes = fwd_bwd_groups[n]
                 # first is g_w, second is g_x
-                add_node_constraint(bwd_nodes[0], (Partial(), Shard(0)))
+                add_node_constraint(bwd_nodes[0], (Partial(), Shard(dim2)))
                 add_node_constraint(bwd_nodes[1], (Shard(0), Shard(feat_dim)))
 
 


### PR DESCRIPTION
This PR is in preparation to switching the flags for enabling fusing `nn.Linear` into a single op, as well as the new `add_alias_v2` flag, as well as for merging https://github.com/meta-pytorch/autoparallel/pull/125

This is also helpful for identifying potential problems with the cost model for comms / compute.

This can also serve as an example of how users can customize precise shardings of their model, without having to change user-code. We might want to add helper ops so that this customization can happen directly in the model code as well, but I'm keeping it completely separate for now.

I've also removed the embedding constraint for 1d -- it is not needed anymore now that we have a cost model for memory-bound ops (like Embedding).