### PR TITLE
Remove default input/output constraints from optimize_placement

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -417,14 +417,6 @@ class AutoParallel:
     def optimize_placement(self, verbose=True):
         self._assert_entered()
 
-        if self.input_constraints is None:
-            # forces sharding of input to be S(0) on first dimension and R on others
-            self.add_input_constraints(None)
-
-        if self.output_constraints is None:
-            # forces sharding of fwd output to be S(0) on first dimension and R on others
-            self.add_output_constraints(None)
-
         self.sharding_placement = self.sharding_optimizer.get_solution(verbose=False)
 
         if verbose:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -445,6 +445,7 @@ def test_fx_graph_annotate(device_mesh_1d):
     ) as autop:
         x_sharding = (Shard(0),)
         autop.add_input_constraints([x_sharding])
+        autop.add_output_constraints([x_sharding])
         sharding_placement = autop.optimize_placement()
 
         # AutoParallel produces a module with meta-DTensor parameters that need to be initialized

--- a/tests/test_optimize_placement.py
+++ b/tests/test_optimize_placement.py
@@ -153,6 +153,11 @@ def test_optimization_finds_fsdp_and_ddp_1d(device_mesh_1d, high_mem, model_type
         model = model_fn()
 
     with AutoParallel(model, input_fn, device_mesh_1d) as autop:
+        placement = (Shard(0),)
+        n_inputs = 2 if model_type == "ffn_with_multiple_input_output" else 1
+        n_outputs = 3 if model_type == "ffn_with_multiple_input_output" else 1
+        autop.add_input_constraints([placement] * n_inputs)
+        autop.add_output_constraints([placement] * n_outputs)
         autop.add_parameter_memory_constraint(low=low_mem, high=high_mem)
 
         sharding_placement = autop.optimize_placement()
@@ -282,6 +287,11 @@ def test_optimization_finds_fsdp_tp_2d(
         model = model_fn()
 
     with AutoParallel(model, input_fn, device_mesh_2d) as autop:
+        placement = (Shard(0), Replicate())
+        n_inputs = 2 if model_type == "ffn_with_multiple_input_output" else 1
+        n_outputs = 3 if model_type == "ffn_with_multiple_input_output" else 1
+        autop.add_input_constraints([placement] * n_inputs)
+        autop.add_output_constraints([placement] * n_outputs)
         autop.add_parameter_memory_constraint(low=low_mem, high=high_mem)
 
         sharding_placement = autop.optimize_placement()
@@ -573,6 +583,7 @@ def test_world_size_larger_than_parameter(device_mesh_1d):
     ) as autop:
         x_sharding = (Shard(0),)
         autop.add_input_constraints([x_sharding])
+        autop.add_output_constraints([x_sharding])
         autop.add_parameter_memory_constraint()
         sharding_placement = autop.optimize_placement()
 

--- a/tests/test_ordered_sharding.py
+++ b/tests/test_ordered_sharding.py
@@ -385,6 +385,9 @@ def test_compute_optimal_placement_order_with_non_trainable_params(device_mesh_2
     ), "Test setup error: should have some non-trainable params"
 
     with AutoParallel(model, input_fn, device_mesh_2d) as autop:
+        placement = (Shard(0), Replicate())
+        autop.add_input_constraints([placement])
+        autop.add_output_constraints([placement])
         autop.add_parameter_memory_constraint(low=0, high=None)
         sharding_placement = autop.optimize_placement()
 
@@ -446,6 +449,9 @@ def test_compute_optimal_placement_order_with_all_non_trainable_params(device_me
     ), "Test setup error: should have NO trainable params"
 
     with AutoParallel(model, input_fn, device_mesh_2d) as autop:
+        placement = (Shard(0), Replicate())
+        autop.add_input_constraints([placement])
+        autop.add_output_constraints([placement])
         autop.add_parameter_memory_constraint(low=0, high=None)
         sharding_placement = autop.optimize_placement()
 


### PR DESCRIPTION
## Summary
- `optimize_placement()` no longer implicitly applies `Shard(0)` input/output constraints when the user hasn't set them. This gives the optimizer full freedom to choose placements unless the caller explicitly constrains them.
- Tests that previously relied on the implicit default now specify their constraints explicitly.

The `auto_parallel` convenience function already passes explicit constraints, so it is unaffected.

This is made possible thanks to https://github.com/meta-pytorch/autoparallel/pull/334 and https://github.com/meta-pytorch/autoparallel/pull/341

## Test plan
- [x] Existing tests pass with the explicit constraints

Authored with Claude.