### PR TITLE
Pass inductor flag through overlap_fw_bw to multiplexed graph execution

### DIFF
--- a/autoparallel/graph_passes/graph_pp_runner.py
+++ b/autoparallel/graph_passes/graph_pp_runner.py
@@ -844,6 +844,7 @@ def overlap_fw_bw(
     multiplexed_graph_callables: dict[tuple[int, int], fx.GraphModule],
     action: _Action,
     ctx: _PipelineContext,
+    inductor: bool = False,
 ) -> None:
     assert action.sub_actions is not None, "Expected sub actions for overlap callback"
     fw_action = action.sub_actions[0]
@@ -896,7 +897,11 @@ def overlap_fw_bw(
         output,
         saved_intermediates,
     ) = _run_multiplexed_fw_bw_module(
-        multiplexed_fw_bw_module, fw_stage.graph_meta, bw_stage.graph_meta, bw_fw_args
+        multiplexed_fw_bw_module,
+        fw_stage.graph_meta,
+        bw_stage.graph_meta,
+        bw_fw_args,
+        inductor=inductor,
     )
 
     bw_stage._accumulate_stage_unsharded_grads(param_buffer_grads)


### PR DESCRIPTION
Stacked PRs:
 * __->__#374


--- --- ---

Pass inductor flag through overlap_fw_bw to multiplexed graph execution

overlap_fw_bw was calling _run_multiplexed_fw_bw_module without
inductor=True, causing the multiplexed F+B graph to run through the
Python FX interpreter instead of inductor-compiled kernels. This made
OVERLAP_F_B ~3x slower than sequential F→B dispatch.

Add an inductor parameter to overlap_fw_bw and forward it to
_run_multiplexed_fw_bw_module so callers can enable inductor
compilation on the fused graph.