### PR TITLE
Refactor view-mm-view einsum replacement into separate matchers and add tests

### DIFF
--- a/autoparallel/graph_passes/graph_utils.py
+++ b/autoparallel/graph_passes/graph_utils.py
@@ -202,67 +202,78 @@ def assert_has_no_collectives(gm: torch.fx.GraphModule):
 # We perform this pattern-matching replacement for both the forward as well as
 # the backward pass.
 # TODO: use graph_patterns to simplify writing this
+def _batch_dims(n: int) -> str:
+    """Return a string of `n` batch-dimension letters starting from 'a'."""
+    assert 0 < n <= 25
+    return "".join(chr(97 + i) for i in range(n))
+
+
+def _match_forward_linear(mm_node):
+    """Match the forward pattern: view -> mm -> view.
+
+    Returns (inputs, replaced_node, equation) or None.
+    """
+    first_input, second_input = mm_node.all_input_nodes
+    if first_input.target != torch.ops.aten.view.default:
+        return None
+    view_input = first_input.all_input_nodes[0]
+    users = list(mm_node.users)
+    if not (
+        len(users) == 1
+        and users[0].target == torch.ops.aten.view.default
+        and view_input.meta["val"].shape[:-1] == users[0].meta["val"].shape[:-1]
+        and second_input.meta["val"].ndim == 2
+    ):
+        return None
+    ndim = view_input.meta["val"].ndim
+    assert 1 < ndim <= 26, "Only support up to 26D for now"
+    dims = _batch_dims(ndim - 1)
+    equation = f"{dims}k,kn->{dims}n"
+    return [view_input, second_input], users[0], equation
+
+
+def _match_backward_linear(mm_node):
+    """Match the backward pattern: view -> permute -> mm -> permute.
+
+    Returns (inputs, replaced_node, equation) or None.
+    """
+    first_input, second_input = mm_node.all_input_nodes
+    if second_input.target != torch.ops.aten.view.default:
+        return None
+    if first_input.target != torch.ops.aten.permute.default:
+        return None
+    if first_input.all_input_nodes[0].target != torch.ops.aten.view.default:
+        return None
+    orig_first = first_input.all_input_nodes[0].all_input_nodes[0]
+    orig_second = second_input.all_input_nodes[0]
+    users = list(mm_node.users)
+    if not (
+        len(users) == 1
+        and users[0].target == torch.ops.aten.permute.default
+        and orig_first.meta["val"].shape[:-1] == orig_second.meta["val"].shape[:-1]
+        and mm_node.meta["val"].ndim == 2
+    ):
+        return None
+    ndim = orig_first.meta["val"].ndim
+    assert 1 < ndim <= 26, "Only support up to 26D for now"
+    dims = _batch_dims(ndim - 1)
+    equation = f"{dims}n,{dims}k->kn"
+    return [orig_first, orig_second], users[0], equation
+
+
 def _replace_view_mm_view_with_einsum(gm):
     mm_nodes = gm.graph.find_nodes(op="call_function", target=torch.ops.aten.mm.default)
     for node in mm_nodes:
