### PR TITLE
Switch to the newer graph capture API for export.

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -8,10 +8,10 @@ import itertools
 import warnings
 from contextlib import ExitStack, contextmanager
 from types import MethodType
-from typing import Any, Optional, Union
+from typing import Optional, Union
 
 import torch
-from torch._dynamo.functional_export import _dynamo_graph_capture_for_export
+from torch._dynamo.functional_export import dynamo_graph_capture_for_export
 from torch._functorch.aot_autograd import (
     aot_compile_joint_with_descriptors,
     aot_export_joint_with_descriptors,
@@ -23,7 +23,6 @@ from torch._logging import trace_structured
 from torch._subclasses import FakeTensorMode
 from torch.distributed.fsdp import MixedPrecisionPolicy
 from torch.distributed.tensor import DeviceMesh
-from torch.export._trace import _restore_state_dict
 from torch.export._unlift import _assign_attr
 from torch.export.unflatten import _AttrKind
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
@@ -166,21 +165,6 @@ def enable_local_map_wrapping():
         yield
 
 
-def _export(model: torch.nn.Module, inputs: tuple[Any]) -> torch.nn.Module:
-    """
-    Thin wrapper around graph capture output that restores the
-    original calling convention and attribute fqn. TODO:
-    1) Use bytecode for calling convention instead of pytree for more
-       seamless UX.
-    2) Attach guards
-    3) Be more careful about tensor constants names.
-    """
-    with torch._dynamo.config.patch(install_free_tensors=True):
-        gm = _dynamo_graph_capture_for_export(model)(*inputs)
-        _restore_state_dict(model, gm)
-        return gm
-
-
 class AutoParallel:
     """
     Args:
@@ -303,7 +287,7 @@ class AutoParallel:
         with set_dtype_cast(
             True
         ), enable_local_map_wrapping(), torch._dynamo.utils._disable_saved_tensors_hooks_during_tracing():
-            torch_ir_with_fqn = _export(self.model, inputs)
+            torch_ir_with_fqn = dynamo_graph_capture_for_export(self.model)(*inputs)
             # TODO Cna't use fake mode here because it clashes with the user level
             # fake mode. Ideally dynamo should reuse the user level fake mode.
             self.joint_with_descriptors = aot_export_joint_with_descriptors(


### PR DESCRIPTION
`dynamo_graph_capture_for_export` is a new graph capture API which is a re-implementation of the old `_dynamo_graph_capture_for_export` and the behavior is much closer to torch.compile() and has less divergent behavior from torch.export.

Our plan is to codemod all the uses of `_dynamo_graph_capture_for_export` to the newer version and users should observe any behavior difference.

Test Plan:
```
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.12.11, pytest-7.3.2, pluggy-1.6.0
rootdir: /data/users/zhxchen17/autoparallel
plugins: xdoctest-1.1.0, hypothesis-5.35.1, xdist-3.3.1, subtests-0.13.1, rerunfailures-14.0, flakefinder-1.1.0, cpp-2.3.0, anyio-4.10.0
collected 21 items

tests/test_aot_eager.py ..x                                                                                                                                                         [ 14%]
tests/test_api.py ....                                                                                                                                                              [ 33%]
tests/test_dtensor.py ....                                                                                                                                                          [ 52%]
tests/test_optimize_placement.py ........                                                                                                                                           [ 90%]
tests/test_ordered_sharding.py ..                                                                                                                                                   [100%]

======================================================================== 20 passed, 1 xfailed in 86.30s (0:01:26) =========================================================================
```