### PR TITLE
Cache ILP cost computation to avoid redundant work across repeated layers

### DIFF
--- a/autoparallel/cost_models/collective_runtime_estimation.py
+++ b/autoparallel/cost_models/collective_runtime_estimation.py
@@ -143,11 +143,28 @@ def redistribute_cost(
     return cost
 
 
+_comms_cost_cache: dict[tuple, float] = {}
+
+
+def reset_comms_cost_cache():
+    _comms_cost_cache.clear()
+
+
 def estimate_strategy_comms_cost(src_spec, tgt_spec):
+    key = (
+        src_spec.placements,
+        src_spec.tensor_meta,
+        tgt_spec.placements,
+        tgt_spec.tensor_meta,
+    )
+    cached = _comms_cost_cache.get(key)
+    if cached is not None:
+        return cached
     order = list(range(src_spec.mesh.ndim))
     if src_spec.placements == (Partial(), Partial()) and all(
         p.is_shard() for p in tgt_spec.placements
     ):
         order = [1, 0]
-    comms_cost = redistribute_cost(src_spec, tgt_spec, order)
-    return comms_cost
+    cost = redistribute_cost(src_spec, tgt_spec, order)
+    _comms_cost_cache[key] = cost
+    return cost

--- a/autoparallel/cost_models/collective_runtime_estimation.py
+++ b/autoparallel/cost_models/collective_runtime_estimation.py
@@ -157,14 +157,20 @@ def estimate_strategy_comms_cost(src_spec, tgt_spec):
         tgt_spec.placements,
         tgt_spec.tensor_meta,
     )
-    cached = _comms_cost_cache.get(key)
-    if cached is not None:
-        return cached
+    try:
+        hash(key)  # fail fast if key contains unhashable types (e.g. SymInts)
+    except TypeError:
+        key = None
+    if key is not None:
+        cached = _comms_cost_cache.get(key)
+        if cached is not None:
+            return cached
     order = list(range(src_spec.mesh.ndim))
     if src_spec.placements == (Partial(), Partial()) and all(
         p.is_shard() for p in tgt_spec.placements
     ):
         order = [1, 0]
     cost = redistribute_cost(src_spec, tgt_spec, order)
-    _comms_cost_cache[key] = cost
+    if key is not None:
+        _comms_cost_cache[key] = cost
     return cost

--- a/autoparallel/cost_models/compute_estimation.py
+++ b/autoparallel/cost_models/compute_estimation.py
@@ -387,6 +387,21 @@ def _get_dtype_from_args(args):
     return dtype
 
 
