### PR TITLE
Expose parameter_memory_budget in auto_parallel and simplify tests

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -846,6 +846,7 @@ def auto_parallel(
     *,
     mp_policy: Optional[MixedPrecisionPolicy] = None,
     compile: bool = True,
+    parameter_memory_budget: Optional[tuple[Optional[float], Optional[float]]] = None,
 ) -> torch.nn.Module:
     """
     Parallelize a model with automatic sharding optimization.
@@ -870,6 +871,8 @@ def auto_parallel(
                 - Dict output: {"logits": (Shard(0),), "loss": (Replicate(),)}
         mp_policy: Optional mixed precision policy.
         compile: Whether to use torch.compile (default: True).
+        parameter_memory_budget: Optional (low, high) bounds for parameter memory.
+            Each bound is a float multiplier or None for unbounded.
 
     Returns:
         Parallelized module. Call to_empty(device="cuda") and init_weights()
@@ -925,8 +928,11 @@ def auto_parallel(
         enable_ac=False,
     ) as autop:
         # Add constraints
-        # autop.add_parameter_memory_constraint(low=None, high=None)
         autop.add_input_constraints(input_placements)
+        if parameter_memory_budget is not None:
+            autop.add_parameter_memory_constraint(
+                low=parameter_memory_budget[0], high=parameter_memory_budget[1]
+            )
         autop.add_output_constraints(output_placements)
 
         # Optimize and apply

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,10 +7,11 @@ import pytest
 import torch
 import torch.fx.traceback as fx_traceback
 from torch import nn
+from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import Replicate, Shard
 from torch.testing._internal.distributed.fake_pg import FakeStore
 
-from autoparallel.api import AutoParallel
+from autoparallel.api import AutoParallel, auto_parallel
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -84,24 +85,23 @@ def test_init(device_mesh_1d):
                 self.linear.bias.fill_(98.6)
             self.buf = torch.arange(dim)
 
-    def input_fn():
-        b = 512
-        inputs = (torch.rand(b, dim, device="cuda"),)
-        return inputs
-
     with torch.device("meta"):
         model = Model(dim)
-    with AutoParallel(
-        model,
-        input_fn,
-        device_mesh_1d,
-    ) as autop:
-        x_sharding = (Shard(0),)
-        autop.add_input_constraints([x_sharding])
-        sharding_placement = autop.optimize_placement()
 
-        # AutoParallel produces a module with meta-DTensor parameters that need to be initialized
-        parallel_mod = autop.apply_placement(sharding_placement)
+    batch_size = 512
+    local_batch_size = batch_size // device_mesh_1d.size()
+    x = DTensor.from_local(
+        torch.rand(local_batch_size, dim, device="cuda"),
+        device_mesh_1d,
+        [Shard(0)],
+    )
+    parallel_mod = auto_parallel(
+        model,
+        device_mesh_1d,
+        sample_inputs=(x,),
+        out_shardings=(Shard(0),),
+        compile=False,
+    )
     parallel_mod.to_empty(device="cuda")
     parallel_mod.init_weights()
     assert torch.equal(
@@ -135,23 +135,23 @@ def test_init_inplace_data(device_mesh_1d):
             self.linear.bias.data[:] = torch.full((dim,), 98.6)
             self.buf.data[:] = torch.arange(dim, dtype=torch.float32)
 
-    def input_fn():
-        b = 512
-        inputs = (torch.rand(b, dim, device="cuda"),)
-        return inputs
-
     with torch.device("meta"):
         model = Model(dim)
-    with AutoParallel(
-        model,
-        input_fn,
-        device_mesh_1d,
-    ) as autop:
-        x_sharding = (Shard(0),)
-        autop.add_input_constraints([x_sharding])
-        sharding_placement = autop.optimize_placement()
 
-        parallel_mod = autop.apply_placement(sharding_placement)
+    batch_size = 512
+    local_batch_size = batch_size // device_mesh_1d.size()
+    x = DTensor.from_local(
+        torch.rand(local_batch_size, dim, device="cuda"),
+        device_mesh_1d,
+        [Shard(0)],
+    )
+    parallel_mod = auto_parallel(
+        model,
+        device_mesh_1d,
+        sample_inputs=(x,),
+        out_shardings=(Shard(0),),
+        compile=False,
+    )
     parallel_mod.to_empty(device="cuda")
     parallel_mod.init_weights()
     assert torch.equal(
@@ -206,25 +206,25 @@ def test_init_aliased_buffers(device_mesh_1d):
             self.rope.init_weights()
             self.freqs_cis = self.rope.cache
 
-    def input_fn():
-        b = 512
-        inputs = (torch.rand(b, dim, device="cuda"),)
-        return inputs
-
     with torch.device("meta"):
         model = Model(dim)
 
     assert model.freqs_cis is model.rope.cache
 
-    with AutoParallel(
-        model,
-        input_fn,
+    batch_size = 512
+    local_batch_size = batch_size // device_mesh_1d.size()
+    x = DTensor.from_local(
+        torch.rand(local_batch_size, dim, device="cuda"),
         device_mesh_1d,
-    ) as autop:
-        x_sharding = (Shard(0),)
-        autop.add_input_constraints([x_sharding])
-        sharding_placement = autop.optimize_placement()
-        parallel_mod = autop.apply_placement(sharding_placement)
+        [Shard(0)],
+    )
+    parallel_mod = auto_parallel(
+        model,
+        device_mesh_1d,
+        sample_inputs=(x,),
+        out_shardings=(Shard(0),),
+        compile=False,
+    )
 
     parallel_mod.to_empty(device="cuda")
     parallel_mod.init_weights()
@@ -260,25 +260,25 @@ def test_init_aliased_parameters(device_mesh_1d):
             with torch.no_grad():
                 self.embed.weight.fill_(1.0)
 
-    def input_fn():
-        b = 512
-        inputs = (torch.rand(b, dim, device="cuda"),)
-        return inputs
-
     with torch.device("meta"):
         model = Model(dim)
 
     assert model.lm_head.weight is model.embed.weight
 
-    with AutoParallel(
-        model,
-        input_fn,
+    batch_size = 512
+    local_batch_size = batch_size // device_mesh_1d.size()
+    x = DTensor.from_local(
+        torch.rand(local_batch_size, dim, device="cuda"),
         device_mesh_1d,
-    ) as autop:
-        x_sharding = (Shard(0),)
-        autop.add_input_constraints([x_sharding])
-        sharding_placement = autop.optimize_placement()
-        parallel_mod = autop.apply_placement(sharding_placement)
+        [Shard(0)],
+    )
+    parallel_mod = auto_parallel(
+        model,
+        device_mesh_1d,
+        sample_inputs=(x,),
+        out_shardings=(Shard(0),),
+        compile=False,
+    )
 
     parallel_mod.to_empty(device="cuda")
     parallel_mod.init_weights()
@@ -324,19 +324,25 @@ def test_aliased_buffers_both_used_in_forward(device_mesh_1d):
             self.rope.cache = torch.arange(dim).float()
             self.freqs_cis = self.rope.cache
 
-    def input_fn():
-        b = 512
-        return (torch.rand(b, dim, device="cuda"),)
-
     with torch.device("meta"):
         model = Model(dim)
 
     assert model.freqs_cis is model.rope.cache
 
-    with AutoParallel(model, input_fn, device_mesh_1d) as autop:
-        autop.add_input_constraints([(Shard(0),)])
-        sharding_placement = autop.optimize_placement()
-        parallel_mod = autop.apply_placement(sharding_placement)
+    batch_size = 512
+    local_batch_size = batch_size // device_mesh_1d.size()
+    x = DTensor.from_local(
+        torch.rand(local_batch_size, dim, device="cuda"),
+        device_mesh_1d,
+        [Shard(0)],
+    )
+    parallel_mod = auto_parallel(
+        model,
+        device_mesh_1d,
+        sample_inputs=(x,),
+        out_shardings=(Shard(0),),
+        compile=False,
+    )
 
     parallel_mod.to_empty(device="cuda")
     parallel_mod.init_weights()
@@ -371,19 +377,25 @@ def test_aliased_parameters_both_used_in_forward(device_mesh_1d):
             with torch.no_grad():
                 self.embed.weight.fill_(1.0)
 
-    def input_fn():
-        b = 512
-        return (torch.rand(b, dim, device="cuda"),)
-
     with torch.device("meta"):
         model = Model(dim)
 
     assert model.lm_head.weight is model.embed.weight
 
-    with AutoParallel(model, input_fn, device_mesh_1d) as autop:
-        autop.add_input_constraints([(Shard(0),)])
-        sharding_placement = autop.optimize_placement()
-        parallel_mod = autop.apply_placement(sharding_placement)
+    batch_size = 512
+    local_batch_size = batch_size // device_mesh_1d.size()
+    x = DTensor.from_local(
+        torch.rand(local_batch_size, dim, device="cuda"),
+        device_mesh_1d,
+        [Shard(0)],
+    )
+    parallel_mod = auto_parallel(
+        model,
+        device_mesh_1d,
+        sample_inputs=(x,),
+        out_shardings=(Shard(0),),
+        compile=False,
+    )
 
     parallel_mod.to_empty(device="cuda")
     parallel_mod.init_weights()
@@ -658,28 +670,26 @@ def test_moduledict_preservation(device_mesh_1d):
             x = self.layers["layer2"](x)
             return x
 
-    def input_fn():
-        b = 512
-        inputs = (torch.rand(b, dim, device="cuda"),)
-        return inputs
-
     with torch.device("meta"):
         model = Model(dim)
 
     # Verify original model has ModuleDict
     assert isinstance(model.layers, nn.ModuleDict)
 
-    with AutoParallel(
-        model,
-        input_fn,
+    batch_size = 512
+    local_batch_size = batch_size // device_mesh_1d.size()
+    x = DTensor.from_local(
+        torch.rand(local_batch_size, dim, device="cuda"),
         device_mesh_1d,
-    ) as autop:
-        x_sharding = (Shard(0),)
-        autop.add_input_constraints([x_sharding])
-        sharding_placement = autop.optimize_placement()
-
-        # AutoParallel produces a module with meta-DTensor parameters that need to be initialized
-        parallel_mod = autop.apply_placement(sharding_placement)
+        [Shard(0)],
+    )
+    parallel_mod = auto_parallel(
+        model,
+        device_mesh_1d,
+        sample_inputs=(x,),
+        out_shardings=(Shard(0),),
+        compile=False,
+    )
 
     # Verify that the parallel_mod preserves the ModuleDict structure
     assert isinstance(
@@ -702,10 +712,6 @@ def test_moduledict_preservation(device_mesh_1d):
 
 def test_auto_parallel_basic(device_mesh_1d):
     """Test basic auto_parallel usage with DTensor input."""
-    from torch.distributed.tensor import DTensor
-
-    from autoparallel import auto_parallel
-
     dim = 128
     batch_size = 512
     local_batch_size = batch_size // device_mesh_1d.size()
@@ -756,10 +762,6 @@ def test_auto_parallel_basic(device_mesh_1d):
 
 def test_auto_parallel_tuple_inputs(device_mesh_1d):
     """Test auto_parallel with multiple DTensor inputs as tuple."""
-    from torch.distributed.tensor import DTensor
-
-    from autoparallel import auto_parallel
-
     dim = 128
     batch_size = 512
     local_batch_size = batch_size // device_mesh_1d.size()
@@ -801,10 +803,6 @@ def test_auto_parallel_tuple_inputs(device_mesh_1d):
 
 def test_auto_parallel_multiple_outputs(device_mesh_1d):
     """Test auto_parallel with multiple outputs and pytree out_shardings."""
-    from torch.distributed.tensor import DTensor
-
-    from autoparallel import auto_parallel
-
     dim = 128
     batch_size = 512
     local_batch_size = batch_size // device_mesh_1d.size()
@@ -841,8 +839,6 @@ def test_auto_parallel_multiple_outputs(device_mesh_1d):
 
 def test_auto_parallel_replicated_input(device_mesh_1d):
     """Test auto_parallel with regular tensor (assumed Replicate)."""
-    from autoparallel import auto_parallel
-
     dim = 128
     batch_size = 512
 
@@ -874,10 +870,6 @@ def test_auto_parallel_replicated_input(device_mesh_1d):
 
 def test_auto_parallel_callable_inputs(device_mesh_1d):
     """Test auto_parallel with callable sample_inputs."""
-    from torch.distributed.tensor import DTensor
-
-    from autoparallel import auto_parallel
-
     dim = 128
     batch_size = 512
     local_batch_size = batch_size // device_mesh_1d.size()
@@ -916,9 +908,6 @@ def test_auto_parallel_callable_inputs(device_mesh_1d):
 def test_auto_parallel_with_mp_policy(device_mesh_1d):
     """Test auto_parallel with mixed precision policy."""
     from torch.distributed.fsdp import MixedPrecisionPolicy
-    from torch.distributed.tensor import DTensor
-
-    from autoparallel import auto_parallel
 
     dim = 128
     batch_size = 512

--- a/tests/test_optimize_placement.py
+++ b/tests/test_optimize_placement.py
@@ -11,10 +11,11 @@ import torch.nn.functional as F
 from torch import nn
 from torch._functorch._aot_autograd.fx_utils import get_param_nodes
 from torch.distributed._tensor.experimental import local_map
+from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import Partial, Replicate, Shard
 from torch.testing._internal.distributed.fake_pg import FakeStore
 
-from autoparallel.api import AutoParallel
+from autoparallel.api import AutoParallel, auto_parallel
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -335,24 +336,23 @@ def test_in_graph_tensor_ctor(device_mesh_1d):
                 self.linear.bias.fill_(98.6)
             self.buf = torch.arange(dim)
 
-    def input_fn():
-        b = 512
-        inputs = (torch.rand(b, dim, device="cuda"),)
-        return inputs
-
     with torch.device("meta"):
         model = Model(dim)
-    with AutoParallel(
-        model,
-        input_fn,
-        device_mesh_1d,
-    ) as autop:
-        x_sharding = (Shard(0),)
-        autop.add_input_constraints([x_sharding])
-        sharding_placement = autop.optimize_placement()
 
-        # AutoParallel produces a module with meta-DTensor parameters that need to be initialized
-        parallel_mod = autop.apply_placement(sharding_placement)
+    batch_size = 512
+    local_batch_size = batch_size // device_mesh_1d.size()
+    x = DTensor.from_local(
+        torch.rand(local_batch_size, dim, device="cuda"),
+        device_mesh_1d,
+        [Shard(0)],
+    )
+    parallel_mod = auto_parallel(
+        model,
+        device_mesh_1d,
+        sample_inputs=(x,),
+        out_shardings=(Shard(0),),
+        compile=False,
+    )
     parallel_mod.to_empty(device="cuda")
     parallel_mod.init_weights()
     assert torch.equal(


### PR DESCRIPTION
Add a parameter_memory_budget keyword argument to auto_parallel() so callers can set parameter memory constraints without dropping down to the AutoParallel context manager.

Convert 7 tests in test_api.py and 1 test in test_optimize_placement.py from the verbose AutoParallel context manager pattern to the simpler auto_parallel() call. Tests that need access to internal state (sharding_placement, autop.parallel_gm.graph, etc.) are left as-is.

The per-test local imports of DTensor and auto_parallel are hoisted to module-level imports in both test files.

Authored with Claude.