### PR TITLE
Use DeviceMesh context manager to set global mesh in AutoParallel 

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -272,6 +272,8 @@ class AutoParallel:
             else:
                 set_nccl_topo_config(None)
 
+            self.stack.enter_context(self.mesh)
+
             self.build_model_graph()
             self.old_inductor_comprehensive_padding = (
                 torch._inductor.config.comprehensive_padding

--- a/autoparallel/collectives.py
+++ b/autoparallel/collectives.py
@@ -8,27 +8,20 @@ from typing import Any, Optional
 import torch
 import torch.distributed.distributed_c10d as c10d
 from torch.distributed._tensor.experimental import local_map as _local_map
+from torch.distributed.device_mesh import _mesh_resources
 from torch.distributed.distributed_c10d import GroupName
-
-_local_map_device_mesh = None
 
 
 def local_map(*args, **kwargs):
-    # TODO: ideally after we get out of the local map region we should
-    # just reset the global device mesh to None. For now we just keep it
-    # around.
-    global _local_map_device_mesh
-    _local_map_device_mesh = kwargs.get("device_mesh", None)
+    # TODO: upstream this fallback into PyTorch's local_map, matching
+    # DTensor.from_local and distribute_tensor which already do this.
+    if kwargs.get("device_mesh", None) is None:
+        kwargs["device_mesh"] = _mesh_resources.get_current_mesh()
     return _local_map(*args, **kwargs)
 
 
 def get_mesh_from_global():
-    global _local_map_device_mesh
-    if _local_map_device_mesh is None:
-        raise RuntimeError(
-            "No mesh found, make sure to call this collective in a local_map region"
-        )
-    return _local_map_device_mesh
+    return _mesh_resources.get_current_mesh()
 
 
 def _get_group_name_from_axis_name(mesh_name):

--- a/tests/test_activation_checkpointing.py
+++ b/tests/test_activation_checkpointing.py
@@ -108,6 +108,7 @@ def _build_joint_graph(model, input_fn, mesh):
     sharding optimizer."""
     autop = AutoParallel(model, input_fn, mesh)
     try:
+        autop.stack.enter_context(mesh)
         autop.build_model_graph()
         return autop.gm
     finally:
@@ -424,11 +425,11 @@ def test_ac_joint_pass_stages_recomputation(device_mesh_1d):
 # ---------------------------------------------------------------------------
 
 
-def _make_local_map_block(mesh):
+def _make_local_map_block():
     """Build a Block class that uses local_map-wrapped ops inside a
-    checkpoint region.  The local_map decorators capture `mesh`, so the
-    class factory must receive the mesh at definition time."""
-    from torch.distributed._tensor.experimental import local_map
+    checkpoint region.  The local_map decorators pick up the mesh from
+    the global DeviceMesh context set by AutoParallel."""
+    from autoparallel.collectives import local_map
 
     def policy_fn(ctx, op, *args, **kwargs):
         if (
@@ -448,7 +449,6 @@ def _make_local_map_block(mesh):
         ),
         redistribute_inputs=True,
         in_grad_placements=None,
-        device_mesh=mesh,
     )
     def replicate_linear(w, x):
         with fx_traceback.annotate({"inside_local_map": 1}):
@@ -459,7 +459,6 @@ def _make_local_map_block(mesh):
         in_placements=((Shard(0), Shard(0), Replicate()),),
         redistribute_inputs=True,
         in_grad_placements=None,
-        device_mesh=mesh,
     )
     def sharded_pointwise(x):
         with fx_traceback.annotate({"inside_local_map": 0}):
@@ -474,7 +473,6 @@ def _make_local_map_block(mesh):
         ),
         redistribute_inputs=True,
         in_grad_placements=None,
-        device_mesh=mesh,
     )
     def context_parallel_attention(query, key, value):
         with fx_traceback.annotate({"inside_local_map": 2}):
@@ -529,7 +527,7 @@ def test_local_map_ac_recompute_tags(device_mesh_3d):
     """Recompute tags from user checkpoint policy survive graph capture
     when local_map ops are used inside the checkpointed function."""
     mesh = device_mesh_3d
-    Block, policy_fn = _make_local_map_block(mesh)
+    Block, policy_fn = _make_local_map_block()
 
     nheads, dim, ffn_dim = 8, 128, 512
     bs = 8 * mesh.shape[0]
@@ -557,7 +555,7 @@ def test_local_map_ac_seq_nr_consistency(device_mesh_3d):
     """seq_nr consistency holds when local_map ops are used inside a
     checkpoint region."""
     mesh = device_mesh_3d
-    Block, _ = _make_local_map_block(mesh)
+    Block, _ = _make_local_map_block()
 
     nheads, dim, ffn_dim = 8, 128, 512
     bs = 8 * mesh.shape[0]
@@ -589,7 +587,7 @@ def test_local_map_custom_metadata_propagation(device_mesh_3d):
     """Custom fx_traceback annotations propagate through local_map + checkpoint
     onto the parallel graph."""
     mesh = device_mesh_3d
-    Block, _ = _make_local_map_block(mesh)
+    Block, _ = _make_local_map_block()
 
     nheads, dim, ffn_dim = 8, 128, 512
     bs = 8 * mesh.shape[0]

--- a/tests/test_activation_checkpointing.py
+++ b/tests/test_activation_checkpointing.py
@@ -108,7 +108,6 @@ def _build_joint_graph(model, input_fn, mesh):
     sharding optimizer."""
     autop = AutoParallel(model, input_fn, mesh)
     try:
-        autop.stack.enter_context(mesh)
         autop.build_model_graph()
         return autop.gm
     finally:
@@ -425,11 +424,11 @@ def test_ac_joint_pass_stages_recomputation(device_mesh_1d):
 # ---------------------------------------------------------------------------
 
 
-def _make_local_map_block():
+def _make_local_map_block(mesh):
     """Build a Block class that uses local_map-wrapped ops inside a
