### PR TITLE
Add support for arbitrary inputs and outputs in AutoParallel

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -805,10 +805,6 @@ class AutoParallel:
                         dict(self.named_buffers(remove_duplicate=False)).items(),
                     )
                 ]
-                from IPython import embed
-
-                embed()
-                exit()
                 # new_args = flatten_fn(*args)
                 filtered_args = [x for x in args if isinstance(x, torch.Tensor)]
                 boxed_args = [*params, *filtered_args]

--- a/autoparallel/shardings/ordered_sharding.py
+++ b/autoparallel/shardings/ordered_sharding.py
@@ -94,7 +94,7 @@ def get_redistributed_input_placements(
         x for x in tree_flatten(node.args)[0] if isinstance(x, torch.fx.Node)
     ]
     num_input_nodes = len(all_input_nodes)
-    curr_specs: list[Union[DTensorSpec, tuple[Optional[DTensorSpec], ...]]] = [
+    curr_specs: list[Union[DTensorSpec, tuple[Optional[DTensorSpec], ...], None]] = [
         sharding_placement[n].output_specs for n in all_input_nodes
     ]  # FIXME ?
     if node.target == operator.getitem:
@@ -149,7 +149,11 @@ def compute_optimal_placement_order_for_parameters(module, sharding_placement):
     param_and_grad_users = {}
     param_grad_chain = {}
     for param, grad in param_and_grad_nodes:
-        last_p = list(param.users)[0]
+        param_users = list(param.users)
+        if not param_users:
+            # if unused parameter, don't bother with it
+            continue
+        last_p = param_users[0]
         p_chain = [param]
         # get all linear chain of users of the parameter
         while len(last_p.all_input_nodes) == 1:

--- a/tests/test_optimize_placement.py
+++ b/tests/test_optimize_placement.py
@@ -16,6 +16,13 @@ from torch.testing._internal.distributed.fake_pg import FakeStore
 
 from autoparallel.api import AutoParallel
 
+# @pytest.fixture(autouse=True)
+# def reset_dynamo():
+#     """Reset dynamo state before each test to ensure test isolation."""
+#     torch._dynamo.reset()
+#     yield
+#     torch._dynamo.reset()
+
 
 @pytest.fixture(scope="module", autouse=True)
 def init_pg():


### PR DESCRIPTION
Non-tensor inputs gets baked in the graph. Need to add an assert to ensure they haven't changed from user side.

The overall idea is to rely on the output from `dynamo_graph_capture_for_export`, which has a `_dynamo_bytecode_flatten` and `_dynamo_bytecode_unflatten` and passes to its underlying `fx.Graph` only the required inputs, with ints / bools being baked in the graph already.
I additionally add as well the unused parameters of the model as inputs to the graph, so that they can be sharded as well (just for consistency).

Subsumes https://github.com/meta-pytorch/autoparallel/pull/264