### PR TITLE
Estimate redistribute_cost by _TransformInfo

### DIFF
--- a/autoparallel/collective_runtime_estimation.py
+++ b/autoparallel/collective_runtime_estimation.py
@@ -8,11 +8,10 @@ from typing import cast
 import torch.distributed.tensor._dtensor_spec as dtensor_spec
 from torch._prims_common import check_contiguous_sizes_strides
 from torch.distributed.tensor._collective_utils import (
+    MeshTopoInfo,
     allgather_cost,
     allreduce_cost,
-    MeshTopoInfo,
     reduce_scatter_cost,
-    spec_to_bytes,
 )
 from torch.distributed.tensor.placement_types import Partial, Shard
 
@@ -85,6 +84,9 @@ def redistribute_cost(
         current_spec.shape, current_spec.stride
     )
     for transform_info in transform_infos:
+        assert (
+            current_spec.tensor_meta is not None
+        ), "spec should have tensor meta defined!"
         comm_bytes_gb = (
             current_spec.tensor_meta.dtype.itemsize
             * math.prod(transform_info.logical_shape)


### PR DESCRIPTION
Estimate redistribute_cost by _TransformInfo rather than comparing source and destination state
Here are the changes:
1. use _TransformInfo to collect shard order
2. use _TransformInfo to explore the path during redistribute. The previous approach only considers the source and destination state and a one-step redistribute for each placement combination, however, it could be incorrect in some cases:
a. S(0)S(0) -> S(0)R, need 1 allgather
b. S(0)S(0) -> RS(0), need 2 allgather, which could not be found if only care S(0)->R
3. use _TransformInfo.logical_shape to estimate comm_byte. The current `comm_bytes_gb` is based on tensor shape and number of shards. In case 2.b, the comm_byte for 2 allgather is different.

TODO:
There are some compute_cost with comm_bytes_gb, need to verify whether they could return the expected cost.