### PR TITLE
Remove decomposition from softmax

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -60,6 +60,8 @@ def _get_decomp_table():
     decomp_table.pop(torch.ops.aten.native_layer_norm.default)
     decomp_table.pop(torch.ops.aten.embedding_dense_backward.default)
     decomp_table.pop(torch.ops.aten.native_layer_norm_backward.default)
+    decomp_table.pop(torch.ops.aten._softmax_backward_data.default)
+    decomp_table.pop(torch.ops.aten._softmax.default)
 
     # decompose addmm to allow for TP on mm
     decomp_table.pop(torch.ops.aten.addmm.default)


### PR DESCRIPTION
Taken from https://github.com/meta-pytorch/autoparallel/pull/3 and https://github.com/meta-pytorch/autoparallel/pull/29. Decomposing softmax_backward leads to prims.fma, which doesn't have a sharding rule and we end up having a Replicate showing up as only possible sharding