### PR TITLE
Handle TupleStrategy in _try_single_dim_strategy

### DIFF
--- a/autoparallel/shardings/dtensor_sharding_helpers.py
+++ b/autoparallel/shardings/dtensor_sharding_helpers.py
@@ -16,6 +16,7 @@ from torch.distributed.tensor._op_schema import (
     OpSpec,
     OpStrategy,
     StrategyType,
+    TupleStrategy,
 )
 from torch.distributed.tensor._ops.utils import (
     generate_redistribute_costs,
@@ -257,9 +258,20 @@ def _try_single_dim_strategy(
     mesh = op_schema.args_strategy[0].mesh
 
     # Compute output tensor meta via the propagator's existing infra.
-    spec_args = tuple(
-        arg.strategies[0].output_spec if isinstance(arg, OpStrategy) else arg
-        for arg in op_schema.args_schema
+    def _extract_spec(arg: object) -> object:
+        if isinstance(arg, OpStrategy):
+            return arg.strategies[0].output_spec
+        if isinstance(arg, TupleStrategy):
+            return [
+                child.strategies[0].output_spec
+                if isinstance(child, OpStrategy)
+                else child
+                for child in arg.children
+            ]
+        return arg
+
+    spec_args: tuple[object, ...] = tuple(
+        _extract_spec(arg) for arg in op_schema.args_schema
     )
     spec_schema = OpSchema(op, spec_args, op_schema.kwargs_schema)
     out_tensor_meta = propagator._propagate_tensor_meta_non_cached(spec_schema)

--- a/tests/test_propagation_rules.py
+++ b/tests/test_propagation_rules.py
@@ -160,3 +160,46 @@ def test_iota(device_mesh_1d):
 
     out.sum().backward()
     assert parallel_mod.embed.weight.grad is not None
+
+
+def test_index_put(device_mesh_1d):
+    """Test that aten.index_put with List[Tensor] args works through the solver.
+
+    Advanced indexing (e.g. `out[:, idx] = x[:, idx]`) decomposes into
+    aten.index_put, whose `indices` argument is List[Optional[Tensor]].
+    In autoparallel's placement_options.py, list-of-OpStrategy args become
+    TupleStrategy. The _try_single_dim_strategy path must unwrap these
+    TupleStrategy children into DTensorSpecs when computing tensor meta,
+    otherwise _propagate_tensor_meta_non_cached sees TupleStrategy where
+    it expects a list of tensors.
+    """
+
+    class IndexPutModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = nn.Parameter(torch.randn(32, 64))
+
+        def forward(self, x):
+            out = torch.zeros_like(x)
+            idx = torch.arange(x.shape[1], device=x.device)
+            out[:, idx] = x[:, idx]
+            return out @ self.weight
+
+    batch_size = 256
+
+    def input_fn():
+        return torch.randn(batch_size, 32, device="cuda")
+
+    with torch.device("meta"):
+        model = IndexPutModel()
+
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=torch.bfloat16, reduce_dtype=torch.float32
+    )
+
+    with AutoParallel(
+        model, input_fn, device_mesh_1d, mp_policy, compile=True
+    ) as autop:
+        autop.add_input_constraints([(Shard(0),)])
+        sharding_placement = autop.optimize_placement()
+        autop.apply_placement(sharding_placement)


### PR DESCRIPTION
- ops like aten.index_put have TupleStrategy for inputs that are lists (indices input in index_put)

- Issue seen in HF's falcon model.

<!-- ps-id: d74cab25-9840-46e6-8bed-43be48202e65 -->