### PR TITLE
Revert "Include --job.save_config_file "params.json" in mast launch script. (#272)"

### DIFF
--- a/mast/run_torchtitan.sh
+++ b/mast/run_torchtitan.sh
@@ -78,5 +78,4 @@ python torchtitan/train.py \
 --validation.dataset_path "${dataset_path}" \
 --metrics.save_tb_folder "${save_tb_folder}" \
 --metrics.disable_color_printing \
---job.save_config_file "params.json" \
 $overrides


### PR DESCRIPTION
Stacked PRs:
 * __->__#278


--- --- ---

Broke internal difftrain due to out of order lands

Revert "Include --job.save_config_file "params.json" in mast launch script. (#272)"

This reverts commit feee51a5c34a795d5e68bebba3660c651f82464b.