### PR TITLE
Add timing instrumentation to apply_sharding_to_model

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -554,9 +554,11 @@ class AutoParallel:
                 self.joint_with_descriptors.params_spec,
                 self.joint_with_descriptors.buffers_spec,
             )
+        t_apply = time.perf_counter()
         # clean it up by removing the added aliases from previous pass
         # as well as redundant views
         cleanup_graph(parallel_gm, aggressive=True)
+        t_cleanup = time.perf_counter()
 
         trace_structured(
             "artifact",
@@ -568,11 +570,13 @@ class AutoParallel:
                 print_output=False, include_stride=True, include_device=True
             ),
         )
+        t_trace = time.perf_counter()
 
         if self.enable_ac:
             ac_joint_pass(
                 parallel_gm.graph, self.ac_stage_size_in_GiB, self.reshard_after_forward
             )
+        t_ac = time.perf_counter()
         # now rename input/param/tangent/output/grad_param/grad_input nodes following
         # our convention
         # apply_node_renaming(
@@ -599,7 +603,15 @@ class AutoParallel:
             torch.fx.node._side_effectful_functions.remove(
                 torch.ops._c10d_functional.wait_tensor.default
             )
-        logger.info("Apply placements took %.3fs", time.perf_counter() - t0)
+        logger.info(
+            "Apply placements took %.3fs "
+            "(apply_sharding=%.3fs, cleanup=%.3fs, trace=%.3fs, ac=%.3fs)",
+            time.perf_counter() - t0,
+            t_apply - t0,
+            t_cleanup - t_apply,
+            t_trace - t_cleanup,
+            t_ac - t_trace,
+        )
         return (
             sharded_param_dict,
             sharded_buffer_dict,

--- a/autoparallel/apply_sharding.py
+++ b/autoparallel/apply_sharding.py
@@ -5,7 +5,9 @@
 
 import contextlib
 import copy
+import logging
 import operator
+import time
 from typing import Any
 
 import torch
@@ -31,6 +33,8 @@ from .shardings.ordered_sharding import (
 from .shardings.propagation_rules import TENSOR_FACTORY_OPS
 
 _ENABLE_ORDERED_SHARDING_OPTIMIZATION = True
+
+logger = logging.getLogger(__name__)
 
 
 class ApplyShardingInterpreter(torch.fx.Interpreter):
@@ -302,25 +306,34 @@ def _get_inductor_decomp_table():
 
 
 def apply_sharding_to_model(gm, sharding_placement, params_spec, buffers_spec):
+    t0 = time.perf_counter()
     args = shard_nodes_given_placements(gm, sharding_placement)
     local_args = [arg.to_local() for arg in args]
+    t1 = time.perf_counter()
 
     decomp_table = _get_inductor_decomp_table()
     # run with DTensor to apply the collectives given the graph
     interp = ApplyShardingInterpreter(gm, sharding_placement)
+    t2 = time.perf_counter()
 
     # TODO: make_fx here is suspicious in case of dynamic shapes
     # here we update sharding_placement if device order get muted
     with fx_traceback.preserve_node_meta():
         parallel_gm0 = make_fx(interp.run)(*local_args)
+    t3 = time.perf_counter()
 
     cleanup_graph(parallel_gm0)
+    t4 = time.perf_counter()
+
     interp2 = torch.fx.Interpreter(parallel_gm0)
     with fx_traceback.preserve_node_meta():
         parallel_gm = make_fx(interp2.run, decomposition_table=decomp_table)(
             *local_args
         )
+    t5 = time.perf_counter()
+
     cleanup_graph(parallel_gm)
+    t6 = time.perf_counter()
 
     # Copy descriptors over to new graph
     for n1, n2 in zip(
@@ -335,6 +348,7 @@ def apply_sharding_to_model(gm, sharding_placement, params_spec, buffers_spec):
             rename_placeholder_node(parallel_gm, n2, n1.name)
     # need to recompile after renaming nodes
     parallel_gm.recompile()
+    t7 = time.perf_counter()
 
     sharded_param_dict = {}
     sharded_buffer_dict = {}
@@ -359,5 +373,21 @@ def apply_sharding_to_model(gm, sharding_placement, params_spec, buffers_spec):
         sharded_buffer_dict[fqn] = shard_node_given_placements(
             n, sharding_placement, meta=True
         )
+    t8 = time.perf_counter()
+
+    logger.info(
+        "apply_sharding_to_model breakdown: "
+        "shard_inputs=%.3fs, interp_init=%.3fs, make_fx_1=%.3fs, "
+        "cleanup_1=%.3fs, make_fx_2=%.3fs, cleanup_2=%.3fs, "
+        "rename=%.3fs, shard_params=%.3fs",
+        t1 - t0,
+        t2 - t1,
+        t3 - t2,
+        t4 - t3,
+        t5 - t4,
+        t6 - t5,
+        t7 - t6,
+        t8 - t7,
+    )
 
     return parallel_gm, sharded_param_dict, sharded_buffer_dict


### PR DESCRIPTION
Breaks down the `Apply placements` timing into its components to identify optimization targets. The inner `apply_sharding_to_model` now logs: `shard_inputs`, `interp_init`, `make_fx_1`, `cleanup_1`, `make_fx_2`, `cleanup_2`, `rename`, `shard_params`. The outer  `_apply_placement_common` logs: `apply_sharding`, `cleanup`, `trace`, `ac`.                                                                                                                                                                                  

On 32-layer LLaMA-3 8B, the two `make_fx` passes dominate at ~8.7s and ~5.0s respectively.

Authored with Claude.