### PR TITLE
Enabling split_dI_dW and split_fsdp_collectives passes

### DIFF
--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -46,4 +46,4 @@ jobs:
         python examples/example_dcp.py
         python examples/example_local_map.py
         python examples/example_ds3_local_map.py
-        python examples/example_pp_graph_partition.py
+        python examples/example_pp_graph_passes.py

--- a/autoparallel/_passes/graph_partition.py
+++ b/autoparallel/_passes/graph_partition.py
@@ -29,7 +29,15 @@ def partition_joint_with_descriptors(
     fw_compiler: Callable = boxed_nop_preserve_node_meta,
     bw_compiler: Callable = boxed_nop_preserve_node_meta,
 ) -> tuple[
-    torch.fx.GraphModule, torch.fx.GraphModule, int, int, int, int, list[int], list[Any]
+    torch.fx.GraphModule,
+    torch.fx.GraphModule,
+    int,
+    int,
+    int,
+    int,
+    int,
+    list[int],
+    list[Any],
 ]:
     aot_state: AOTState = jd._aot_state
     aot_graph_capture: AOTGraphCapture = jd._aot_graph_capture
@@ -79,9 +87,11 @@ def partition_joint_with_descriptors(
     num_mutate_inputs = len(
         [x for x in fw_metadata.input_info if x.mutates_data or x.mutates_metadata]
     )
+    num_params_buffers = aot_config.num_params_buffers
     return (
         fw_module,
         bw_module,
+        num_params_buffers,
         num_user_outputs,
         num_mutate_inputs,
         num_fw_outs_saved_for_bw,

--- a/autoparallel/_passes/split_di_dw_graph.py
+++ b/autoparallel/_passes/split_di_dw_graph.py
@@ -191,7 +191,7 @@ def _extract_fwd_bwd_modules(
 
 # TODO: in theory we can infer num_weight_gradients from the graph metadata directly
 def split_di_dw_graph(
-    bw_gm_old: fx.GraphModule, *, num_weight_gradients
+    bw_gm_old: fx.GraphModule, *, num_weight_gradients: int
 ) -> tuple[fx.GraphModule, fx.GraphModule, int]:
     # we could consider doing this is a non-mutating way
     bw_gm = copy.deepcopy(bw_gm_old)

--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -588,14 +588,21 @@ class AutoParallelPPModule(torch.nn.Module):
 
 class AutoParallelPP(AutoParallel):
     def apply_placement_pp(
-        self, sharding_placement=None, generate_di_dw_split_graphs=False
+        self, sharding_placement=None, graph_passes: list[str] = []
     ) -> dict[str, Any]:
+        assert all(
+            g_pass in ["split_fsdp_collectives", "split_dI_dW"]
+            for g_pass in graph_passes
+        ), "Only split_fsdp_collectives and split_dI_dW_graph are supported"
         sharded_param_dict, sharded_buffer_dict = self._apply_placement_common(
             sharding_placement
         )
+        num_params = len(sharded_param_dict)
+        num_buffers = len(sharded_buffer_dict)
         (
             fw_module,
             bw_module,
+            num_params_buffers,
             num_user_outputs,
             num_mutate_inputs,
             num_fw_outs_saved_for_bw,
@@ -603,8 +610,11 @@ class AutoParallelPP(AutoParallel):
             _indices_of_inps_to_detach,
             adjusted_flat_args,
         ) = partition_joint_with_descriptors(self.joint_with_descriptors)
-
+        assert num_params_buffers == (
+            num_params + num_buffers
+        ), f"num_params_buffers: {num_params_buffers}, num_params: {num_params}, num_buffers: {num_buffers}"
         print(
+            f"num_params_buffers: {num_params_buffers}\n"
             f"num_user_outputs: {num_user_outputs}\n"
             f"num_mutate_inputs: {num_mutate_inputs}\n"
             f"num_fw_outs_saved_for_bw: {num_fw_outs_saved_for_bw}\n"
@@ -631,14 +641,71 @@ class AutoParallelPP(AutoParallel):
                 print_output=False, include_stride=True, include_device=True
             ),
         )
-        if generate_di_dw_split_graphs:
+        unshard_module: Optional[torch.fx.GraphModule] = None
+        reduce_grad_module: Optional[torch.fx.GraphModule] = None
+        if "split_fsdp_collectives" in graph_passes:
+            assert (
+                not self.reshard_after_forward
+            ), "reshard_after_forward should be False to disable FSDP all_gather in the backward pass"
+            from autoparallel._passes.split_fsdp_collectives import (
+                split_fsdp_prefetch,
+                split_fsdp_reduce_scatters_epilogue,
+            )
+
+            unshard_module, fw_module = split_fsdp_prefetch(fw_module, num_params)
+            trace_structured(
+                "artifact",
+                metadata_fn=lambda: {
+                    "name": "autoparallel_pp_unshard_graph",
+                    "encoding": "string",
+                },
+                payload_fn=lambda: unshard_module.print_readable(
+                    print_output=False, include_stride=True, include_device=True
+                ),
+            )
+            trace_structured(
+                "artifact",
+                metadata_fn=lambda: {
+                    "name": "autoparallel_pp_fwd_no_fsdp_graph",
+                    "encoding": "string",
+                },
+                payload_fn=lambda: fw_module.print_readable(
+                    print_output=False, include_stride=True, include_device=True
+                ),
+            )
+            bw_module, reduce_grad_module = split_fsdp_reduce_scatters_epilogue(
+                bw_module, num_params
+            )
+            trace_structured(
+                "artifact",
+                metadata_fn=lambda: {
+                    "name": "autoparallel_pp_bwd_no_fsdp_graph",
+                    "encoding": "string",
+                },
+                payload_fn=lambda: bw_module.print_readable(
+                    print_output=False, include_stride=True, include_device=True
+                ),
+            )
+            trace_structured(
+                "artifact",
+                metadata_fn=lambda: {
+                    "name": "autoparallel_pp_reduce_grad_graph",
+                    "encoding": "string",
+                },
+                payload_fn=lambda: reduce_grad_module.print_readable(
+                    print_output=False, include_stride=True, include_device=True
+                ),
+            )
+
+        bw_dI_module: Optional[torch.fx.GraphModule] = None
+        bw_dW_module: Optional[torch.fx.GraphModule] = None
+        num_input_grads = 0
+        if "split_dI_dW" in graph_passes:
             from autoparallel._passes.split_di_dw_graph import split_di_dw_graph
 
-            num_weight_gradients = (
-                self.joint_with_descriptors._aot_state.aot_config.num_params_buffers
-            )
             bw_dI_module, bw_dW_module, num_input_grads = split_di_dw_graph(
-                bw_module, num_weight_gradients=num_weight_gradients
+                bw_module,
+                num_weight_gradients=num_params_buffers,
             )
             trace_structured(
                 "artifact",
@@ -669,24 +736,23 @@ class AutoParallelPP(AutoParallel):
                 raise RuntimeError(
                     "attempted to run split dI/dW pass on a graph that has no input gradients"
                 )
-        else:
-            bw_dI_module, bw_dW_module, num_input_grads = None, None, -1
 
         graph_meta: dict[str, int] = {
             "num_mutate_inputs": num_mutate_inputs,
             "num_user_outputs": num_user_outputs,
             "num_symints_saved_for_bw": num_symints_saved_for_bw,
-            "num_weight_buffer_grads": len(sharded_param_dict)
-            + len(sharded_buffer_dict),
+            "num_params": num_params,
+            "num_buffers": num_buffers,
             "num_input_grads": num_input_grads,
         }
+
         graph_modules: dict[str, Optional[torch.fx.GraphModule]] = {
             "fw": fw_module,
             "full_bw": bw_module,
             "bw_dI": bw_dI_module,
             "bw_dW": bw_dW_module,
-            "unshard": None,
-            "reduce_grad": None,
+            "unshard": unshard_module,
+            "reduce_grad": reduce_grad_module,
         }
         self.parallel_model = AutoParallelPPModule(
             sharded_param_dict,

--- a/examples/example_ds3_pp.py
+++ b/examples/example_ds3_pp.py
@@ -373,7 +373,9 @@ def run_test(fake_evaluate: bool = True):
             num_mutate_inputs=graph_meta["num_mutate_inputs"],
             num_user_outputs=graph_meta["num_user_outputs"],
             num_symints_saved_for_bw=graph_meta["num_symints_saved_for_bw"],
-            num_weight_buffer_grads=graph_meta["num_weight_buffer_grads"],
+            num_params=graph_meta["num_params"],
+            num_buffers=graph_meta["num_buffers"],
+            num_input_grads=graph_meta["num_input_grads"],
         )
         trace_structured(
             "artifact",

--- a/examples/example_pp_graph_passes.py
+++ b/examples/example_pp_graph_passes.py
@@ -1,0 +1,420 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+from contextlib import nullcontext
+from typing import Callable
+
+import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.distributed.tensor import DeviceMesh, DTensor
+from torch.distributed.tensor.placement_types import Shard
+from torch.fx.experimental.symbolic_shapes import ShapeEnv
+from torch.testing._internal.distributed.fake_pg import FakeStore
+
+from autoparallel._testing.models.dsv3 import (
+    DeepSeekV3Model,
+    DeepSeekV3ModelArgs,
+    MoEArgs,
+)
+from autoparallel.api import AutoParallelPP
+from autoparallel.graph_pp_runner import (
+    GraphCallables,
+    GraphMeta,
+    _run_dI_bw_module,
+    _run_dW_bw_module,
+    _run_full_bw_module,
+    _run_fw_module,
+    _run_reduce_grad_module,
+    _run_unshard_module,
+)
+
+
+def _get_pp_module_and_graphs(
+    model: torch.nn.Module,
+    mesh: DeviceMesh,
+    tracing_input_fn: Callable,
+    graph_passes: list[str] = [],
+) -> tuple[torch.nn.Module, GraphCallables, GraphMeta]:
+
+    with AutoParallelPP(
+        model, tracing_input_fn, mesh, dynamic=True, reshard_after_forward=False
+    ) as autop:
+        autop.add_parameter_memory_constraint(low=None, high=None)
+
+        # x_sharding = (Shard(0), Replicate())
+        x_sharding = (Shard(0), Shard(0))
+
+        autop.add_input_constraints([x_sharding])
+        autop.add_output_constraints([x_sharding])
+
+        sharding_placement = autop.optimize_placement()
+        res = autop.apply_placement_pp(
+            sharding_placement=sharding_placement,
+            graph_passes=graph_passes,
+        )
+        pp_mod = autop.parallel_model
+    graph_callables = res["graph_callables"]
+    graph_modules = GraphCallables(
+        fw=graph_callables["fw"],
+        full_bw=graph_callables["full_bw"],
+        bw_dI=graph_callables["bw_dI"],
+        bw_dW=graph_callables["bw_dW"],
+        unshard=graph_callables["unshard"],
+        reduce_grad=graph_callables["reduce_grad"],
+    )
+    graph_meta = res["graph_meta"]
+    graph_meta = GraphMeta(
+        num_mutate_inputs=graph_meta["num_mutate_inputs"],
+        num_user_outputs=graph_meta["num_user_outputs"],
+        num_symints_saved_for_bw=graph_meta["num_symints_saved_for_bw"],
+        num_params=graph_meta["num_params"],
+        num_buffers=graph_meta["num_buffers"],
+        num_input_grads=graph_meta["num_input_grads"],
+    )
+
+    pp_mod.to_empty(device="cuda")
+    pp_mod.init_weights(buffer_device="cuda")
+    return pp_mod, graph_modules, graph_meta
+
+
+# graph_passes=["split_dI_dW", "split_fsdp_collectives"],
+
+
+def _get_fw_inputs(
+    pp_mod: torch.nn.Module, eval_input_fn: Callable
+) -> tuple[list[torch.Tensor], list[torch.Tensor], list[torch.Tensor]]:
+    x: list[torch.Tensor] = [
+        eval_input_fn(),
+    ]
+    sharded_params = [
+        v.to_local() if isinstance(v, DTensor) else v
+        for k, v in dict(pp_mod.named_parameters(remove_duplicate=False)).items()
+    ]
+    buffers = [
+        v.to_local() if isinstance(v, DTensor) else v
+        for k, v in dict(pp_mod.named_buffers(remove_duplicate=False)).items()
+    ]
+    return [sharded_params, buffers, x]
+
+
+# Symbolically evaluate in case you want to test running a graph bigger than your gpu
+
+
+def test_graph_partition(
+    model: torch.nn.Module,
+    mesh: DeviceMesh,
+    tracing_input_fn: Callable,
+    eval_input_fn: Callable,
+    fake_evaluate: bool = True,
+):
+
+    pp_mod, graph_modules, graph_meta = _get_pp_module_and_graphs(
+        model, mesh, tracing_input_fn
+    )
+    sharded_params, buffers, x = _get_fw_inputs(pp_mod, eval_input_fn)
+    with (
+        FakeTensorMode(
+            allow_non_fake_inputs=True,
+            shape_env=ShapeEnv(),
+        )
+        if fake_evaluate
+        else nullcontext()
+    ):
+        # # now let's run it
+        with torch.no_grad():
+            fw_args = [*sharded_params, *buffers, *x]
+            output, saved_intermediates = _run_fw_module(
+                graph_modules.fw, graph_meta, fw_args
+            )
+            tangents = [torch.randn_like(output)]
+            tensors_for_backward, non_tensors_for_backward = saved_intermediates
+
+            bw_args = [
+                *non_tensors_for_backward,
+                *tensors_for_backward,
+                *tangents,
+            ]
+            del (
+                tensors_for_backward,
+                non_tensors_for_backward,
+                tangents,
+                saved_intermediates,
+            )
+
+            input_grads, param_buffer_grads = _run_full_bw_module(
+                graph_modules.full_bw, graph_meta, bw_args
+            )
+
+    print("All good!")
+
+
+def test_split_fsdp_collectives(
+    model: torch.nn.Module,
+    mesh: DeviceMesh,
+    tracing_input_fn: Callable,
+    eval_input_fn: Callable,
+    fake_evaluate: bool = True,
+):
+
+    pp_mod, graph_modules, graph_meta = _get_pp_module_and_graphs(
+        model, mesh, tracing_input_fn, graph_passes=["split_fsdp_collectives"]
+    )
+    sharded_params, buffers, x = _get_fw_inputs(pp_mod, eval_input_fn)
+    with (
+        FakeTensorMode(
+            allow_non_fake_inputs=True,
+            shape_env=ShapeEnv(),
+        )
+        if fake_evaluate
+        else nullcontext()
+    ):
+        # # now let's run it
+        with torch.no_grad():
+            unshard_args = list(sharded_params)
+            assert graph_modules.unshard is not None
+            unsharded_params = _run_unshard_module(
+                graph_modules.unshard, graph_meta, unshard_args
+            )
+            fw_args = [*unsharded_params, *buffers, *x]
+            output, saved_intermediates = _run_fw_module(
+                graph_modules.fw, graph_meta, fw_args
+            )
+            tangents = [torch.randn_like(output)]
+            tensors_for_backward, non_tensors_for_backward = saved_intermediates
+
+            bw_args = [
+                *non_tensors_for_backward,
+                *tensors_for_backward,
+                *tangents,
+            ]
+            del (
+                tensors_for_backward,
+                non_tensors_for_backward,
+                tangents,
+                saved_intermediates,
+            )
+            input_grads, unsharded_param_buffer_grads = _run_full_bw_module(
+                graph_modules.full_bw, graph_meta, bw_args
+            )
+            unsharded_grads = list(unsharded_param_buffer_grads[: len(sharded_params)])
+            del unsharded_param_buffer_grads, input_grads
+            assert graph_modules.reduce_grad is not None
+            sharded_grads = _run_reduce_grad_module(
+                graph_modules.reduce_grad, graph_meta, unsharded_grads
+            )
+            assert len(sharded_grads) == len(sharded_params)
+
+    print("All good!")
+
+
+def test_split_dI_dW(
+    model: torch.nn.Module,
+    mesh: DeviceMesh,
+    tracing_input_fn: Callable,
+    eval_input_fn: Callable,
+    fake_evaluate: bool = True,
+):
+
+    pp_mod, graph_modules, graph_meta = _get_pp_module_and_graphs(
+        model, mesh, tracing_input_fn, graph_passes=["split_dI_dW"]
+    )
+    sharded_params, buffers, x = _get_fw_inputs(pp_mod, eval_input_fn)
+    with (
+        FakeTensorMode(
+            allow_non_fake_inputs=True,
+            shape_env=ShapeEnv(),
+        )
+        if fake_evaluate
+        else nullcontext()
+    ):
+        # # now let's run it
+        with torch.no_grad():
+            fw_args = [*sharded_params, *buffers, *x]
+            output, saved_intermediates = _run_fw_module(
+                graph_modules.fw, graph_meta, fw_args
+            )
+            tangents = [torch.randn_like(output)]
+            tensors_for_backward, non_tensors_for_backward = saved_intermediates
+
+            bw_args = [
+                *non_tensors_for_backward,
+                *tensors_for_backward,
+                *tangents,
+            ]
+            del (
+                tensors_for_backward,
+                non_tensors_for_backward,
+                tangents,
+                saved_intermediates,
+            )
+            assert graph_modules.bw_dI is not None
+            input_grads, activations_for_backward = _run_dI_bw_module(
+                graph_modules.bw_dI, graph_meta, bw_args
+            )
+            dw_args = list(activations_for_backward)
+            del activations_for_backward
+            assert graph_modules.bw_dW is not None
+            sharded_param_buffer_grads = _run_dW_bw_module(
+                graph_modules.bw_dW, graph_meta, dw_args
+            )
+            assert len(sharded_param_buffer_grads) == (
+                len(sharded_params) + len(buffers)
+            )
+
+    print("All good!")
+
+
+def test_combined(
+    model: torch.nn.Module,
+    mesh: DeviceMesh,
+    tracing_input_fn: Callable,
+    eval_input_fn: Callable,
+    fake_evaluate: bool = True,
+):
+
+    pp_mod, graph_modules, graph_meta = _get_pp_module_and_graphs(
+        model,
+        mesh,
+        tracing_input_fn,
+        graph_passes=["split_fsdp_collectives", "split_dI_dW"],
+    )
+    sharded_params, buffers, x = _get_fw_inputs(pp_mod, eval_input_fn)
+    with (
+        FakeTensorMode(
+            allow_non_fake_inputs=True,
+            shape_env=ShapeEnv(),
+        )
+        if fake_evaluate
+        else nullcontext()
+    ):
+        # # now let's run it
+        with torch.no_grad():
+            unshard_args = list(sharded_params)
+            assert graph_modules.unshard is not None
+            unsharded_params = _run_unshard_module(
+                graph_modules.unshard, graph_meta, unshard_args
+            )
+            fw_args = [*unsharded_params, *buffers, *x]
+            output, saved_intermediates = _run_fw_module(
+                graph_modules.fw, graph_meta, fw_args
+            )
+            tangents = [torch.randn_like(output)]
+            tensors_for_backward, non_tensors_for_backward = saved_intermediates
+
+            bw_args = [
+                *non_tensors_for_backward,
+                *tensors_for_backward,
+                *tangents,
+            ]
+            del (
+                tensors_for_backward,
+                non_tensors_for_backward,
+                tangents,
+                saved_intermediates,
+            )
+            assert graph_modules.bw_dI is not None
+            input_grads, activations_for_backward = _run_dI_bw_module(
+                graph_modules.bw_dI, graph_meta, bw_args
+            )
+            dw_args = list(activations_for_backward)
+            del activations_for_backward
+            assert graph_modules.bw_dW is not None
+            unsharded_param_buffer_grads = _run_dW_bw_module(
+                graph_modules.bw_dW, graph_meta, dw_args
+            )
+            unsharded_grads = list(unsharded_param_buffer_grads[: len(sharded_params)])
+            del unsharded_param_buffer_grads, input_grads
+            assert graph_modules.reduce_grad is not None
+            sharded_grads = _run_reduce_grad_module(
+                graph_modules.reduce_grad, graph_meta, unsharded_grads
+            )
+            assert len(sharded_grads) == len(sharded_params)
+
+    print("All good!")
+
+
+if __name__ == "__main__":
+    # must symbolically evaluate to run on 32 dp ranks
+    # world_size = 2048
+    fake_evaluate = True
+
+    world_size = 256
+
+    fake_store = FakeStore()
+    torch.distributed.init_process_group(
+        "fake", store=fake_store, rank=0, world_size=world_size
+    )
+    # mesh = torch.distributed.device_mesh.init_device_mesh("cuda", (world_size,), mesh_dim_names=("dp",))
+    mesh = torch.distributed.device_mesh.init_device_mesh(
+        "cuda",
+        (world_size // 64, 64),
+        mesh_dim_names=(
+            "dp",
+            "ep",
+        ),
+    )
+
+    device = torch.device("cuda")
+
+    bs = 4 * mesh.shape[0] * mesh.shape[1]
+    seq_len = 1024
+
+    config = DeepSeekV3ModelArgs(
+        vocab_size=102400,
+        max_seq_len=seq_len,
+        dim=2048,
+        inter_dim=10944,
+        moe_inter_dim=1408,
+        n_layers=1,  # 27,
+        n_dense_layers=0,  # 1,
+        n_heads=16,
+        moe_args=MoEArgs(
+            num_experts=64,
+            num_shared_experts=2,
+            top_k=6,
+            score_func="softmax",
+            route_norm=False,
+            score_before_experts=False,
+            mesh=mesh,
+        ),
+        q_lora_rank=0,
+        kv_lora_rank=512,
+        qk_nope_head_dim=128,
+        qk_rope_head_dim=64,
+        v_head_dim=128,
+        mscale=0.70,
+        use_flex_attn=False,
+        attn_mask_type="causal",
+    )
+
+    # parallelize the model
+    with torch.device("meta"):
+        model = DeepSeekV3Model(config).bfloat16()
+        model.tok_embeddings = None  # type: ignore[assignment]
+
+    def tracing_input_fn() -> torch.Tensor:
+        return torch.randn(
+            (bs, seq_len, config.dim),
+            device=device,
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+
+    def eval_input_fn() -> torch.Tensor:
+        return torch.randn(
+            (bs // mesh.shape[0] // mesh.shape[1], seq_len, config.dim),
+            device=device,
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+
+    test_graph_partition(model, mesh, tracing_input_fn, eval_input_fn, fake_evaluate)
+    test_split_fsdp_collectives(
+        model, mesh, tracing_input_fn, eval_input_fn, fake_evaluate
+    )
+    test_split_dI_dW(model, mesh, tracing_input_fn, eval_input_fn, fake_evaluate)
+    test_combined(model, mesh, tracing_input_fn, eval_input_fn, fake_evaluate)
+    if torch.distributed.is_initialized():
+        torch.distributed.destroy_process_group()


### PR DESCRIPTION
Based off #227, will rebase once it lands. 
Test file: `examples/example_pp_graph_passes.py`

Made some modifications to Ivan’s pass (#201) as follows:

The split_fsdp_prefetch pass required all the inputs (params+buffers+microbatch) to be passed to the prefetch graph and required all the outputs of the prefetch graph to be passed to the fwd_graph. But we wanted something slightly different. We only want to pass the sharded_params to the prefetch_graph and obtain unsharded_params from it. The fwd_graph then takes in these unsharded_params (obtained from prefetch_graph)+buffers+microbatch. This is important because we want the prefetch graph to be independent of micro batch since the unshard action won’t have an associated micro batch.

Similarly, reduce_grad graph should only take in the unsharded_grads from the bwd_graph and produce sharded_grads. We cannot pass in all the outputs of the bwd_graph to the reduce_grad graph, since it would make it micro batch dependent and we want to call reduce_grad action only once after accumulating unsharded_grads across micro batches.

Brian’s pass (#232) worked perfectly fine, just integrated it differently in the end-to-end workflow.