-        first_input, second_input = node.all_input_nodes
-        if first_input.target == torch.ops.aten.view.default:
-            view_input = first_input.all_input_nodes[0]
-            users = list(node.users)
-            if (
-                len(users) == 1
-                and users[0].target == torch.ops.aten.view.default
-                and view_input.meta["val"].shape[:-1] == users[0].meta["val"].shape[:-1]
-                and second_input.meta["val"].ndim == 2
-            ):
-                print(
-                    f"Found matmul node {node}, {view_input.meta['val'].shape, second_input.meta['val'].shape}"
-                )
-                ndim = view_input.meta["val"].ndim
-                assert 1 < ndim <= 10, "Only support up to 10D for now"
-
-                # generate the leading dimensions as a, b, c, etc
-                dims = "".join([chr(97 + i) for i in range(ndim - 1)])
-                mm_equation = f"{dims}k,kn->{dims}n"
-                with gm.graph.inserting_before(node):
-                    new_node = gm.graph.call_function(
-                        torch.ops.aten.einsum.default,
-                        args=(mm_equation, [view_input, second_input]),
-                    )
-                    new_node.meta.update(users[0].meta)
-                    users[0].replace_all_uses_with(new_node)
-
-        elif second_input.target == torch.ops.aten.view.default:
-            if first_input.target != torch.ops.aten.permute.default:
-                continue
-            if first_input.all_input_nodes[0].target != torch.ops.aten.view.default:
-                continue
-            orig_first = first_input.all_input_nodes[0].all_input_nodes[0]
-            orig_second = second_input.all_input_nodes[0]
-            users = list(node.users)
-            if (
-                len(users) == 1
-                and users[0].target == torch.ops.aten.permute.default
-                and orig_first.meta["val"].shape[:-1]
-                == orig_second.meta["val"].shape[:-1]
-                and node.meta["val"].ndim == 2
-            ):
-                print(
-                    f"Found matmul node {node} {orig_first.meta['val'].shape, orig_second.meta['val'].shape}"
-                )
-
-                ndim = orig_first.meta["val"].ndim
-                assert 1 < ndim <= 10, "Only support up to 10D for now"
-
-                # generate the leading dimensions as a, b, c, etc
-                dims = "".join([chr(97 + i) for i in range(ndim - 1)])
-                mm_equation = f"{dims}n,{dims}k->kn"
-                with gm.graph.inserting_before(node):
-                    new_node = gm.graph.call_function(
-                        torch.ops.aten.einsum.default,
-                        args=(mm_equation, [orig_first, orig_second]),
-                    )
-                    new_node.meta.update(users[0].meta)
-                    users[0].replace_all_uses_with(new_node)
+        match = _match_forward_linear(node) or _match_backward_linear(node)
+        if match is None:
+            continue
+        inputs, replaced_node, equation = match
+        with gm.graph.inserting_before(node):
+            new_node = gm.graph.call_function(
+                torch.ops.aten.einsum.default,
+                args=(equation, inputs),
+            )
+            new_node.meta.update(replaced_node.meta)
+            replaced_node.replace_all_uses_with(new_node)
     gm.graph.eliminate_dead_code()
     gm.recompile()

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -1,0 +1,114 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from torch.fx.experimental.proxy_tensor import make_fx
+
+from autoparallel.graph_passes.graph_utils import _replace_view_mm_view_with_einsum
+
+
+def _count_ops(gm, target):
+    return len(gm.graph.find_nodes(op="call_function", target=target))
+
+
+def test_forward_pattern_3d():
+    """view(x, [-1,K]) -> mm(_, w) -> view(_, [B,S,N]) is replaced by einsum."""
+    B, S, K, N = 2, 8, 16, 32
+
+    def f(x, w):
+        flat = torch.ops.aten.view.default(x, [B * S, K])
+        out = torch.ops.aten.mm.default(flat, w)
+        return torch.ops.aten.view.default(out, [B, S, N])
+
+    x = torch.randn(B, S, K)
+    w = torch.randn(K, N)
+    gm = make_fx(f, tracing_mode="fake")(x, w)
+
+    _replace_view_mm_view_with_einsum(gm)
+
+    assert _count_ops(gm, torch.ops.aten.einsum.default) == 1
+    assert _count_ops(gm, torch.ops.aten.mm.default) == 0
+    assert _count_ops(gm, torch.ops.aten.view.default) == 0
+
+
+def test_forward_pattern_4d():
+    """Same pattern but with 4D input [B,S,T,K] -> 3 batch dims in equation."""
+    B, S, T, K, N = 2, 4, 3, 16, 32
+
+    def f(x, w):
+        flat = torch.ops.aten.view.default(x, [B * S * T, K])
+        out = torch.ops.aten.mm.default(flat, w)
+        return torch.ops.aten.view.default(out, [B, S, T, N])
+
+    x = torch.randn(B, S, T, K)
+    w = torch.randn(K, N)
+    gm = make_fx(f, tracing_mode="fake")(x, w)
+
+    _replace_view_mm_view_with_einsum(gm)
+
+    assert _count_ops(gm, torch.ops.aten.einsum.default) == 1
+    assert _count_ops(gm, torch.ops.aten.mm.default) == 0
+    assert _count_ops(gm, torch.ops.aten.view.default) == 0
+
+
+def test_backward_pattern():
+    """view -> permute -> mm -> permute is replaced by einsum."""
+    B, S, K, N = 2, 8, 16, 32
+
+    def f(grad_out, x):
+        # grad_out: [B, S, N], x: [B, S, K]
+        # flatten both, permute grad_out^T, mm, permute result
+        flat_grad = torch.ops.aten.view.default(grad_out, [B * S, N])
+        perm_grad = torch.ops.aten.permute.default(flat_grad, [1, 0])
+        flat_x = torch.ops.aten.view.default(x, [B * S, K])
+        out = torch.ops.aten.mm.default(perm_grad, flat_x)
+        return torch.ops.aten.permute.default(out, [1, 0])
+
+    grad_out = torch.randn(B, S, N)
+    x = torch.randn(B, S, K)
+    gm = make_fx(f, tracing_mode="fake")(grad_out, x)
+
+    _replace_view_mm_view_with_einsum(gm)
+
+    assert _count_ops(gm, torch.ops.aten.einsum.default) == 1
+    assert _count_ops(gm, torch.ops.aten.mm.default) == 0
+    assert _count_ops(gm, torch.ops.aten.view.default) == 0
+
+
+def test_no_match_plain_mm():
+    """Plain mm without surrounding views should be left untouched."""
+
+    def f(a, b):
+        return torch.ops.aten.mm.default(a, b)
+
+    a = torch.randn(4, 8)
+    b = torch.randn(8, 16)
+    gm = make_fx(f, tracing_mode="fake")(a, b)
+
+    _replace_view_mm_view_with_einsum(gm)
+
+    assert _count_ops(gm, torch.ops.aten.einsum.default) == 0
+    assert _count_ops(gm, torch.ops.aten.mm.default) == 1
+
+
+def test_no_match_shape_mismatch():
+    """view -> mm -> view where leading dims of input/output don't match."""
+    K, N = 16, 32
+
+    def f(x, w):
+        # input [6, K] viewed as [6, K], output viewed as [2, 3, N]
+        # leading dims: (6,) vs (2, 3) — different, so no match
+        flat = torch.ops.aten.view.default(x, [6, K])
+        out = torch.ops.aten.mm.default(flat, w)
+        return torch.ops.aten.view.default(out, [2, 3, N])
+
+    x = torch.randn(6, K)
+    w = torch.randn(K, N)
+    gm = make_fx(f, tracing_mode="fake")(x, w)
+
+    _replace_view_mm_view_with_einsum(gm)
+
+    assert _count_ops(gm, torch.ops.aten.einsum.default) == 0
+    assert _count_ops(gm, torch.ops.aten.mm.default) == 1


### PR DESCRIPTION
## Summary
- Refactors `_replace_view_mm_view_with_einsum` by extracting the forward (`view → mm → view`) and backward (`view → permute → mm → permute`) pattern matching into `_match_forward_linear` and `_match_backward_linear`, with a shared `_batch_dims` helper. The main function now just loops over mm nodes, tries each matcher, and applies a single replacement path.
- Removes debug `print` statements.
- Adds unit tests covering both matching patterns (3D and 4D forward, backward) and non-matching cases (plain mm, shape mismatch).

Start with `graph_utils.py` (the helpers, then the simplified main function), then `test_graph_utils.py`.

Authored with Claude.

## Test plan
- [x] `python -m pytest tests/test_graph_utils.py -v`