### PR TITLE
Split single-GPU CI into separate test and examples jobs

### DIFF
--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -32,6 +32,26 @@ jobs:
         pip install --no-input --quiet --pre torch --index-url https://download.pytorch.org/whl/nightly/cu126
         pip install --quiet .
         pytest tests
+
+  examples-cuda-single-gpu:
+    name: Examples CUDA Single GPU (cuda12.6-py3.12)
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      timeout: 60
+      runner: linux.g5.4xlarge.nvidia.gpu
+      gpu-arch-type: cuda
+      gpu-arch-version: "12.6"
+      submodules: recursive
+      script: |
+        conda create --yes --quiet --name py312 python=3.12
+        source $(conda info --base)/etc/profile.d/conda.sh
+        conda activate py312
+
+        pip install --quiet -r requirements-test.txt
+        # For some reason the spec above isnt working
+        pip uninstall -y torch
+        pip install --no-input --quiet --pre torch --index-url https://download.pytorch.org/whl/nightly/cu126
+        pip install --quiet .
         python examples/example_autoparallel.py
         python examples/example_llama3.py
         python examples/example_local_map.py


### PR DESCRIPTION
## Summary
- The single-GPU CI job was running both `pytest tests` and the example scripts in one step, making it hard to attribute time and failures. Split them into two parallel jobs so they run concurrently and report independently.

## Test plan
- CI should now show three jobs: tests (single-GPU), examples (single-GPU), and multi-GPU.

Authored with Claude.