### PR TITLE
Fix crash in build_param_grad_linear_chains when a node in the chain has no users

### DIFF
--- a/autoparallel/shardings/ordered_sharding.py
+++ b/autoparallel/shardings/ordered_sharding.py
@@ -179,7 +179,7 @@ def build_param_grad_linear_chains(
         last_p = list(param.users)[0]
         p_chain: list[torch.fx.Node] = [param]
         # get all linear chain of users of the parameter
-        while len(last_p.all_input_nodes) == 1:
+        while len(last_p.all_input_nodes) == 1 and len(last_p.users) > 0:
             p_chain.append(last_p)
             # TODO: we need to handle the case where there are multiple users
             # maybe?

--- a/tests/test_ordered_sharding.py
+++ b/tests/test_ordered_sharding.py
@@ -286,6 +286,36 @@ class TestBuildParamGradLinearChains:
             assert param in source_to_chain
             assert param in node_to_source
 
+    def test_dead_end_node_in_chain(self):
+        """Test that a chain node with no users doesn't crash the traversal.
+
+        When a node in the chain has exactly one input (so the while loop
+        enters) but zero users, list(last_p.users.keys())[0] would raise
+        an IndexError without the len(last_p.users) > 0 guard.
+        """
+        # Build a minimal graph where param's sole user is a dead-end node
+        # (single input, no users of its own).
+        graph = torch.fx.Graph()
+        other = graph.placeholder("other")
+        param = graph.placeholder("param")
+        dead_end = graph.call_function(torch.ops.aten.t.default, (param,))
+        graph.output(other)  # neither param nor dead_end is used by output
+
+        assert len(param.users) == 1
+        assert len(dead_end.all_input_nodes) == 1
+        assert len(dead_end.users) == 0
+
+        # Should not raise an IndexError
+        node_to_source, source_to_chain = build_param_grad_linear_chains(
+            [(param, None)]
+        )
+
+        # The chain should contain only param — the dead-end node is excluded
+        # because the loop stops before appending a node with no users.
+        assert param in source_to_chain
+        chain = source_to_chain[param]
+        assert chain == [param]
+
     def test_chains_contain_only_single_input_nodes(self):
         """Test that chains only include nodes with single inputs (linear dependency)."""
         dim = 64


### PR DESCRIPTION
## Summary

- Fix an `IndexError` in `build_param_grad_linear_chains` when traversing linear chains of parameter users. The existing check at line 175-177 handles parameters with no users, but a node further down the chain could also have zero users (a dead-end). The while loop condition only checked `len(last_p.all_input_nodes) == 1`, so it would enter the loop body and crash on `list(last_p.users.keys())[0]`. Adding `len(last_p.users) > 0` to the loop condition fixes this.

## Test plan

- Reproduce with a model that has a parameter whose user chain ends in a node with no consumers (e.g., an unused intermediate op)
- Verify the chain is built up to (but not including) the dead-end node