### PR TITLE
Update README to point to PyTorch nightly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 > work. It's recommended that you signal your intention to contribute in the
 > issue tracker, either by filing a new issue or by claiming an existing one.
 
-This currently works on PyTorch 2.8.0.dev20250506.
+AutoParallel requires installing [PyTorch nightly](https://pytorch.org/get-started/locally/).
 
 ## Installing it
 


### PR DESCRIPTION
Currently it lists a PyTorch nightly version that no longer can be downloaded.

<!-- ps-id: 1b5fe9ef-7f36-469c-82d2-ece012d9a04f -->