### PR TITLE
Split CUDA CI into single-GPU and multi-GPU jobs

### DIFF
--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -12,23 +12,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-cuda:
-    name: Test CUDA (cuda12.6-py3.12)
+  test-cuda-single-gpu:
+    name: Test CUDA Single GPU (cuda12.6-py3.12)
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - name: 12xlargegpu
-            runs-on: linux.g5.12xlarge.nvidia.gpu
-            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/cu126'
-            gpu-arch-type: "cuda"
-            gpu-arch-version: "12.6"
     with:
       timeout: 60
-      runner: ${{ matrix.runs-on }}
-      gpu-arch-type: ${{ matrix.gpu-arch-type }}
-      gpu-arch-version: ${{ matrix.gpu-arch-version }}
+      runner: linux.g5.4xlarge.nvidia.gpu
+      gpu-arch-type: cuda
+      gpu-arch-version: "12.6"
       submodules: recursive
       script: |
         conda create --yes --quiet --name py312 python=3.12
@@ -43,8 +34,28 @@ jobs:
         pytest tests
         python examples/example_autoparallel.py
         python examples/example_llama3.py
-        python examples/example_dcp.py
         python examples/example_local_map.py
         python examples/example_pp_graph_passes.py
+
+  test-cuda-multi-gpu:
+    name: Test CUDA Multi GPU (cuda12.6-py3.12)
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      timeout: 60
+      runner: linux.g5.12xlarge.nvidia.gpu
+      gpu-arch-type: cuda
+      gpu-arch-version: "12.6"
+      submodules: recursive
+      script: |
+        conda create --yes --quiet --name py312 python=3.12
+        source $(conda info --base)/etc/profile.d/conda.sh
+        conda activate py312
+
+        pip install --quiet -r requirements-test.txt
+        # For some reason the spec above isnt working
+        pip uninstall -y torch
+        pip install --no-input --quiet --pre torch --index-url https://download.pytorch.org/whl/nightly/cu126
+        pip install --quiet .
+        python examples/example_dcp.py
         torchrun --standalone --nproc-per-node 4 examples/example_ds3_local_map.py
         torchrun --standalone --nproc_per_node=4 examples/example_ds3_pp.py --use-loss-fn --fake-evaluate


### PR DESCRIPTION
Split the test_cuda workflow into two parallel jobs so that only the tests that actually need multiple GPUs run on the larger linux.g5.12xlarge.nvidia.gpu runner:

- Single GPU (linux.g5.4xlarge.nvidia.gpu): pytest tests and the single-process examples (example_autoparallel.py, example_llama3.py, example_local_map.py, example_pp_graph_passes.py)
- Multi GPU (linux.g5.12xlarge.nvidia.gpu): example_dcp.py and the two torchrun examples (example_ds3_local_map.py, example_ds3_pp.py)

All tests in tests/ use FakeStore for distributed process groups, so they don't require real multi-GPU hardware.

Authored with Claude.