### PR TITLE
Add MI210X, MI300X, MI325X, MI350X AMD GPU support to Auto Parallel.

### DIFF
--- a/autoparallel/cost_models/compute_estimation.py
+++ b/autoparallel/cost_models/compute_estimation.py
@@ -167,7 +167,7 @@ DEVICE_LIMITS: Tuple[DeviceLimit, ...] = (
     DeviceLimit(
         "AMD Instinct MI200X",
         "https://www.amd.com/content/dam/amd/en/documents/instinct-business-docs/product-briefs/instinct-mi210-brochure.pdf",
-        sm=(-1, -1), # sm not defined for AMD GPUs
+        sm=(-1, -1),  # sm not defined for AMD GPUs
         gmem_bandwidth=1.6 * (1024**4),
         gemm_tflops={
             torch.float64: 45.3,
@@ -181,7 +181,7 @@ DEVICE_LIMITS: Tuple[DeviceLimit, ...] = (
     DeviceLimit(
         "AMD Instinct MI300X",
         "https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/data-sheets/amd-instinct-mi300x-data-sheet.pdf",
-        sm=(-1, -1), # sm not defined for AMD GPUs
+        sm=(-1, -1),  # sm not defined for AMD GPUs
         gmem_bandwidth=5.3 * (1024**4),
         gemm_tflops={
             torch.float64: 163.4,
@@ -195,7 +195,7 @@ DEVICE_LIMITS: Tuple[DeviceLimit, ...] = (
     DeviceLimit(
         "AMD Instinct MI325X",
         "https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/product-briefs/instinct-mi325x-datasheet.pdf",
-        sm=(-1, -1), # sm not defined for AMD GPUs
+        sm=(-1, -1),  # sm not defined for AMD GPUs
         gmem_bandwidth=6.0 * (1024**4),
         gemm_tflops={
             torch.float64: 163.4,
@@ -209,7 +209,7 @@ DEVICE_LIMITS: Tuple[DeviceLimit, ...] = (
     DeviceLimit(
         "AMD Instinct MI350X",
         "https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/product-briefs/amd-instinct-mi350x-gpu-brochure.pdf",
-        sm=(-1, -1), # sm not defined for AMD GPUs
+        sm=(-1, -1),  # sm not defined for AMD GPUs
         gmem_bandwidth=8.0 * (1024**4),
         gemm_tflops={
             torch.float64: 72.1,


### PR DESCRIPTION
In this PR, we have added AMD GPU support for devices MI210X, MI300X, MI325X, MI350X in Auto Parallel. It is needed to support PR https://github.com/pytorch/torchtitan/pull/2248