### PR TITLE
Add missing FUSE_SRC to mast.py

### DIFF
--- a/mast/mast.py
+++ b/mast/mast.py
@@ -167,6 +167,7 @@ def train(
             mast_env.pop(env_var, None)
 
     if not mast_env.get("ENABLE_AIRSTORE"):
+        mast_env["FUSE_SRC"] = "ws://ws.ai.nha0genai/checkpoint/infra"
         mast_env["FUSE_SRC_PATH"] = "checkpoint/infra"
 
     # Ensure that a dump dir is available


### PR DESCRIPTION
I was getting this error when launching mast jobs with sweep.py:

```
facebook.hpc_scheduler.hpcscheduler.types.HpcSchedulerServiceException:
WarmStorageSpec in task group 'torchrun' has a non-empty directory field
('checkpoint/infra') but has missing clusters field. If job requires
warm storage cluster mount, please configure storage mount options by
specifying region or conda storage mount environment variables. For more
details please see wiki:
https://www.internalfb.com/code/fbsource/fbcode/conda/mast/mount/README.md
.If you need further assistance, please make a post in
https://fb.workplace.com/groups/mast.users., error:
HpcSchedulerErrorCode::INVALID_JOB_DEFINITION (errorCode: 402)
```

Looking at the wiki, I guessed that probably I was missing the 'cluster' info in the FUSE_SRC var, and I also noted that we already specify this var in mount.py in torchtitan, so I copied the value from there to mast.py and it works.