### PR TITLE
Handle None output in propagate_tensor_meta

### DIFF
--- a/autoparallel/shardings/placement_options.py
+++ b/autoparallel/shardings/placement_options.py
@@ -75,6 +75,13 @@ def propagate_tensor_meta(op, user_args, user_kwargs, out_strat):
                     ospec = DTensorSpec(
                         mesh=mesh, placements=(Replicate(),) * mesh.ndim
                     )
+                # Some multi-output ops (e.g. SDPA backward) have optional
+                # outputs that are None at runtime. DTensor's strategy still
+                # creates a DTensorSpec for the position, but the actual
+                # output doesn't exist (hence, tm is None). Replace with None so downstream
+                # code (remove_invalid_configs, validate) skips it gracefully.
+                elif ospec is not None and tm is None:
+                    ospec = None
                 new_output_specs.append(ospec)
             strat.output_specs = tuple(new_output_specs)
 


### PR DESCRIPTION
Some multi-output ops like SDPA bw can have optional outputs that are None at runtime (e.g., gradient w.r.t bias when no bias is used). DTensor's strategy functions create a DTensorSpec for every output, but propagate_tensor_meta does not reconcile this with None outputs -- we end up setting tensor_meta = None on the spec, which causes downstream failures in validate().

By setting the spec to be None for None outputs, downstream works gracefully, incl the solver which ignores this tensor (nothing to shard).

Issue discovered while testing gpt2.

<!-- ps-id: ab0ba120-5eaa-46ea-97b8-face2f2d5577 -->