### PR TITLE
Enable sharding rule for iota

### DIFF
--- a/autoparallel/shardings/placement_options.py
+++ b/autoparallel/shardings/placement_options.py
@@ -25,12 +25,7 @@ from torch.utils._pytree import tree_flatten, tree_map_only
 from autoparallel.shardings.propagation_rules import generate_dummy_redistribute_costs
 
 from .dtensor_sharding_helpers import get_op_strategy, with_implicit_strategies
-from .propagation_rules import (
-    TENSOR_FACTORY_OPS,
-    _op_partial_rules,
-    _op_rules,
-    remove_invalid_configs,
-)
+from .propagation_rules import _op_partial_rules, _op_rules, remove_invalid_configs
 
 
 def _get_meta_tensors_for_op(op, user_args, user_kwargs):
@@ -108,12 +103,10 @@ def propagate_tensor_meta(op, user_args, user_kwargs, out_strat):
             )
             strat.input_specs = (strat.output_specs,)
             assert strat.redistribute_cost is None
-        # NOTE: this invariant wrt factory ops is something I believe
-        # I'll keep for the solver, so we need to have some consistency here
-        # i.e., even though factory ops don't have inputs, we do put an
-        # input spec for it which is equal to the output spec
-        if op in TENSOR_FACTORY_OPS:
-            assert len(tensor_metas) == 0, f"{op}, {len(tensor_metas)}"
+        # Factory ops and other no-input ops (e.g. iota) have 0 tensor
+        # inputs but carry a dummy input_spec equal to output_spec so
+        # the solver has something to wire up.
+        if len(tensor_metas) == 0:
             assert len(strat.input_specs) == 1, f"{op}, {len(strat.input_specs)}"
         else:
             assert len(tensor_metas) == len(

--- a/autoparallel/shardings/propagation_rules.py
+++ b/autoparallel/shardings/propagation_rules.py
@@ -310,12 +310,13 @@ def split_with_sizes_rule(mesh, specs):
 
 @register_rule(torch.ops.prims.iota.default)
 def iota_rule(mesh, specs):
-    raise NotImplementedError("Needs hardening, only tested on a few cases")
+    # Replicate-only: iota's output values are position-dependent
+    # ([0, 1, ..., length-1]), so Shard would require adjusting `start`
+    # per rank. Replicate is correct and cheap (small index tensors).
     shape = [specs[0]]
     tensor_meta = _gen_tensor_meta(shape, dtype=torch.int64)
     placement = (Replicate(),) * mesh.ndim
     spec = DTensorSpec(mesh, placement, tensor_meta=tensor_meta)
-    # return OpStrategy([OpSpec(spec, input_specs=[spec], redistribute_cost=[[0.0]])])
     return OpStrategy([OpSpec(spec, input_specs=[spec], redistribute_cost=[[0.0]])])
 
 

--- a/tests/test_propagation_rules.py
+++ b/tests/test_propagation_rules.py
@@ -110,3 +110,53 @@ def test_permute_layernorm_stride_handling(device_mesh_1d):
 
     # Verify forward execution produces correct output
     assert out.abs().sum() > 0
+
+
+def test_iota(device_mesh_1d):
+    """End-to-end test: model with torch.arange (decomposes to prims.iota)."""
+    seq_len = 256
+    dim = 64
+
+    class ArangeModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embed = nn.Embedding(seq_len, dim)
+
+        def forward(self, x):
+            positions = torch.arange(x.shape[1], device=x.device)
+            return x + self.embed(positions)
+
+    batch_size = 256
+
+    def input_fn():
+        return torch.rand(batch_size, seq_len, dim, device="cuda")
+
+    with torch.device("meta"):
+        model = ArangeModel()
+
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=torch.float32, reduce_dtype=torch.float32
+    )
+
+    with AutoParallel(
+        model, input_fn, device_mesh_1d, mp_policy, compile=True
+    ) as autop:
+        autop.add_input_constraints([(Shard(0),)])
+        autop.add_output_constraints([(Shard(0),)])
+        sharding_placement = autop.optimize_placement()
+        parallel_mod = autop.apply_placement(sharding_placement)
+
+    parallel_mod.to_empty(device="cuda")
+    torch.nn.init.ones_(parallel_mod.embed.weight)
+
+    local_batch = batch_size // torch.distributed.get_world_size()
+    x = torch.ones(local_batch, seq_len, dim, device="cuda")
+    out = parallel_mod(x)
+
+    assert out.shape == (local_batch, seq_len, dim)
+
+    # embed(positions) with all-ones weight gives all-ones, plus all-ones input = 2.0
+    assert torch.allclose(out, torch.full_like(out, 2.0))
+
+    out.sum().backward()
+    assert parallel_mod.embed.weight.grad is not None


### PR DESCRIPTION
- iota is found in most HF models.
- Restricting to R only for now. 

Testing: Adding unit test. Also validated with gpt2 from HF.

<!-- ps-id: 1044a6d6-f346-4770-b268-2699c012d11c -->