### PR TITLE
Fix print when we have violated constraints

### DIFF
--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -655,7 +655,7 @@ class ShardingOptimizer:
         self.res = [k for k, v in sol.items() if v == 1]
 
         if self.prob.status == -1:
-            print(self.get_log())
+            print(self.get_violated_constraints_log())
             raise RuntimeError("Unsolvable problem")
 
         opt = {}


### PR DESCRIPTION
Before, we could have errors happening right on the get_log method because some nodes might not have any sharding chosen. This PR changes instead to print the violated constraints, so that we can have a clear error message to users