### PR TITLE
Fix FakeTensorMode leak when AutoParallel.__enter__ fails

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -350,36 +350,45 @@ class AutoParallel:
     def __enter__(self):
         assert self.active is False
 
-        self.build_model_graph()
-        self.old_inductor_comprehensive_padding = (
-            torch._inductor.config.comprehensive_padding
-        )
-        torch._inductor.config.comprehensive_padding = False
+        # build_model_graph and the code below push context managers
+        # (including FakeTensorMode) onto self.stack via
+        # aot_export_joint_with_descriptors. If anything raises, __exit__
+        # won't be called (Python only calls __exit__ if __enter__
+        # succeeds), so we must unwind the stack ourselves.
+        try:
+            self.build_model_graph()
+            self.old_inductor_comprehensive_padding = (
+                torch._inductor.config.comprehensive_padding
+            )
+            torch._inductor.config.comprehensive_padding = False
 
-        rescale_grad_comm_cost_for_mp = 1.0
-        if self.mp_policy is not None:
-            param_size = self.mp_policy.param_dtype.itemsize
-            reduce_size = self.mp_policy.reduce_dtype.itemsize
-            if param_size != reduce_size:
-                rescale_grad_comm_cost_for_mp = reduce_size / param_size
-                # Tiebreak, favoring performing the comms in the largest
-                # dtype
-                rescale_grad_comm_cost_for_mp *= 1.1
-        sharding_optimizer = ShardingOptimizer(
-            self.gm,
-            self.mesh,
-            rescale_grad_comm_cost_for_mp,
-            repeated_subgraphs=self.kwargs.get("repeated_subgraphs", False),
-        )
+            rescale_grad_comm_cost_for_mp = 1.0
+            if self.mp_policy is not None:
+                param_size = self.mp_policy.param_dtype.itemsize
+                reduce_size = self.mp_policy.reduce_dtype.itemsize
+                if param_size != reduce_size:
+                    rescale_grad_comm_cost_for_mp = reduce_size / param_size
+                    # Tiebreak, favoring performing the comms in the largest
+                    # dtype
+                    rescale_grad_comm_cost_for_mp *= 1.1
+            sharding_optimizer = ShardingOptimizer(
+                self.gm,
+                self.mesh,
+                rescale_grad_comm_cost_for_mp,
+                repeated_subgraphs=self.kwargs.get("repeated_subgraphs", False),
+            )
 
-        self.sharding_optimizer = sharding_optimizer
+            self.sharding_optimizer = sharding_optimizer
 
-        self.input_constraints = None
-        self.output_constraints = None
+            self.input_constraints = None
+            self.output_constraints = None
 
-        self.active = True
+            self.active = True
 
-        self.stack.__enter__()
+            self.stack.__enter__()
+        except BaseException:
+            self.stack.__exit__(None, None, None)
+            raise
 
         return self
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1073,3 +1073,47 @@ def test_forward_input_validation_integration(device_mesh_1d):
 
     with pytest.raises(TypeError, match="Tensor"):
         parallel_mod(42)
+
+
+def test_enter_failure_cleans_up_fake_mode(device_mesh_1d):
+    """FakeTensorMode pushed during build_model_graph is unwound if __enter__ fails.
+
+    build_model_graph() pushes FakeTensorMode onto self.stack via
+    aot_export_joint_with_descriptors. If something after build_model_graph()
+    raises (e.g. ShardingOptimizer), Python never calls __exit__ because
+    __enter__ didn't succeed, so __enter__ must unwind self.stack explicitly.
+    Without cleanup, the leaked FakeTensorMode causes "Mixing fake modes NYI"
+    on subsequent usage.
+    """
+    from unittest.mock import patch
+
+    dim = 128
+
+    class Model(nn.Module):
+        def __init__(self, dim):
+            super().__init__()
+            self.linear = nn.Linear(dim, dim)
+
+        def forward(self, x):
+            return self.linear(x)
+
+    def input_fn():
+        return (torch.rand(32, dim, device="cuda"),)
+
+    with torch.device("meta"):
+        model1 = Model(dim)
+    auto_p = AutoParallel(model1, input_fn, device_mesh_1d)
+
+    # Make ShardingOptimizer raise to simulate __enter__ failing
+    # after build_model_graph() has already pushed FakeTensorMode.
+    with patch(
+        "autoparallel.api.ShardingOptimizer", side_effect=RuntimeError("injected")
+    ):
+        with pytest.raises(RuntimeError, match="injected"):
+            auto_p.__enter__()
+
+    # If FakeTensorMode leaked, this would fail with "Mixing fake modes NYI"
+    # during copy.deepcopy inside AutoParallel.__init__.
+    with torch.device("meta"):
+        model2 = Model(dim)
+    AutoParallel(model2, input_fn, device_mesh_1d)


### PR DESCRIPTION
`build_model_graph()` pushes `FakeTensorMode` (and other context managers) onto `self.stack` via `aot_export_joint_with_descriptors → create_aot_state → stack.enter_context(fake_mode)`. If anything after that push raises — e.g. `ShardingOptimizer.__init__` hitting a PuLP error — then `__enter__` fails and Python's with statement never calls `__exit__`, so the `FakeTensorMode` remains active on the global dispatch stack.

The next `AutoParallel.__init__` then creates a new `FakeTensorMode`, but `copy.deepcopy(model)` runs under the leaked old mode, producing `FakeTensors` bound to it. `move_to_fake` with the new mode rejects these with "Mixing fake modes NYI".

The fix wraps the body of `__enter__` (including `build_model_graph())` in a try/except that calls `self.stack.__exit__(None, None, None)` on failure, ensuring all pushed context managers are properly unwound even when `__enter__` doesn't complete.

Authored with Claude.