### PR TITLE
Add initial version of GraphView

### DIFF
--- a/autoparallel/graph_view.py
+++ b/autoparallel/graph_view.py
@@ -32,11 +32,14 @@ class Container:
         self.name = name
         self.klass = klass
         self.data = []
+        self.unique_nodes = set()
         # self.children = defaultdict(Container)
         self.children = {}
 
-    def append(self, data):
-        self.data.append(data)
+    def add(self, data):
+        if data not in self.unique_nodes:
+            self.data.append(data)
+            self.unique_nodes.add(data)
 
     def get_child(self, module_stack, klass=None):
         if module_stack not in self.children:
@@ -125,6 +128,10 @@ def _make_subgraph(nodes):
     return new_graph
 
 
+def _is_root(stack):
+    return stack == ""
+
+
 def make_graph_view(graph):
     """
     Make a graph view from the fx.Graph. This is a tree structure that
@@ -186,7 +193,10 @@ def make_graph_view(graph):
                 if nodes_by_module_stack is None:
                     nodes_by_module_stack = Container(name, module_class)
                     nodes_by_module_stack_root = nodes_by_module_stack
-                new_stack = nodes_by_module_stack.get_child(name, module_class)
-                nodes_by_module_stack.data.append(node)
+                if _is_root(module_stack):
+                    new_stack = nodes_by_module_stack
+                else:
+                    new_stack = nodes_by_module_stack.get_child(name, module_class)
                 nodes_by_module_stack = new_stack
+                nodes_by_module_stack.add(node)
     return nodes_by_module_stack_root


### PR DESCRIPTION
This PR proposes a thin wrapper around a `fx.Graph` that allows for a simpler experience for querying / manipulating graphs.

It uses the module hierarchy to organise the nodes / subcontainers in a tree, similar to what `nn.Module` do.

Thus, for a model like `nn.Sequential(nn.Linear(2,2), nn.Sequential(nn.Linear(2,2), nn.Linear(2,2))`, one can get quick information about submodules via `graph_view['1']['0']`, or for more complex modules, via `model.block['0'].attention`.

Things that this might make it easier:
* bucketing on a per-module basis
* moving certain operators to the beginning / end of a given module (for prefetching)
* quickly visualizing a subregion of a graph (through the .graph_view() representation), which returns a fresh new graph with only the nodes present in that region

For now, only forward nodes are handled, but we should handle backward nodes as well.