-    checkpoint region.  The local_map decorators pick up the mesh from
-    the global DeviceMesh context set by AutoParallel."""
-    from autoparallel.collectives import local_map
+    checkpoint region.  The local_map decorators capture `mesh`, so the
+    class factory must receive the mesh at definition time."""
+    from torch.distributed._tensor.experimental import local_map
 
     def policy_fn(ctx, op, *args, **kwargs):
         if (
@@ -449,6 +448,7 @@ def _make_local_map_block():
         ),
         redistribute_inputs=True,
         in_grad_placements=None,
+        device_mesh=mesh,
     )
     def replicate_linear(w, x):
         with fx_traceback.annotate({"inside_local_map": 1}):
@@ -459,6 +459,7 @@ def _make_local_map_block():
         in_placements=((Shard(0), Shard(0), Replicate()),),
         redistribute_inputs=True,
         in_grad_placements=None,
+        device_mesh=mesh,
     )
     def sharded_pointwise(x):
         with fx_traceback.annotate({"inside_local_map": 0}):
@@ -473,6 +474,7 @@ def _make_local_map_block():
         ),
         redistribute_inputs=True,
         in_grad_placements=None,
+        device_mesh=mesh,
     )
     def context_parallel_attention(query, key, value):
         with fx_traceback.annotate({"inside_local_map": 2}):
@@ -527,7 +529,7 @@ def test_local_map_ac_recompute_tags(device_mesh_3d):
     """Recompute tags from user checkpoint policy survive graph capture
     when local_map ops are used inside the checkpointed function."""
     mesh = device_mesh_3d
-    Block, policy_fn = _make_local_map_block()
+    Block, policy_fn = _make_local_map_block(mesh)
 
     nheads, dim, ffn_dim = 8, 128, 512
     bs = 8 * mesh.shape[0]
@@ -555,7 +557,7 @@ def test_local_map_ac_seq_nr_consistency(device_mesh_3d):
     """seq_nr consistency holds when local_map ops are used inside a
     checkpoint region."""
     mesh = device_mesh_3d
-    Block, _ = _make_local_map_block()
+    Block, _ = _make_local_map_block(mesh)
 
     nheads, dim, ffn_dim = 8, 128, 512
     bs = 8 * mesh.shape[0]
@@ -587,7 +589,7 @@ def test_local_map_custom_metadata_propagation(device_mesh_3d):
     """Custom fx_traceback annotations propagate through local_map + checkpoint
     onto the parallel graph."""
     mesh = device_mesh_3d
-    Block, _ = _make_local_map_block()
+    Block, _ = _make_local_map_block(mesh)
 
     nheads, dim, ffn_dim = 8, 128, 512
     bs = 8 * mesh.shape[0]

--- a/tests/test_optimize_placement.py
+++ b/tests/test_optimize_placement.py
@@ -10,11 +10,11 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 from torch._functorch._aot_autograd.fx_utils import get_param_nodes
-from torch.distributed._tensor.experimental import local_map
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import Partial, Replicate, Shard
 
 from autoparallel.api import AutoParallel, auto_parallel
+from autoparallel.collectives import local_map
 
 
 class FFN(nn.Module):
@@ -333,7 +333,7 @@ def test_in_graph_tensor_ctor(device_mesh_1d):
 
 
 class LocalMapTransformerBlock(nn.Module):
-    def __init__(self, nheads, dim1, dim2, mesh):
+    def __init__(self, nheads, dim1, dim2):
         super().__init__()
         self.nheads = nheads
         bias = False
@@ -343,7 +343,6 @@ class LocalMapTransformerBlock(nn.Module):
         self.wo = nn.Linear(dim1, dim1, bias=bias)
         self.w1 = nn.Linear(dim1, dim2, bias=bias)
         self.w2 = nn.Linear(dim2, dim1, bias=bias)
-        self.mesh = mesh
 
     def forward(self, x):
         @local_map(
@@ -355,7 +354,6 @@ class LocalMapTransformerBlock(nn.Module):
             ),
             redistribute_inputs=True,
             in_grad_placements=None,
-            device_mesh=self.mesh,
         )
         def _context_parallel_attention(query, key, value):
             out = F.scaled_dot_product_attention(
@@ -396,7 +394,7 @@ def test_local_map_placement_respected(device_mesh_2d, device="cuda"):
     seq_len = 256
 
     def model_fn():
-        return LocalMapTransformerBlock(nheads, dim1, dim2, device_mesh_2d)
+        return LocalMapTransformerBlock(nheads, dim1, dim2)
 
     def input_fn():
         return torch.randn(bs, seq_len, dim1, device=device, requires_grad=True)


### PR DESCRIPTION
Instead of requiring users to thread `device_mesh` through every `local_map` call, we now push the `DeviceMesh` onto PyTorch's built-in context stack when entering AutoParallel. Internal code (collectives, axis_size, etc.) resolves the mesh from `_mesh_resources.get_current_mesh()`, replacing the hand-rolled global that was previously set as a side-effect of local_map.

The `local_map` wrapper in `collectives.py` now injects the mesh from the context when `device_mesh` is not passed explicitly — this is needed because AutoParallel operates on plain tensors, not DTensors, so PyTorch's local_map can't infer the mesh from the inputs. This fallback should be upstreamed into PyTorch to match `DTensor.from_local` and `distribute_tensor`.

This will also make the `with_sharding_constraint` implementation from #297 more natural

Authored with Claude.