### PR TITLE
Fix mypy errors: import GroupName directly instead of aliasing

### DIFF
--- a/autoparallel/collectives.py
+++ b/autoparallel/collectives.py
@@ -8,9 +8,7 @@ from typing import Any, Optional
 import torch
 import torch.distributed.distributed_c10d as c10d
 from torch.distributed._tensor.experimental import local_map as _local_map
-
-# Import GroupName for type checking
-GroupName = c10d.GroupName
+from torch.distributed.distributed_c10d import GroupName
 
 _local_map_device_mesh = None
 

--- a/autoparallel/graph_passes/async_tp/asynctp_ops.py
+++ b/autoparallel/graph_passes/async_tp/asynctp_ops.py
@@ -19,9 +19,7 @@ from torch._C._autograd import DeviceType
 from torch._C._distributed_c10d import Work as _Work
 from torch._C._distributed_c10d import _register_work, _SymmetricMemory
 from torch.distributed._symmetric_memory import get_symm_mem_workspace, rendezvous
-
-# Import GroupName for type checking
-GroupName = c10d.GroupName
+from torch.distributed.distributed_c10d import GroupName
 
 _is_test_mode: bool = False
 _mocked_group_names: set[str] | None = None


### PR DESCRIPTION
Stacked PRs:
 * __->__#330
 * #329


--- --- ---

Fix mypy errors: import GroupName directly instead of aliasing

Authored with Claude.