### PR TITLE
Re-enable llama3 runtime

### DIFF
--- a/examples/example_llama3.py
+++ b/examples/example_llama3.py
@@ -192,7 +192,7 @@ with AutoParallel(
         add_tp_constraints(autop)
 
     t = time.time()
-    sharding_placement = autop.optimize_placement(verbose=False)
+    sharding_placement = autop.optimize_placement(verbose=True)
     print(f"Took {time.time() - t:.2f} s")
     parallel_mod = autop.apply_placement(sharding_placement)
 


### PR DESCRIPTION
This is a copy of https://github.com/meta-pytorch/autoparallel/pull/163 but pointing on main