### PR TITLE
Refactor `apply_sharding.py` for readability and testability

### DIFF
--- a/autoparallel/apply_sharding.py
+++ b/autoparallel/apply_sharding.py
@@ -93,13 +93,9 @@ class ApplyShardingInterpreter(torch.fx.Interpreter):
         self._curr_node = n
         return super().run_node(n)
 
-    def _get_input_nodes(self):
+    def _get_input_nodes(self, node):
         # node.all_input_nodes deduplicates, but we need repeated nodes preserved
-        return [
-            x
-            for x in tree_flatten(self._curr_node.args)[0]
-            if isinstance(x, torch.fx.Node)
-        ]
+        return [x for x in tree_flatten(node.args)[0] if isinstance(x, torch.fx.Node)]
 
     def _set_origin_and_target_device_order(self, node, curr_spec, tgt_spec):
         # shard_order should be automatically assigned once `placements` is set
@@ -149,7 +145,7 @@ class ApplyShardingInterpreter(torch.fx.Interpreter):
 
         new_args_0 = list(args[0])
         if isinstance(arg, torch.Tensor):
-            all_input_nodes = self._get_input_nodes()
+            all_input_nodes = self._get_input_nodes(node)
             curr_spec = self.sharding_placement[all_input_nodes[0]].output_specs[idx]
             tgt_spec = self.sharding_placement[node].input_specs[0]
             new_args_0[idx] = self.redistribute_tensor(arg, curr_spec, tgt_spec, node)
@@ -160,7 +156,7 @@ class ApplyShardingInterpreter(torch.fx.Interpreter):
 
     def _redistribute_and_adjust_args(self, target, args):
         node = self._curr_node
-        all_input_nodes = self._get_input_nodes()
+        all_input_nodes = self._get_input_nodes(node)
         num_input_nodes = len(all_input_nodes)
         curr_specs = [
             self.sharding_placement[n].output_specs for n in all_input_nodes
@@ -260,7 +256,7 @@ def shard_node_given_placements(node, sharding_placement, *, meta: bool):
     return sharded_tensor
 
 
-def shard_nodes_given_placements(gm, sharding_placement):
+def shard_placeholder_inputs(gm, sharding_placement):
     nodes = [x for x in gm.graph.find_nodes(op="placeholder")]
     sharded_tensors = []
     for node in nodes:
@@ -356,7 +352,7 @@ def _shard_params_and_buffers(gm, sharding_placement, params_spec, buffers_spec)
 
 def apply_sharding_to_model(gm, sharding_placement, params_spec, buffers_spec):
     t0 = time.perf_counter()
-    args = shard_nodes_given_placements(gm, sharding_placement)
+    args = shard_placeholder_inputs(gm, sharding_placement)
     local_args = [arg.to_local() for arg in args]
     t1 = time.perf_counter()
 

--- a/tests/test_apply_sharding.py
+++ b/tests/test_apply_sharding.py
@@ -1,0 +1,84 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+from torch.distributed.tensor._dtensor_spec import ShardOrderEntry
+from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+from autoparallel.apply_sharding import (
+    _compute_shard_order,
+    _filter_specs_for_local_map,
+)
+
+
+class TestComputeShardOrder:
+    def test_sorted_order(self):
+        shard_order = (ShardOrderEntry(tensor_dim=0, mesh_dims=(2, 0, 1)),)
+        result = _compute_shard_order(shard_order, reverse=False)
+        assert result == (ShardOrderEntry(tensor_dim=0, mesh_dims=(0, 1, 2)),)
+
+    def test_reversed_order(self):
+        shard_order = (ShardOrderEntry(tensor_dim=0, mesh_dims=(2, 0, 1)),)
+        result = _compute_shard_order(shard_order, reverse=True)
+        assert result == (ShardOrderEntry(tensor_dim=0, mesh_dims=(2, 1, 0)),)
+
+    def test_multiple_entries(self):
+        shard_order = (
+            ShardOrderEntry(tensor_dim=0, mesh_dims=(3, 1)),
+            ShardOrderEntry(tensor_dim=1, mesh_dims=(2, 0)),
+        )
+        result = _compute_shard_order(shard_order, reverse=False)
+        assert result == (
+            ShardOrderEntry(tensor_dim=0, mesh_dims=(1, 3)),
+            ShardOrderEntry(tensor_dim=1, mesh_dims=(0, 2)),
+        )
+
+    def test_already_sorted_is_idempotent(self):
+        shard_order = (ShardOrderEntry(tensor_dim=0, mesh_dims=(0, 1, 2)),)
+        result = _compute_shard_order(shard_order, reverse=False)
+        assert result == shard_order
+
+    def test_empty(self):
+        assert _compute_shard_order((), reverse=False) == ()
+        assert _compute_shard_order((), reverse=True) == ()
+
+
+def _make_symint(val: int) -> torch.SymInt:
+    shape_env = ShapeEnv()
+    from torch._dynamo.source import ConstantSource
+
+    sym = shape_env.create_symbol(val, source=ConstantSource(source_name=f"s{val}"))
+    return shape_env.create_symintnode(sym, hint=val)
+
+
+class TestFilterSpecsForLocalMap:
+    def test_tensors_only(self):
+        flat_args = [torch.tensor(1.0), torch.tensor(2.0)]
+        curr_specs = ["spec_a", "spec_b"]
+        tgt_specs = ["spec_c", "spec_d"]
+        c, t = _filter_specs_for_local_map(flat_args, curr_specs, tgt_specs)
+        assert c == ["spec_a", "spec_b"]
+        assert t == ["spec_c", "spec_d"]
+
+    def test_mixed_tensor_and_symint(self):
+        s = _make_symint(3)
+        flat_args = [torch.tensor(1.0), s, torch.tensor(2.0)]
+        curr_specs = ["spec_a", None, "spec_b"]
+        tgt_specs = ["spec_c", None, "spec_d"]
+        c, t = _filter_specs_for_local_map(flat_args, curr_specs, tgt_specs)
+        assert c == ["spec_a", "spec_b"]
+        assert t == ["spec_c", "spec_d"]
+
+    def test_symint_with_non_none_spec_raises(self):
+        s = _make_symint(3)
+        flat_args = [s]
+        with pytest.raises(AssertionError):
+            _filter_specs_for_local_map(flat_args, ["spec_a"], ["spec_b"])
+
+    def test_unexpected_type_raises(self):
+        flat_args = [42]
+        with pytest.raises(ValueError, match="Unexpected local_map HOP argument"):
+            _filter_specs_for_local_map(flat_args, [None], [None])


### PR DESCRIPTION
Refactor `apply_sharding.py` to improve maintainability without changing behavior:

- Extract top-level pure functions (`_compute_shard_order`, `_filter_specs_for_local_map`) from interpreter methods
- Extract `_lower_to_parallel_graph`, `_copy_descriptors_and_rename_placeholders`, and `_shard_params_and_buffers` from the monolithic `apply_sharding_to_model`
- Replace `self.tgt_spec` side-effect with explicit return values from `_call_getitem` / `_redistribute_and_adjust_args`
- Turn `_ENABLE_ORDERED_SHARDING_OPTIMIZATION` global into a constructor parameter
- Rename `shard_nodes_given_placements → shard_placeholder_inputs` to reflect that it operates on placeholder nodes
- Add unit tests for `_compute_shard_order` and `_filter_specs_for_local_map`

Authored with Claude.