### PR TITLE
Fix IndexError in build_param_grad_linear_chains for unused parameters

### DIFF
--- a/autoparallel/shardings/ordered_sharding.py
+++ b/autoparallel/shardings/ordered_sharding.py
@@ -172,6 +172,9 @@ def build_param_grad_linear_chains(
     source_to_chain: dict[torch.fx.Node, list[torch.fx.Node]] = {}
 
     for param, grad in param_and_grad_nodes:
+        # Skip unused parameters — no chain to build
+        if not param.users:
+            continue
         # Build forward chain of users for the parameter
         last_p = list(param.users)[0]
         p_chain: list[torch.fx.Node] = [param]

--- a/tests/test_ordered_sharding.py
+++ b/tests/test_ordered_sharding.py
@@ -250,6 +250,42 @@ class TestBuildParamGradLinearChains:
         chain2_nodes = set(source_to_chain[param2])
         assert chain1_nodes.isdisjoint(chain2_nodes), "Param chains should be disjoint"
 
+    def test_unused_parameter_skipped(self):
+        """Test that parameters with no users are skipped without raising an error.
+
+        This can happen when a parameter exists in the graph as a placeholder
+        but is not used by any operation in the forward pass.
+        """
+        dim = 64
+        model = SimpleLinearModel(dim)
+        sample_input = torch.randn(8, dim, requires_grad=True)
+
+        gm, param_grad_nodes = _get_joint_graph(model, sample_input)
+
+        # Insert an unused placeholder node into the graph to simulate
+        # an unused parameter
+        graph = gm.graph
+        first_node = next(iter(graph.nodes))
+        with graph.inserting_before(first_node):
+            unused_param = graph.placeholder("unused_param")
+
+        # Prepend the unused parameter (with no grad) to the list
+        param_grad_nodes_with_unused = [(unused_param, None)] + param_grad_nodes
+
+        # This should not raise an IndexError
+        node_to_source, source_to_chain = build_param_grad_linear_chains(
+            param_grad_nodes_with_unused
+        )
+
+        # The unused parameter should not appear in either dict
+        assert unused_param not in node_to_source
+        assert unused_param not in source_to_chain
+
+        # The other (used) parameters should still have their chains
+        for param, grad in param_grad_nodes:
+            assert param in source_to_chain
+            assert param in node_to_source
+
     def test_chains_contain_only_single_input_nodes(self):
         """Test that chains only include nodes with single inputs (linear dependency)."""
         dim = 64


### PR DESCRIPTION
## Summary

- build_param_grad_linear_chains crashes with IndexError: list index out of range when a parameter node has no users in the graph. This can happen when a model has parameters that are unused in the forward pass. The fix skips such parameters since there is no dependency chain to build for them.

## Test plan

- Added test_unused_parameter_skipped to TestBuildParamGradLinearChains which inserts an unused placeholder into a real FX graph and verifies that build_param_grad_linear_chains handles it gracefully while still correctly processing the other parameters.