### PR TITLE
Fix duplicate node in region group during graph clustering

### DIFF
--- a/autoparallel/graph_passes/graph_clustering.py
+++ b/autoparallel/graph_passes/graph_clustering.py
@@ -172,8 +172,10 @@ def get_identical_regions(
         # NOTE: this seems like it's missing in the original implementation
         # from PyTorch. Given that fully_expand_region_group doesn't check
         # if the root from a region is in a seen node, it might end up
-        # having duplicate nodes in different clusters
-        if region_group[0][0] in seen_nodes:
+        # having duplicate nodes in different clusters. We must check all
+        # regions' root nodes, because any region's root could have been
+        # claimed by a prior group.
+        if any(region[0] in seen_nodes for region in region_group):
             continue
         fully_expand_region_group(
             region_group,


### PR DESCRIPTION
Before expanding a region group, check that none of its region's root nodes have already been claimed -- not just the first region's.

GPT-J from HF triggers this because it has a parallel architecture where attention and MLP run in parallel off the same LayerNorm. This means structurally identical ops from both paths can end up mixed in a single region group. A prior group can claim ops from one path without claiming the other, so the first root may be unseen, but a later root is seen.

Testing: EleutherAI/gpt-j-6b with mesh 8 passes now

<!-- ps-id: b6d5e42a-22b2-4682-a5ea-0ab654824b43 -->