### PR TITLE
Fix-up split_rule

### DIFF
--- a/autoparallel/shardings/propagation_rules.py
+++ b/autoparallel/shardings/propagation_rules.py
@@ -664,22 +664,18 @@ def constant_pad_nd_rule(mesh, op_schema):
 def split_rule(mesh, op_schema):
     strat = op_schema.args_schema
     op = torch.ops.aten.split.Tensor
-    from torch.distributed.tensor._ops._tensor_ops import split_rule
+    from torch.distributed.tensor._ops._tensor_ops import split_strategy
+
+    op_schema = OpSchema(op, (strat[0], strat[1], strat[2]), {})
+    upstream_strat = split_strategy(op_schema)
 
     res = []
-    oo = []
-    for i, ss in enumerate(strat[0].strategies):
-        ispec = ss.input_specs[0]
-        assert ss.output_spec == ispec
-        o = split_rule(OpSchema(op, (ispec, strat[1], strat[2]), {}))
-        # res.append(o)
-        oo.append(o)
-        if o.output_spec is not None:
-            s = OpSpec(o.output_spec, input_specs=(ispec,))
-            s.redistribute_cost = [[math.inf] * len(ss.redistribute_cost[0])]
-            # s.redistribute_cost = [[0.0] * len(ss.redistribute_cost[0])]
-            s.redistribute_cost[0][i] = 0.0
-            res.append(s)
+    n_input_strats = len(strat[0].strategies)
+    for i, os in enumerate(upstream_strat.strategies):
+        s = OpSpec(os.output_specs, input_specs=os.input_specs)
+        s.redistribute_cost = [[math.inf] * n_input_strats]
+        s.redistribute_cost[0][i] = 0.0
+        res.append(s)
 
     out_strat = OpStrategy(res)
     return out_strat


### PR DESCRIPTION
Upstream API was renamed & migrated to sharding strategy by https://github.com/pytorch/pytorch/pull/149106

Discovered while testing gpt2 model.

<!-- ps-id: 7d82e51b-c885-45ae-b7c1-8394e5868b2e -->