+_compute_cost_cache: dict[tuple, float] = {}
+
+
+def reset_compute_cost_cache():
+    _compute_cost_cache.clear()
+
+
+def _make_hashable(x):
+    if isinstance(x, (list, tuple)):
+        return tuple(_make_hashable(a) for a in x)
+    if isinstance(x, torch.Tensor):
+        return (x.shape, x.stride(), x.dtype)
+    return x
+
+
 def estimate_strategy_runtime_cost(node, strategy):
     """
     This function estimates the runtime cost of a given strategy
@@ -398,6 +413,26 @@ def estimate_strategy_runtime_cost(node, strategy):
     if _has_zero_cost(node):
         return 0
 
+    cache_key = None
+    if strategy is not None:
+        input_specs_key = tuple(
+            (s.placements, s.tensor_meta) for s in strategy.input_specs
+        )
+        try:
+            non_tensor_args = tuple(
+                _make_hashable(a)
+                for a in tree_flatten(node.args)[0]
+                if not isinstance(a, torch.fx.Node)
+            )
+            cache_key = (node.target, input_specs_key, non_tensor_args)
+        except TypeError:
+            pass
+
+        if cache_key is not None:
+            cached = _compute_cost_cache.get(cache_key)
+            if cached is not None:
+                return cached
+
     args, kwargs = _shard_args_for_node(node, strategy)
 
     flops, out = _compute_flops(node.target, *args, **kwargs)
@@ -406,19 +441,23 @@ def estimate_strategy_runtime_cost(node, strategy):
     read_write_time = compute_read_write_time(read_write_bytes)
 
     if flops == 0:
-        return read_write_time
+        result = read_write_time
+    else:
+        dtype = _get_dtype_from_args(args)
 
-    dtype = _get_dtype_from_args(args)
+        # TODO: use PyTorch's version once it's giving correct results
+        gpu_flops = _get_device_tflops(dtype) * 10**12
 
-    # TODO: use PyTorch's version once it's giving correct results
-    gpu_flops = _get_device_tflops(dtype) * 10**12
+        # suppose 70% efficiency for the operator
+        compute_efficiency = 0.70
+        compute_time = flops / gpu_flops * 1e6  # us
+        compute_time = compute_time / compute_efficiency
 
-    # suppose 70% efficiency for the operator
-    compute_efficiency = 0.70
-    compute_time = flops / gpu_flops * 1e6  # us
-    compute_time = compute_time / compute_efficiency
+        result = max(compute_time, read_write_time)
 
-    return max(compute_time, read_write_time)
+    if cache_key is not None:
+        _compute_cost_cache[cache_key] = result
+    return result
 
 
 def benchmark_strategy_runtime_cost(node, strategy):

--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -155,10 +155,20 @@ class ShardingOptimizer:
 
         t0 = time.perf_counter()
         self.decision_vars = self._build_decision_vars()
+        t1 = time.perf_counter()
         self.validate()
+        t2 = time.perf_counter()
         self.prob = pulp.LpProblem("AutoParallel", pulp.LpMinimize)
         self.add_default_constraints()
-        logger.info("ILP construction took %.3fs", time.perf_counter() - t0)
+        t3 = time.perf_counter()
+        logger.info(
+            "ILP construction took %.3fs "
+            "(decision_vars=%.3fs, validate=%.3fs, constraints=%.3fs)",
+            t3 - t0,
+            t1 - t0,
+            t2 - t1,
+            t3 - t2,
+        )
 
     def _get_next_name(self, prefix):
         idx = self._name_counters.setdefault(prefix, 0)
@@ -305,10 +315,17 @@ class ShardingOptimizer:
     def _build_decision_vars(self):
         """Build DecisionVar entries for every (node_idx, argi, out_idx, inp_idx)
         combination in the strategy space."""
+        t_pulp_start = time.perf_counter()
         pulp_variables = self._create_pulp_variables()
+        t_pulp_end = time.perf_counter()
         grad_param_nodes = set(
             x[1] for x in get_param_and_grad_nodes(self.graph).values()
         )
+
+        t_compute = 0.0
+        t_edge = 0.0
+        t_decvar = 0.0
+        n_vars = 0
 
         decision_vars = {}
         for node_idx, (node, op_strategy) in enumerate(self.strats.items()):
@@ -319,7 +336,10 @@ class ShardingOptimizer:
             num_args = len(op_strategy.strategies[0].input_specs)
 
             for out_idx, output_strategy in enumerate(op_strategy.strategies):
+                tc0 = time.perf_counter()
                 compute_cost = estimate_strategy_runtime_cost(node, output_strategy)
+                tc1 = time.perf_counter()
+                t_compute += tc1 - tc0
                 per_arg_compute = compute_cost / num_args
 
                 for argi, redist_costs in enumerate(output_strategy.redistribute_cost):
@@ -327,6 +347,7 @@ class ShardingOptimizer:
                         self.strats[all_input_nodes[argi]] if all_input_nodes else None
                     )
                     for inp_idx, default_comm_cost in enumerate(redist_costs):
+                        te0 = time.perf_counter()
                         comm_cost, transition_cost = self._compute_edge_costs(
                             node,
                             output_strategy,
@@ -336,11 +357,14 @@ class ShardingOptimizer:
                             producer_strategy,
                             grad_param_nodes,
                         )
+                        te1 = time.perf_counter()
+                        t_edge += te1 - te0
                         # Update OpSpec redistribute_cost so print_costs_for_node
                         # reflects the recomputed costs
                         redist_costs[inp_idx] = comm_cost
 
                         key = (node_idx, argi, out_idx, inp_idx)
+                        td0 = time.perf_counter()
                         decision_vars[key] = DecisionVar(
                             var=pulp_variables[key],
                             cost=comm_cost + per_arg_compute + transition_cost,
@@ -351,7 +375,19 @@ class ShardingOptimizer:
                             output_spec=output_strategy.output_specs,
                             input_spec=output_strategy.input_specs[argi],
                         )
+                        t_decvar += time.perf_counter() - td0
+                        n_vars += 1
 
+        logger.info(
+            "_build_decision_vars breakdown (%d vars): "
+            "pulp_vars=%.3fs, compute_cost=%.3fs, edge_cost=%.3fs, "
+            "decvar_create=%.3fs",
+            n_vars,
+            t_pulp_end - t_pulp_start,
+            t_compute,
+            t_edge,
+            t_decvar,
+        )
         return decision_vars
 
     def _collect_vars(self, node, node_idx, argi, group_by, resolve_clusters=False):


### PR DESCRIPTION
After caching placement options in https://github.com/meta-pytorch/autoparallel/pull/354, ILP construction became the dominant bottleneck at 142s for LLaMA-3 8B. Added timing instrumentation to `_build_decision_vars` which revealed the breakdown across 3.67M decision variables:

- edge_cost (comm cost estimation): 98s (67%)
- compute_cost (FlopCounterMode): 26s (18%)
- constraints (PuLP): 12s (8%)
- decvar_create: 5s (3.5%)
- pulp_vars: 3s (2.4%)

The comm and compute cost functions are called millions of times but produce identical results for nodes with the same op, placements, and tensor shapes — which is the case across repeated transformer layers.

Added caching to estimate_strategy_comms_cost keyed on `(src_placements, src_tensor_meta, tgt_placements, tgt_tensor_meta)` and to `estimate_strategy_runtime_cost` keyed on `(op, input_specs, non_tensor_args)`.

Results on LLaMA-3 8B (32 layers, 2D mesh):
- edge_cost: 98s → 16s
- compute_cost: 26s → 1.8s
- ILP construction total: 142s → 40s (3.6x speedup)

Authored with Claude.