### PR TITLE
Capture unused parameters and buffers in the parallel model

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -278,6 +278,47 @@ def _check_forward_args(args, expected_inputs):
                 )
 
 
+def _add_unused_params_and_buffers(model, graph_module):
+    """Register parameters/buffers from model that are missing from graph_module.
+
+    Dynamo only captures parameters/buffers actually used in forward(). This
+    adds unused ones as get_attr nodes so aot_export_joint_with_descriptors
+    lifts them into the joint graph and they appear in params_spec/buffers_spec.
+    """
+    from torch.fx.graph_module import _assign_attr
+
+    existing_params = set(dict(graph_module.named_parameters()))
+    existing_buffers = set(dict(graph_module.named_buffers()))
+
+    graph = graph_module.graph
+    # Insert after all existing placeholder/get_attr nodes, before computation.
+    insert_before = None
+    for node in graph.nodes:
+        if node.op not in ("placeholder", "get_attr"):
+            insert_before = node
+            break
+
+    added = False
+    for fqn, param in model.named_parameters():
+        if fqn not in existing_params:
+            _assign_attr(param, graph_module, fqn)
+            with graph.inserting_before(insert_before):
+                n = graph.create_node("get_attr", target=fqn)
+                n.meta["val"] = param
+            added = True
+
+    for fqn, buf in model.named_buffers():
+        if fqn not in existing_buffers:
+            _assign_attr(buf, graph_module, fqn)
+            with graph.inserting_before(insert_before):
+                n = graph.create_node("get_attr", target=fqn)
+                n.meta["val"] = buf
+            added = True
+
+    if added:
+        graph_module.recompile()
+
+
 class AutoParallel:
     """
     Args:
@@ -455,6 +496,7 @@ class AutoParallel:
                 *formatted_inputs
             )
             _restore_state_dict(self.model, torch_ir_with_fqn)
+            _add_unused_params_and_buffers(self.model, torch_ir_with_fqn)
             # TODO Can't use fake mode here because it clashes with the user level
             # fake mode. Ideally dynamo should reuse the user level fake mode.
             self.joint_with_descriptors = aot_export_joint_with_descriptors(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1117,3 +1117,45 @@ def test_enter_failure_cleans_up_fake_mode(device_mesh_1d):
     with torch.device("meta"):
         model2 = Model(dim)
     AutoParallel(model2, input_fn, device_mesh_1d)
+
+
+def test_unused_parameters_captured(device_mesh_1d):
+    """Unused parameters should appear on the parallel model."""
+    dim = 128
+
+    class Model(nn.Module):
+        def __init__(self, dim):
+            super().__init__()
+            self.used_linear = nn.Linear(dim, dim)
+            self.unused_linear = nn.Linear(dim, dim)
+
+        def forward(self, x):
+            return self.used_linear(x)
+
+    with torch.device("meta"):
+        model = Model(dim)
+
+    batch_size = 512
+    local_batch_size = batch_size // device_mesh_1d.size()
+    x = DTensor.from_local(
+        torch.rand(local_batch_size, dim, device="cuda"),
+        device_mesh_1d,
+        [Shard(0)],
+    )
+    parallel_mod = auto_parallel(
+        model,
+        device_mesh_1d,
+        sample_inputs=(x,),
+        out_shardings=(Shard(0),),
+        compile=False,
+    )
+
+    param_names = {name for name, _ in parallel_mod.named_parameters()}
+    assert "used_linear.weight" in param_names
+    assert "used_linear.bias" in param_names
+    assert (
+        "unused_linear.weight" in param_names
+    ), f"unused_linear.weight not found in parallel model params: {param_names}"
+    assert (
+        "unused_linear.bias" in param_names
+    ), f"unused_linear.bias not found in parallel model params: {param_names}"


### PR DESCRIPTION
Dynamo only traces parameters and buffers that are actually used in forward(), so any unused ones are silently dropped from the exported graph module. This causes them to be missing from the resulting parallel model after `aot_export_joint_with_descriptors`, which is incorrect — the parallel model should preserve all parameters and buffers from the original model.

`_add_unused_params_and_buffers` walks the original model's parameters/buffers and registers any that are missing from the graph module, inserting corresponding `get_attr` nodes so they are properly lifted into the joint graph.