### PR TITLE
Deprecate compile, enable_ac, and numerics_logger from AutoParallel API

### DIFF
--- a/autoparallel/__init__.py
+++ b/autoparallel/__init__.py
@@ -6,10 +6,12 @@
 from autoparallel.api import AutoParallel, auto_parallel
 from autoparallel.api_pp import AutoParallelPP
 from autoparallel.collectives import with_sharding_constraint
+from autoparallel.compile import autoparallel_backend
 
 __all__ = [
     "auto_parallel",
     "AutoParallel",
     "AutoParallelPP",
+    "autoparallel_backend",
     "with_sharding_constraint",
 ]

--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import copy
-import functools
 import logging
 import time
 from contextlib import ExitStack, contextmanager
@@ -17,7 +16,6 @@ from torch._functorch.aot_autograd import (
     aot_compile_joint_with_descriptors,
     aot_export_joint_with_descriptors,
 )
-from torch._inductor.compile_fx import compile_fx_inner
 from torch._logging import trace_structured
 from torch._subclasses import FakeTensorMode
 from torch.distributed.fsdp import MixedPrecisionPolicy
@@ -27,10 +25,7 @@ from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
 from .apply_sharding import apply_sharding_to_model
 from .cast_parametrization import apply_dtype_cast, canonicalize_mp, set_dtype_cast
-from .graph_passes.activation_checkpointing import (
-    ac_joint_pass,
-    mark_fsdp_all_gather_recomputation,
-)
+from .graph_passes.activation_checkpointing import mark_fsdp_all_gather_recomputation
 from .graph_passes.graph_utils import (
     _add_alias,
     _replace_view_mm_view_with_einsum,
@@ -48,11 +43,7 @@ from .input_validation import (
 )
 from .module_construction import make_parallel_module
 from .optimize_sharding import ShardingOptimizer
-from .shardings.placement_options import (
-    NumericsLogger,
-    _get_device_from_mesh,
-    debug_boxed_nop_preserve_node_meta,
-)
+from .shardings.placement_options import _get_device_from_mesh
 from .tracing import (
     _add_unused_params_and_buffers,
     _get_decomp_table,
@@ -66,28 +57,6 @@ logger = logging.getLogger(__name__)
 
 
 def _boxed_nop_preserve_node_meta(fx_g, example_inputs):
-    if torch._inductor.config.aten_distributed_optimizations.enable_overlap_scheduling:
-        from torch._inductor.fx_passes.overlap_scheduling import (
-            schedule_overlap_bucketing_from_inductor_configs,
-        )
-
-        # disable flags which are inductor-specific
-        with torch._inductor.config.patch(
-            {
-                "aten_distributed_optimizations.insert_overlap_deps": False,
-                "aten_distributed_optimizations.enable_fusion_regions": False,
-            }
-        ):
-            schedule_overlap_bucketing_from_inductor_configs(fx_g)
-
-    # Replace aten.view with aten.reshape for eager execution. Graph passes
-    # (sharding redistributions, collective bucketing) can produce non-contiguous
-    # tensors that break aten.view's contiguity requirement. Inductor handles this
-    # in compile_fx; we need to do it here for the compile=False path.
-    from torch._inductor.fx_passes.post_grad import view_to_reshape
-
-    view_to_reshape(fx_g)
-
     def run(args):
         with torch.fx.traceback.preserve_node_meta():
             return torch.fx.Interpreter(fx_g).boxed_run(args)
@@ -172,9 +141,11 @@ def build_joint_graph(
 
     traced_inputs = list(formatted_inputs)
 
-    with set_dtype_cast(
-        True
-    ), enable_local_map_wrapping(), torch._dynamo.utils._disable_saved_tensors_hooks_during_tracing():
+    with (
+        set_dtype_cast(True),
+        enable_local_map_wrapping(),
+        torch._dynamo.utils._disable_saved_tensors_hooks_during_tracing(),
+    ):
         torch_ir_with_fqn = _dynamo_graph_capture_for_export(model)(*formatted_inputs)
         _restore_state_dict(model, torch_ir_with_fqn)
         _add_unused_params_and_buffers(model, torch_ir_with_fqn)
@@ -227,13 +198,8 @@ class AutoParallel:
         input_fn,
         mesh: DeviceMesh,
         mp_policy: Optional[MixedPrecisionPolicy] = None,
-        compile: bool = False,
-        enable_ac: bool = True,
-        # None means 'auto'
-        ac_stage_size_in_GiB: Optional[Union[float, str]] = "auto",
         reshard_after_forward: bool = True,
         dynamic: bool = False,
-        numerics_logger: NumericsLogger | None = None,
         cost_model: Any = "nccl",
         repeated_subgraphs: bool = True,
     ):
@@ -258,16 +224,7 @@ class AutoParallel:
         self.model = move_to_fake(model, self.fake_mode, device)
         self.input_fn = input_fn
         self.mesh = mesh
-        if compile:
-            self.compiler_fn = compile_fx_inner
-        elif numerics_logger:
-            self.compiler_fn = functools.partial(
-                debug_boxed_nop_preserve_node_meta, numerics_logger=numerics_logger
-            )
-        else:
-            self.compiler_fn = _boxed_nop_preserve_node_meta  # type: ignore[assignment]
-        self.enable_ac = enable_ac
-        self.ac_stage_size_in_GiB = ac_stage_size_in_GiB
+        self.compiler_fn = _boxed_nop_preserve_node_meta  # type: ignore[assignment]
         self.reshard_after_forward = reshard_after_forward
 
         if dynamic:
@@ -483,11 +440,16 @@ class AutoParallel:
         )
         t_trace = time.perf_counter()
 
+        # Replace aten.view with aten.reshape unconditionally. Graph passes
+        # (sharding redistributions, collective bucketing) can produce
+        # non-contiguous tensors that break aten.view's contiguity requirement.
+        from torch._inductor.fx_passes.post_grad import view_to_reshape
+
+        view_to_reshape(parallel_gm)
+
         mark_fsdp_all_gather_recomputation(
             parallel_gm.graph, self.reshard_after_forward
         )
-        if self.enable_ac:
-            ac_joint_pass(parallel_gm.graph, self.ac_stage_size_in_GiB)
         t_ac = time.perf_counter()
         # now rename input/param/tangent/output/grad_param/grad_input nodes following
         # our convention
@@ -633,7 +595,6 @@ def auto_parallel(
     out_shardings: Any,
     *,
     mp_policy: Optional[MixedPrecisionPolicy] = None,
-    compile: bool = True,
     parameter_memory_budget: Optional[tuple[Optional[float], Optional[float]]] = None,
     dynamic: bool = False,
 ) -> torch.nn.Module:
@@ -642,6 +603,10 @@ def auto_parallel(
 
     This is a simplified API that wraps the full AutoParallel context manager.
     For more control, use the AutoParallel class directly.
+
+    The returned module runs eagerly. For compiled execution, use
+    ``torch.compile(module, backend=autoparallel_backend())`` to compile with
+    AP-optimized Inductor passes (activation checkpointing, overlap scheduling).
 
     Args:
         model: Model to parallelize. Can be on meta device for large models.
@@ -659,7 +624,6 @@ def auto_parallel(
                 - Tuple output: ((Shard(0),), (Shard(0),))
                 - Dict output: {"logits": (Shard(0),), "loss": (Replicate(),)}
         mp_policy: Optional mixed precision policy.
-        compile: Whether to use torch.compile (default: True).
         parameter_memory_budget: Optional (low, high) bounds for parameter memory.
             Each bound is a float multiplier or None for unbounded.
         dynamic: If True, trace with symbolic batch dimensions so the parallel
@@ -716,9 +680,6 @@ def auto_parallel(
         input_fn,
         mesh,
         mp_policy=mp_policy,
-        compile=compile,
-        # enable_ac=True,
-        enable_ac=False,
         dynamic=dynamic,
     ) as autop:
         # Add constraints

--- a/autoparallel/compile.py
+++ b/autoparallel/compile.py
@@ -1,0 +1,71 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional, Union
+
+import torch
+import torch._functorch.config
+import torch._inductor.config
+from torch._inductor.compile_fx import compile_fx
+
+from .graph_passes.activation_checkpointing import ac_joint_pass
+
+
+def _make_ac_joint_pass(
+    ac_stage_size_in_GiB: Optional[Union[float, str]] = "auto",
+):
+    def joint_pass(fx_g, joint_inputs):
+        ac_joint_pass(fx_g.graph, ac_stage_size_in_GiB)
+        return fx_g
+
+    return joint_pass
+
+
+def autoparallel_backend(
+    *,
+    enable_ac: bool = True,
+    ac_stage_size_in_GiB: Optional[Union[float, str]] = "auto",
+    overlap_scheduling: bool = True,
+):
+    """Return a torch.compile backend that wraps Inductor with AutoParallel-optimized
+    passes (activation checkpointing, comm/compute overlap scheduling).
+
+    Usage::
+
+        parallel_module = AutoParallel(...)
+        compiled = torch.compile(parallel_module, backend=autoparallel_backend())
+
+    Args:
+        enable_ac: Enable activation checkpointing joint pass.
+        ac_stage_size_in_GiB: Memory budget per AC stage. "auto" uses
+            sqrt(total_recomputable_memory).
+        overlap_scheduling: Enable comm/compute overlap scheduling.
+    """
+    functorch_patches = {}
+    inductor_patches = {}
+
+    if enable_ac:
+        functorch_patches["joint_custom_pass"] = _make_ac_joint_pass(
+            ac_stage_size_in_GiB
+        )
+
+    if overlap_scheduling:
+        inductor_patches.update(
+            {
+                "aten_distributed_optimizations.enable_overlap_scheduling": True,
+                "aten_distributed_optimizations.collective_bucketing": True,
+                "aten_distributed_optimizations.insert_overlap_deps": True,
+                "aten_distributed_optimizations.max_compute_pre_fetch": 10,
+            }
+        )
+
+    def backend(gm, example_inputs):
+        with (
+            torch._functorch.config.patch(functorch_patches),
+            torch._inductor.config.patch(inductor_patches),
+        ):
+            return compile_fx(gm, example_inputs)
+
+    return backend

--- a/examples/example_autoparallel.py
+++ b/examples/example_autoparallel.py
@@ -15,6 +15,7 @@ from torch.testing._internal.distributed.fake_pg import FakeStore
 from torch.utils.checkpoint import create_selective_checkpoint_contexts
 
 from autoparallel.api import AutoParallel
+from autoparallel.compile import autoparallel_backend
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -122,7 +123,7 @@ with torch.device("meta"):
 mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16, reduce_dtype=torch.float32)
 # mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16)
 
-with AutoParallel(model, input_fn, mesh, mp_policy, compile=True) as autop:
+with AutoParallel(model, input_fn, mesh, mp_policy) as autop:
     autop.add_parameter_memory_constraint(low=None, high=None)
 
     x_sharding = (Shard(0),) + (Replicate(),) * (mesh.ndim - 1)
@@ -137,6 +138,11 @@ with AutoParallel(model, input_fn, mesh, mp_policy, compile=True) as autop:
 
 parallel_mod.to_empty(device="cuda")
 parallel_mod.init_weights()
+
+# Compile with AutoParallel-optimized Inductor passes
+parallel_mod = torch.compile(
+    parallel_mod, backend=autoparallel_backend(enable_ac=False)
+)
 
 # now let's run it
 x = (torch.rand(bs // mesh.shape[0], seq_len, dim1, device="cuda"),)

--- a/examples/example_dcp.py
+++ b/examples/example_dcp.py
@@ -24,6 +24,7 @@ from torch.distributed.tensor.placement_types import Replicate, Shard
 from torch.testing._internal.distributed.fake_pg import FakeStore
 
 from autoparallel.api import AutoParallel
+from autoparallel.compile import autoparallel_backend
 
 
 def master_print(*args, **kwargs):
@@ -122,7 +123,7 @@ def prepare_autoparallel_model(fake_world_size):
             print(f"global input shape: {(bs, seq_len, dim1)}")
             return torch.rand(bs, seq_len, dim1, device="cuda")
 
-        with AutoParallel(model, input_fn, mesh, mp_policy, compile=True) as autop:
+        with AutoParallel(model, input_fn, mesh, mp_policy) as autop:
             assert any(n.meta.get("nn_module_stack") for n in autop.gm.graph.nodes)
             assert any(n.meta.get("fwd_nn_module_stack") for n in autop.gm.graph.nodes)
             autop.add_parameter_memory_constraint(low=None, high=None)
@@ -181,7 +182,7 @@ def multiple_process_run(rank, world_size, tmp_dir, model, sharding_map):
             param.data.zero_()
         new_optimizer = torch.optim.Adam(new_model.parameters())
 
-        with AutoParallel(model, input_fn, mesh, mp_policy, compile=True) as autop:
+        with AutoParallel(model, input_fn, mesh, mp_policy) as autop:
             assert any(n.meta.get("nn_module_stack") for n in autop.gm.graph.nodes)
             assert any(n.meta.get("fwd_nn_module_stack") for n in autop.gm.graph.nodes)
             autop.add_parameter_memory_constraint(low=None, high=None)
@@ -229,6 +230,8 @@ def multiple_process_run(rank, world_size, tmp_dir, model, sharding_map):
 
         parallel_mod.to_empty(device="cuda")
         parallel_mod.init_weights()
+
+        parallel_mod = torch.compile(parallel_mod, backend=autoparallel_backend())
 
         # Use smaller learning rate and gradient clipping for numerical stability
         optimizer = torch.optim.Adam(parallel_mod.parameters(), lr=2e-5)

--- a/examples/example_ds3_local_map.py
+++ b/examples/example_ds3_local_map.py
@@ -137,9 +137,7 @@ def run_test(fake_evaluate: bool, rng_seed: Optional[int], logs_dir: str):
     numerics_logger = None
     if rng_seed is not None:
         numerics_logger = NumericsLogger(logs_dir)
-    with AutoParallel(
-        model, input_fn, mesh, dynamic=True, numerics_logger=None
-    ) as autop:
+    with AutoParallel(model, input_fn, mesh, dynamic=True) as autop:
         autop.add_parameter_memory_constraint(low=None, high=None)
 
         # x_sharding = (Shard(0), Replicate())

--- a/examples/example_ds3_pp.py
+++ b/examples/example_ds3_pp.py
@@ -478,7 +478,6 @@ def run_test(
                 input_fn,
                 mesh,
                 dynamic=True,
-                compile=False,
                 reshard_after_forward=False,
             ) as autop:
                 autop.add_parameter_memory_constraint(low=None, high=None)

--- a/examples/example_hf.py
+++ b/examples/example_hf.py
@@ -37,6 +37,7 @@ from transformers import (
 )
 
 from autoparallel.api import AutoParallel
+from autoparallel.compile import autoparallel_backend
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -164,7 +165,7 @@ def main():
         input_constraints = [x_sharding]
 
     with AutoParallel(
-        model, input_fn, mesh, mp_policy, compile=True, repeated_subgraphs=True
+        model, input_fn, mesh, mp_policy, repeated_subgraphs=True
     ) as autop:
         autop.add_input_constraints(input_constraints)
         autop.add_parameter_memory_constraint(low=None, high=None)
@@ -173,6 +174,9 @@ def main():
         parallel_mod = autop.apply_placement(sharding_placement)
 
     print(f"\nAutoParallel pipeline completed in {time.time() - t0:.2f}s")
+
+    # --- Compile with AutoParallel-optimized Inductor passes ---
+    parallel_mod = torch.compile(parallel_mod, backend=autoparallel_backend())
 
     # --- Forward + backward ---
     parallel_mod.to_empty(device="cuda")

--- a/examples/example_llama3.py
+++ b/examples/example_llama3.py
@@ -14,6 +14,7 @@ from torch.testing._internal.distributed.fake_pg import FakeStore
 
 from autoparallel._testing.models.llama3 import Transformer, TransformerModelArgs
 from autoparallel.api import AutoParallel
+from autoparallel.compile import autoparallel_backend
 from autoparallel.graph_passes.auto_bucketing import (
     aten_autobucketing_config,
     aten_autobucketing_reordering_pass,
@@ -216,9 +217,7 @@ def add_tp_constraints(autop):
 
 
 # parallelize the model
-with AutoParallel(
-    model, input_fn, mesh, mp_policy, compile=True, repeated_subgraphs=True
-) as autop:
+with AutoParallel(model, input_fn, mesh, mp_policy, repeated_subgraphs=True) as autop:
     autop.add_parameter_memory_constraint(low=None, high=None)
 
     x_sharding = (Shard(0),) + (Replicate(),) * (mesh.ndim - 1)
@@ -262,6 +261,9 @@ with AutoParallel(
 # run weight init on our sharded DTensor params
 parallel_mod.to_empty(device="cuda")
 parallel_mod.init_weights()
+
+# Compile with AutoParallel-optimized Inductor passes
+parallel_mod = torch.compile(parallel_mod, backend=autoparallel_backend())
 
 # now let's run it
 x = (

--- a/examples/example_local_map.py
+++ b/examples/example_local_map.py
@@ -15,6 +15,7 @@ from torch.testing._internal.distributed.fake_pg import FakeStore
 from torch.utils.checkpoint import create_selective_checkpoint_contexts
 
 from autoparallel.api import AutoParallel
+from autoparallel.compile import autoparallel_backend
 
 world_size = 256
 
@@ -166,9 +167,10 @@ with torch.device("meta"):
 mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16)
 # mp_policy = None
 
-with torch.fx.traceback.preserve_node_meta(), AutoParallel(
-    model, input_fn, mesh, mp_policy, compile=True
-) as autop:
+with (
+    torch.fx.traceback.preserve_node_meta(),
+    AutoParallel(model, input_fn, mesh, mp_policy) as autop,
+):
     autop.add_parameter_memory_constraint(low=None, high=None)
 
     x_sharding = (Shard(0),) + (Replicate(),) * (mesh.ndim - 1)
@@ -183,6 +185,9 @@ with torch.fx.traceback.preserve_node_meta(), AutoParallel(
 
 parallel_mod.to_empty(device="cuda")
 parallel_mod.init_weights()
+
+# Compile with AutoParallel-optimized Inductor passes
+parallel_mod = torch.compile(parallel_mod, backend=autoparallel_backend())
 
 # now let's run it
 x = (torch.rand(bs // mesh.shape[0], seq_len, dim1, device="cuda"),)

--- a/examples/example_pp_graph_passes.py
+++ b/examples/example_pp_graph_passes.py
@@ -269,7 +269,6 @@ def run_all_graph_pass_tests(
         tracing_input_fn,
         mesh,
         dynamic=True,
-        compile=False,
         reshard_after_forward=False,
     ) as autop:
         autop.add_parameter_memory_constraint(low=None, high=None)

--- a/examples/native_ds3/example_deepseek.py
+++ b/examples/native_ds3/example_deepseek.py
@@ -350,6 +350,7 @@ if __name__ == "__main__":
     from torch.testing._internal.distributed.fake_pg import FakeStore
 
     from autoparallel.api import AutoParallel
+    from autoparallel.compile import autoparallel_backend
 
     # Model configuration
     world_size = 256
@@ -404,7 +405,7 @@ if __name__ == "__main__":
         param_dtype=torch.bfloat16, reduce_dtype=torch.float32
     )
 
-    with AutoParallel(model, input_fn, mesh, mp_policy, compile=True) as autop:
+    with AutoParallel(model, input_fn, mesh, mp_policy) as autop:
         assert any(n.meta.get("nn_module_stack") for n in autop.gm.graph.nodes)
         assert any(n.meta.get("fwd_nn_module_stack") for n in autop.gm.graph.nodes)
         autop.add_parameter_memory_constraint(low=None, high=None)
@@ -423,6 +424,9 @@ if __name__ == "__main__":
 
     parallel_mod.to_empty(device="cuda")
     parallel_mod.init_weights(init_std=0.02, buffer_device="cuda")
+
+    # Compile with AutoParallel-optimized Inductor passes
+    parallel_mod = torch.compile(parallel_mod, backend=autoparallel_backend())
 
     # now let's run it
     x = (torch.rand(bs // mesh.shape[0], 1, seq_len, dim, device="cuda"),)

--- a/tests/test_activation_checkpointing.py
+++ b/tests/test_activation_checkpointing.py
@@ -281,8 +281,8 @@ def test_user_ac_policy_fn_applied_to_getitem(device_mesh_1d):
 
 
 def _build_parallel_graph(model_cls, mesh, *, context_fn=None):
-    """Run the full AutoParallel pipeline (with enable_ac=False) and return
-    the parallel graph for ac_joint_pass testing."""
+    """Run the full AutoParallel pipeline and return the parallel graph for
+    ac_joint_pass testing."""
     nheads, dim, ffn_dim = 8, 128, 512
     bs = 8 * mesh.shape[0]
     seq_len = 32
@@ -296,7 +296,7 @@ def _build_parallel_graph(model_cls, mesh, *, context_fn=None):
         else:
             model = model_cls(nheads, dim, ffn_dim)
 
-    with AutoParallel(model, input_fn, mesh, enable_ac=False) as autop:
+    with AutoParallel(model, input_fn, mesh) as autop:
         x_sharding = (Shard(0),)
         autop.add_input_constraints([x_sharding])
         autop.add_output_constraints([x_sharding])
@@ -322,11 +322,20 @@ def test_ac_joint_pass_marks_recomputable_nodes(device_mesh_1d):
         if _has_tag_is_backward(n):
             continue
         recompute = n.meta.get("recompute")
-        if recompute is not None:
-            assert recompute in (
-                CheckpointPolicy.PREFER_RECOMPUTE,
-                CheckpointPolicy.MUST_SAVE,
-            ), f"{n} has unexpected recompute={recompute}"
+        if recompute is None:
+            continue
+        # All-gather nodes are tagged MUST_RECOMPUTE by
+        # mark_fsdp_all_gather_recomputation (runs unconditionally in AP);
+        # skip them so we only assert on tags set by ac_joint_pass.
+        if recompute == CheckpointPolicy.MUST_RECOMPUTE:
+            assert (
+                "all_gather" in n.name
+            ), f"{n} has MUST_RECOMPUTE but is not an all-gather node"
+            continue
+        assert recompute in (
+            CheckpointPolicy.PREFER_RECOMPUTE,
+            CheckpointPolicy.MUST_SAVE,
+        ), f"{n} has unexpected recompute={recompute}"
 
 
 def test_ac_joint_pass_apply_ac_policy_saves_mm_and_sdpa(device_mesh_1d):
@@ -427,6 +436,273 @@ def test_ac_joint_pass_stages_recomputation(device_mesh_1d):
     assert (
         len(must_save_nodes) > 0
     ), "Expected staging to insert MUST_SAVE nodes with tiny stage size"
+
+
+# ---------------------------------------------------------------------------
+# Family 2b: AC tag survival through torch.compile round-trip
+# ---------------------------------------------------------------------------
+
+
+def _build_parallel_module(model_cls, mesh, *, context_fn=None):
+    """Run the full AutoParallel pipeline and return the parallel module
+    (not just the graph) so it can be compiled with torch.compile."""
+    nheads, dim, ffn_dim = 8, 128, 512
+    bs = 8 * mesh.shape[0]
+    seq_len = 32
+
+    def input_fn():
+        return torch.rand(bs, seq_len, dim, device="cuda")
+
+    with torch.device("meta"):
+        if context_fn is not None:
+            model = model_cls(nheads, dim, ffn_dim, context_fn)
+        else:
+            model = model_cls(nheads, dim, ffn_dim)
+
+    x_sharding = (Shard(0),) + (Replicate(),) * (mesh.ndim - 1)
+    with AutoParallel(model, input_fn, mesh) as autop:
+        autop.add_input_constraints([x_sharding])
+        autop.add_output_constraints([x_sharding])
+        sharding_placement = autop.optimize_placement()
+        parallel_mod = autop.apply_placement(sharding_placement)
+
+    return parallel_mod, bs, seq_len, dim
+
+
+def _compile_and_capture_joint_graph(parallel_mod, x, *, joint_custom_pass=None):
+    """Compile the module with aot_eager and capture the fresh joint graph
+    that AOTAutograd creates.  Returns the captured FX GraphModule."""
+    import torch._dynamo
+    import torch._functorch.config
+
+    captured = []
+
+    def capture_pass(fx_g, joint_inputs):
+        if joint_custom_pass is not None:
+            fx_g = joint_custom_pass(fx_g, joint_inputs)
+        captured.append(fx_g)
+        return fx_g
+
+    try:
+        with torch._functorch.config.patch({"joint_custom_pass": capture_pass}):
+            compiled = torch.compile(parallel_mod, backend="aot_eager")
+            compiled(x)
+    finally:
+        torch._dynamo.reset()
+
+    assert len(captured) >= 1, "joint_custom_pass was never called"
+    return captured[0]
+
+
+def _materialize_parallel_module(parallel_mod):
+    """Move a meta-device parallel module to CUDA and initialize weights."""
+    parallel_mod.to_empty(device="cuda")
+    for p in parallel_mod.parameters():
+        torch.nn.init.ones_(p)
+
+
+def test_fsdp_recompute_tags_survive_compile_roundtrip(device_mesh_2d):
+    """Recomputation tags on collective nodes (set by
+    mark_fsdp_all_gather_recomputation before AP's partitioner) survive
+    into the fresh joint graph that torch.compile's AOTAutograd creates,
+    via the preserve_node_meta mechanism."""
+
+    parallel_mod, bs, seq_len, dim = _build_parallel_module(
+        AttentionBlockNoAC, device_mesh_2d
+    )
+    _materialize_parallel_module(parallel_mod)
+
+    local_bs = bs // device_mesh_2d.shape[0]
+    x = torch.rand(local_bs, seq_len, dim, device="cuda")
+
+    fresh_gm = _compile_and_capture_joint_graph(parallel_mod, x)
+
+    # Find collective nodes that have recompute tags (could be all-gather
+    # with MUST_RECOMPUTE or all-reduce with MUST_SAVE depending on the
+    # sharding strategy chosen by the optimizer).
+    tagged_collectives = [
+        n
+        for n in fresh_gm.graph.nodes
+        if n.op == "call_function" and n.meta.get("recompute") is not None
+    ]
+    assert (
+        len(tagged_collectives) > 0
+    ), "Expected nodes with recompute tags in the fresh joint graph"
+
+    for n in tagged_collectives:
+        assert n.meta.get("recompute") in (
+            CheckpointPolicy.MUST_RECOMPUTE,
+            CheckpointPolicy.MUST_SAVE,
+        ), f"{n} has unexpected recompute={n.meta.get('recompute')}"
+
+
+def test_ac_and_fsdp_tags_coexist_in_compile_roundtrip(device_mesh_2d):
+    """The autoparallel_backend() production flow: FSDP tags survived from AP's
+    graph coexist with AC tags freshly applied by ac_joint_pass via
+    joint_custom_pass."""
+    from torch._functorch.partitioners import _has_tag_is_backward
+
+    from autoparallel.graph_passes.activation_checkpointing import ac_joint_pass
+
+    parallel_mod, bs, seq_len, dim = _build_parallel_module(
+        AttentionBlockNoAC, device_mesh_2d
+    )
+    _materialize_parallel_module(parallel_mod)
+
+    local_bs = bs // device_mesh_2d.shape[0]
+    x = torch.rand(local_bs, seq_len, dim, device="cuda")
+
+    def ac_pass(fx_g, joint_inputs):
+        ac_joint_pass(fx_g.graph, ac_stage_size_in_GiB=None)
+        return fx_g
+
+    fresh_gm = _compile_and_capture_joint_graph(
+        parallel_mod, x, joint_custom_pass=ac_pass
+    )
+
+    # FSDP tags survived
+    tagged_collectives = [
+        n
+        for n in fresh_gm.graph.nodes
+        if n.op == "call_function"
+        and n.meta.get("recompute") is not None
+        and "_c10d_functional" in str(n.target)
+    ]
+    assert (
+        len(tagged_collectives) > 0
+    ), "Expected collective nodes with FSDP recompute tags to survive"
+
+    # AC tags applied on fresh graph: mm and SDPA nodes should be MUST_SAVE
+    fwd_must_save = 0
+    for n in fresh_gm.graph.nodes:
+        if n.op != "call_function" or _has_tag_is_backward(n):
+            continue
+        recompute = n.meta.get("recompute")
+        if recompute == CheckpointPolicy.MUST_SAVE:
+            fwd_must_save += 1
+
+    assert fwd_must_save > 0, "Expected forward nodes with MUST_SAVE from ac_joint_pass"
+
+    # Specifically check that some mm or SDPA forward nodes are MUST_SAVE
+    sdpa_targets = {
+        torch.ops.aten._scaled_dot_product_efficient_attention.default,
+        torch.ops.aten._scaled_dot_product_flash_attention.default,
+        torch.ops.aten._scaled_dot_product_cudnn_attention.default,
+    }
+    mm_sdpa_must_save = [
+        n
+        for n in fresh_gm.graph.nodes
+        if n.op == "call_function"
+        and not _has_tag_is_backward(n)
+        and (n.target == torch.ops.aten.mm.default or n.target in sdpa_targets)
+        and n.meta.get("recompute") == CheckpointPolicy.MUST_SAVE
+    ]
+    assert (
+        len(mm_sdpa_must_save) > 0
+    ), "Expected some forward mm/SDPA nodes with MUST_SAVE from ac_joint_pass"
+
+
+def test_user_ac_tags_survive_compile_roundtrip(device_mesh_2d):
+    """User-annotated AC tags (from torch.utils.checkpoint.checkpoint with a
+    selective policy) survive through the torch.compile round-trip via
+    preserve_node_meta."""
+
+    context_fn = functools.partial(
+        create_selective_checkpoint_contexts, _must_save_policy
+    )
+    parallel_mod, bs, seq_len, dim = _build_parallel_module(
+        AttentionBlockWithUserAC, device_mesh_2d, context_fn=context_fn
+    )
+    _materialize_parallel_module(parallel_mod)
+
+    local_bs = bs // device_mesh_2d.shape[0]
+    x = torch.rand(local_bs, seq_len, dim, device="cuda")
+
+    # Capture fresh graph without additional AC pass — we're testing survival
+    # of user-annotated tags, not AP's ac_joint_pass
+    fresh_gm = _compile_and_capture_joint_graph(parallel_mod, x)
+
+    # User policy sets MUST_SAVE on mm/einsum nodes inside checkpoint region
+    linear_nodes = _find_linear_nodes(fresh_gm.graph)
+    fwd_must_save_linear = [
+        n for n in linear_nodes if n.meta.get("recompute") == CheckpointPolicy.MUST_SAVE
+    ]
+    assert len(fwd_must_save_linear) > 0, (
+        "Expected mm/einsum nodes with MUST_SAVE from user AC policy to "
+        "survive the torch.compile round-trip"
+    )
+
+    # FSDP collective tags also survived
+    tagged_collectives = [
+        n
+        for n in fresh_gm.graph.nodes
+        if n.op == "call_function"
+        and n.meta.get("recompute")
+        in (
+            CheckpointPolicy.MUST_RECOMPUTE,
+            CheckpointPolicy.MUST_SAVE,
+        )
+        and "_c10d_functional" in str(n.target)
+    ]
+    assert (
+        len(tagged_collectives) > 0
+    ), "Expected collective nodes with FSDP recompute tags to survive"
+
+
+class MLPBlockWithUserAC(nn.Module):
+    """MLP-only model with user AC — no SDPA, no RNG ops."""
+
+    def __init__(self, nheads, dim, ffn_dim):
+        super().__init__()
+        self.w1 = nn.Linear(dim, ffn_dim, bias=False)
+        self.w2 = nn.Linear(ffn_dim, dim, bias=False)
+        self.w3 = nn.Linear(dim, ffn_dim, bias=False)
+        self.w4 = nn.Linear(ffn_dim, dim, bias=False)
+
+    def _mlp(self, x):
+        return self.w2(torch.nn.functional.relu(self.w1(x)))
+
+    def forward(self, x):
+        o = torch.utils.checkpoint.checkpoint(self._mlp, x, use_reentrant=False)
+        o = o + x
+        o = self.w4(torch.nn.functional.relu(self.w3(o)))
+        return o + x
+
+
+def test_user_ac_tags_survive_compile_roundtrip_no_rng(device_mesh_2d):
+    """User-annotated AC tags from torch.utils.checkpoint.checkpoint survive
+    the torch.compile round-trip.  Uses an MLP-only model (no SDPA) to avoid
+    the torch.Generator issue (pytorch/pytorch#179649)."""
+
+    parallel_mod, bs, seq_len, dim = _build_parallel_module(
+        MLPBlockWithUserAC, device_mesh_2d
+    )
+    _materialize_parallel_module(parallel_mod)
+
+    local_bs = bs // device_mesh_2d.shape[0]
+    x = torch.rand(local_bs, seq_len, dim, device="cuda")
+
+    fresh_gm = _compile_and_capture_joint_graph(parallel_mod, x)
+
+    from torch._functorch.partitioners import _has_tag_is_backward
+
+    # User checkpoint wraps _mlp which contains mm (from w1, w2 linears).
+    # The default checkpoint policy tags all ops inside the region with
+    # PREFER_RECOMPUTE.  These tags should survive into the fresh graph.
+    fwd_mm_nodes = [
+        n
+        for n in fresh_gm.graph.nodes
+        if n.op == "call_function"
+        and n.target == torch.ops.aten.mm.default
+        and not _has_tag_is_backward(n)
+    ]
+    assert len(fwd_mm_nodes) > 0, "Expected forward mm nodes"
+
+    tagged_mm = [n for n in fwd_mm_nodes if n.meta.get("recompute") is not None]
+    assert len(tagged_mm) > 0, (
+        "Expected some forward mm nodes with user AC recompute tags to "
+        "survive the torch.compile round-trip"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -611,9 +887,10 @@ def test_local_map_custom_metadata_propagation(device_mesh_3d):
     with torch.device("meta"):
         model = Block(nheads, dim, ffn_dim)
 
-    with fx_traceback.preserve_node_meta(), AutoParallel(
-        model, input_fn, mesh, compile=True
-    ) as autop:
+    with (
+        fx_traceback.preserve_node_meta(),
+        AutoParallel(model, input_fn, mesh) as autop,
+    ):
         autop.add_parameter_memory_constraint(low=None, high=None)
         x_sharding = (Shard(0),) + (Replicate(),) * (mesh.ndim - 1)
         autop.add_input_constraints([x_sharding])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,6 +12,7 @@ from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import Replicate, Shard
 
 from autoparallel.api import AutoParallel, auto_parallel
+from autoparallel.compile import autoparallel_backend
 
 
 def test_from_meta_model(device_mesh_1d):
@@ -78,11 +79,14 @@ def test_fx_graph_annotate(device_mesh_1d):
     with torch.device("meta"):
         model = Model(dim)
 
-    with fx_traceback.preserve_node_meta(), AutoParallel(
-        model,
-        input_fn,
-        device_mesh_1d,
-    ) as autop:
+    with (
+        fx_traceback.preserve_node_meta(),
+        AutoParallel(
+            model,
+            input_fn,
+            device_mesh_1d,
+        ) as autop,
+    ):
         x_sharding = (Shard(0),)
         autop.add_input_constraints([x_sharding])
         autop.add_output_constraints([x_sharding])
@@ -169,11 +173,14 @@ def test_fx_graph_annotate_overlap_pass(device_mesh_1d):
     with torch.device("meta"):
         model = Model()
 
-    with fx_traceback.preserve_node_meta(), AutoParallel(
-        model,
-        input_fn,
-        device_mesh_1d,
-    ) as autop:
+    with (
+        fx_traceback.preserve_node_meta(),
+        AutoParallel(
+            model,
+            input_fn,
+            device_mesh_1d,
+        ) as autop,
+    ):
         autop.add_input_constraints(
             [
                 (Replicate(),),
@@ -239,7 +246,7 @@ def test_fx_graph_annotate_overlap_pass(device_mesh_1d):
 
 
 def test_inference_mode_compilation(device_mesh_1d):
-    """Test that inference mode (no gradients) works with compile=True.
+    """Test that inference mode (no gradients) works with torch.compile.
 
     This test verifies the fix for the bug where updated_flat_args was incorrectly
     formatted as a tuple for inference mode, causing compilation to fail.
@@ -268,8 +275,7 @@ def test_inference_mode_compilation(device_mesh_1d):
     for param in model.parameters():
         param.requires_grad = False
 
-    # Test with compile=True - this should succeed with the fix
-    with AutoParallel(model, input_fn, device_mesh_1d, None, compile=True) as autop:
+    with AutoParallel(model, input_fn, device_mesh_1d, None) as autop:
         autop.add_parameter_memory_constraint(low=None, high=device_mesh_1d.ndim)
 
         # R -> S(0)
@@ -279,8 +285,6 @@ def test_inference_mode_compilation(device_mesh_1d):
         sharding_placement = autop.optimize_placement()
         parallel_mod = autop.apply_placement(sharding_placement)
 
-        # Verify the model was created
-        assert parallel_mod is not None
         assert hasattr(autop, "parallel_gm")
 
         # Verify graph has expected structure (forward-only, no backward pass)
@@ -289,6 +293,10 @@ def test_inference_mode_compilation(device_mesh_1d):
         ]
         # Should only have 2 placeholders: weight and input (no tangents for inference)
         assert len(placeholders) == 2
+
+    parallel_mod = torch.compile(parallel_mod, backend=autoparallel_backend())
+
+    assert parallel_mod is not None
 
 
 def test_moduledict_preservation(device_mesh_1d):
@@ -329,7 +337,6 @@ def test_moduledict_preservation(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
 
     # Verify that the parallel_mod preserves the ModuleDict structure
@@ -420,7 +427,6 @@ def test_unused_parameters_captured(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
 
     param_names = {name for name, _ in parallel_mod.named_parameters()}
@@ -482,7 +488,6 @@ def test_aliased_submodule(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
 
     # Module alias should be re-established on the parallel model
@@ -527,7 +532,6 @@ def test_parallel_model_isinstance(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
     assert isinstance(parallel_mod, Model)
 
@@ -564,7 +568,6 @@ def test_user_method_accessible(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
     assert hasattr(parallel_mod, "get_num_params")
     assert parallel_mod.get_num_params() > 0
@@ -610,7 +613,6 @@ def test_user_ema_update(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
     parallel_mod.to_empty(device="cuda")
     parallel_mod.init_weights()
@@ -667,7 +669,6 @@ def test_user_reset_buffers(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
     parallel_mod.to_empty(device="cuda")
     parallel_mod.init_weights()
@@ -715,7 +716,6 @@ def test_user_classmethod_and_property(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
     assert parallel_mod.hidden_dim == dim * 4
     assert hasattr(type(parallel_mod), "from_config")
@@ -753,133 +753,7 @@ def test_inherited_user_model(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
     assert isinstance(parallel_mod, Model)
     assert isinstance(parallel_mod, BaseModel)
     assert parallel_mod.get_num_params() > 0
-
-
-# Tests for overlap scheduling in compile=False path
-
-
-def test_overlap_scheduling_called_when_enabled(device_mesh_1d):
-    """Test that schedule_overlap_bucketing_from_inductor_configs is called
-    when compile=False and enable_overlap_scheduling=True.
-    """
-    from unittest.mock import patch
-
-    dim = 128
-
-    class Model(nn.Module):
-        def __init__(self, dim):
-            super().__init__()
-            self.linear = nn.Linear(dim, dim)
-
-        def forward(self, x):
-            return self.linear(x)
-
-    def input_fn():
-        b = 512
-        return (torch.rand(b, dim, device="cuda"),)
-
-    with torch.device("meta"):
-        model = Model(dim)
-
-    overlap_bucketing_called = []
-
-    with patch(
-        "torch._inductor.fx_passes.overlap_scheduling.schedule_overlap_bucketing_from_inductor_configs",
-        side_effect=lambda fx_g: overlap_bucketing_called.append(fx_g) or fx_g,
-    ), torch._inductor.config.patch(
-        {"aten_distributed_optimizations.enable_overlap_scheduling": True}
-    ):
-        with AutoParallel(
-            model,
-            input_fn,
-            device_mesh_1d,
-            compile=False,
-        ) as autop:
-            autop.add_input_constraints([(Shard(0),)])
-            sharding_placement = autop.optimize_placement()
-            _ = autop.apply_placement(sharding_placement)
-
-    assert (
-        len(overlap_bucketing_called) > 0
-    ), "schedule_overlap_bucketing_from_inductor_configs should be called"
-
-    for fx_g in overlap_bucketing_called:
-        assert isinstance(fx_g, torch.fx.GraphModule)
-
-
-def test_overlap_scheduling_not_called_when_disabled(device_mesh_1d):
-    """Test that overlap scheduling is skipped when enable_overlap_scheduling=False (default)."""
-    from unittest.mock import patch
-
-    dim = 128
-
-    class Model(nn.Module):
-        def __init__(self, dim):
-            super().__init__()
-            self.linear = nn.Linear(dim, dim)
-
-        def forward(self, x):
-            return self.linear(x)
-
-    def input_fn():
-        b = 512
-        return (torch.rand(b, dim, device="cuda"),)
-
-    with torch.device("meta"):
-        model = Model(dim)
-
-    overlap_bucketing_called = []
-
-    with patch(
-        "torch._inductor.fx_passes.overlap_scheduling.schedule_overlap_bucketing_from_inductor_configs",
-        side_effect=lambda fx_g: overlap_bucketing_called.append(fx_g) or fx_g,
-    ):
-        with AutoParallel(
-            model,
-            input_fn,
-            device_mesh_1d,
-            compile=False,
-        ) as autop:
-            autop.add_input_constraints([(Shard(0),)])
-            sharding_placement = autop.optimize_placement()
-            _ = autop.apply_placement(sharding_placement)
-
-    assert (
-        len(overlap_bucketing_called) == 0
-    ), "schedule_overlap_bucketing_from_inductor_configs should NOT be called by default"
-
-
-def test_compile_true_uses_compile_fx_inner(device_mesh_1d):
-    """When compile=True, the compiler_fn should be compile_fx_inner."""
-    dim = 128
-
-    class Model(nn.Module):
-        def __init__(self, dim):
-            super().__init__()
-            self.linear = nn.Linear(dim, dim)
-
-        def forward(self, x):
-            return self.linear(x)
-
-    def input_fn():
-        b = 512
-        return (torch.rand(b, dim, device="cuda"),)
-
-    with torch.device("meta"):
-        model = Model(dim)
-
-    from torch._inductor.compile_fx import compile_fx_inner
-
-    autop = AutoParallel(
-        model,
-        input_fn,
-        device_mesh_1d,
-        compile=True,
-    )
-
-    assert autop.compiler_fn is compile_fx_inner

--- a/tests/test_auto_parallel_simple.py
+++ b/tests/test_auto_parallel_simple.py
@@ -44,7 +44,6 @@ def test_auto_parallel_basic(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
 
     # Verify model was created
@@ -96,7 +95,6 @@ def test_auto_parallel_tuple_inputs(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x, y),
         out_shardings=(Shard(0),),
-        compile=False,
     )
 
     assert parallel_model is not None
@@ -132,7 +130,6 @@ def test_auto_parallel_multiple_outputs(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=((Shard(0),), (Shard(0),)),
-        compile=False,
     )
 
     assert parallel_model is not None
@@ -163,7 +160,6 @@ def test_auto_parallel_replicated_input(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),  # Shard output for valid solution
-        compile=False,
     )
 
     assert parallel_model is not None
@@ -200,7 +196,6 @@ def test_auto_parallel_callable_inputs(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=sample_inputs,
         out_shardings=(Shard(0),),
-        compile=False,
     )
 
     assert parallel_model is not None
@@ -241,7 +236,6 @@ def test_auto_parallel_with_mp_policy(device_mesh_1d):
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
         mp_policy=mp_policy,
-        compile=False,
     )
 
     assert parallel_model is not None

--- a/tests/test_dynamic_shapes.py
+++ b/tests/test_dynamic_shapes.py
@@ -914,9 +914,7 @@ def test_dynamic_apply_placement_transformer(device_mesh_2d):
         model = TransformerBlock(nheads, dim1, dim2)
 
     placement = (Shard(0), Replicate())
-    with AutoParallel(
-        model, input_fn, device_mesh_2d, dynamic=True, compile=False
-    ) as autop:
+    with AutoParallel(model, input_fn, device_mesh_2d, dynamic=True) as autop:
         autop.add_input_constraints([placement])
         autop.add_output_constraints([placement])
         sharding_placement = autop.optimize_placement(verbose=False)
@@ -940,9 +938,7 @@ def test_dynamic_joint_graph_has_symbolic_shapes(device_mesh_2d):
         model = TransformerBlock(nheads, dim1, dim2)
 
     placement = (Shard(0), Replicate())
-    with AutoParallel(
-        model, input_fn, device_mesh_2d, dynamic=True, compile=False
-    ) as autop:
+    with AutoParallel(model, input_fn, device_mesh_2d, dynamic=True) as autop:
         autop.add_input_constraints([placement])
         autop.add_output_constraints([placement])
 
@@ -1024,9 +1020,7 @@ def test_dynamic_apply_placement_view_heavy(device_mesh_2d):
         model = ViewHeavyModel(dim, nheads)
 
     placement = (Shard(0), Replicate())
-    with AutoParallel(
-        model, input_fn, device_mesh_2d, dynamic=True, compile=False
-    ) as autop:
+    with AutoParallel(model, input_fn, device_mesh_2d, dynamic=True) as autop:
         autop.add_input_constraints([placement])
         autop.add_output_constraints([placement])
         sharding_placement = autop.optimize_placement(verbose=False)
@@ -1052,9 +1046,7 @@ def test_dynamic_apply_placement_factory_op(device_mesh_1d):
         model = FactoryOpModel(dim)
 
     placement = (Shard(0),)
-    with AutoParallel(
-        model, input_fn, device_mesh_1d, dynamic=True, compile=False
-    ) as autop:
+    with AutoParallel(model, input_fn, device_mesh_1d, dynamic=True) as autop:
         autop.add_input_constraints([placement])
         autop.add_output_constraints([placement])
         sharding_placement = autop.optimize_placement(verbose=False)

--- a/tests/test_flex_attention.py
+++ b/tests/test_flex_attention.py
@@ -249,9 +249,12 @@ def _run_auto_parallel(model, mesh, dim=DIM, compile=False):
         mesh,
         sample_inputs=(x,),
         out_shardings=_out_shardings(mesh),
-        compile=compile,
     )
     assert parallel_model is not None
+    if compile:
+        from autoparallel.compile import autoparallel_backend
+
+        parallel_model = torch.compile(parallel_model, backend=autoparallel_backend())
     return parallel_model
 
 
@@ -325,7 +328,7 @@ def test_flex_attention_block_mask_sharding_matches_shape(device_mesh_1d):
         input_fn = _make_input_fn(shapes, dtypes, treespec, devices)
         output_placements = _flatten_out_shardings(_out_shardings(mesh))
 
-        with AutoParallel(model, input_fn, mesh, compile=False) as autop:
+        with AutoParallel(model, input_fn, mesh) as autop:
             autop.add_input_constraints(input_placements)
             autop.add_output_constraints(output_placements)
 
@@ -415,7 +418,7 @@ def test_flex_attention_gqa_head_sharding(device_mesh_2d):
     input_fn = _make_input_fn(shapes, dtypes, treespec, devices)
     output_placements = _flatten_out_shardings(_out_shardings(mesh))
 
-    with AutoParallel(model, input_fn, mesh, compile=False) as autop:
+    with AutoParallel(model, input_fn, mesh) as autop:
         autop.add_input_constraints(input_placements)
         autop.add_output_constraints(output_placements)
 
@@ -485,7 +488,7 @@ def test_flex_attention_other_buffers_replicated(device_mesh_1d):
     input_fn = _make_input_fn(shapes, dtypes, treespec, devices)
     output_placements = _flatten_out_shardings(_out_shardings(mesh))
 
-    with AutoParallel(model, input_fn, mesh, compile=False) as autop:
+    with AutoParallel(model, input_fn, mesh) as autop:
         autop.add_input_constraints(input_placements)
         autop.add_output_constraints(output_placements)
 
@@ -516,14 +519,14 @@ def test_flex_attention_other_buffers_replicated(device_mesh_1d):
 
 
 def test_flex_attention_compile(device_mesh_1d):
-    """Smoke test with compile=True to verify the parallel graph is compilable."""
+    """Smoke test that the parallel graph is compilable with torch.compile."""
     with torch.device("meta"):
         model = FlexAttnModel(DIM, N_HEADS)
     _run_auto_parallel(model, device_mesh_1d, compile=True)
 
 
 def test_flex_attention_gqa_compile(device_mesh_1d):
-    """Smoke test GQA with compile=True."""
+    """Smoke test GQA is compilable with torch.compile."""
     n_kv_heads = 2
     with torch.device("meta"):
         model = FlexAttnGQAModel(DIM, N_HEADS, n_kv_heads)

--- a/tests/test_inference_path.py
+++ b/tests/test_inference_path.py
@@ -45,7 +45,7 @@ def _auto_parallel_with_internals(model, mesh, sample_inputs, out_shardings):
     output_placements = _flatten_out_shardings(out_shardings)
     input_fn = _make_input_fn(shapes, dtypes, treespec, devices)
 
-    with AutoParallel(model, input_fn, mesh, compile=False) as autop:
+    with AutoParallel(model, input_fn, mesh) as autop:
         autop.add_input_constraints(input_placements)
         autop.add_output_constraints(output_placements)
         sharding_placement = autop.optimize_placement(verbose=False)
@@ -185,7 +185,6 @@ def test_inference_fn_produces_output(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
     parallel_model.to_empty(device="cuda")
     nn.init.ones_(parallel_model.linear.weight)
@@ -209,7 +208,6 @@ def test_training_and_inference_same_output(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
     parallel_model.to_empty(device="cuda")
     nn.init.ones_(parallel_model.linear.weight)
@@ -238,7 +236,6 @@ def test_inference_no_grad_on_output(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
     parallel_model.to_empty(device="cuda")
     nn.init.ones_(parallel_model.linear.weight)
@@ -262,7 +259,6 @@ def test_multi_output_inference(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=((Shard(0),), (Shard(0),)),
-        compile=False,
     )
     parallel_model.to_empty(device="cuda")
     nn.init.ones_(parallel_model.a.weight)

--- a/tests/test_init_weights.py
+++ b/tests/test_init_weights.py
@@ -45,7 +45,6 @@ def test_init(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
     parallel_mod.to_empty(device="cuda")
     parallel_mod.init_weights()
@@ -95,7 +94,6 @@ def test_init_inplace_data(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
     parallel_mod.to_empty(device="cuda")
     parallel_mod.init_weights()
@@ -168,7 +166,6 @@ def test_init_aliased_buffers(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
 
     parallel_mod.to_empty(device="cuda")
@@ -222,7 +219,6 @@ def test_init_aliased_parameters(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
 
     parallel_mod.to_empty(device="cuda")
@@ -286,7 +282,6 @@ def test_aliased_buffers_both_used_in_forward(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
 
     parallel_mod.to_empty(device="cuda")
@@ -339,7 +334,6 @@ def test_aliased_parameters_both_used_in_forward(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
 
     parallel_mod.to_empty(device="cuda")
@@ -388,7 +382,6 @@ def test_init_load_state_dict(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
     parallel_mod.to_empty(device="cuda")
     parallel_mod.init_weights()
@@ -467,7 +460,6 @@ def test_init_submodule_init_weights(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
     parallel_mod.to_empty(device="cuda")
     parallel_mod.init_weights()
@@ -526,7 +518,6 @@ def test_init_access_submodule_params(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
     parallel_mod.to_empty(device="cuda")
     parallel_mod.init_weights()
@@ -599,7 +590,6 @@ def test_init_submodule_load_state_dict(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
     parallel_mod.to_empty(device="cuda")
     parallel_mod.init_weights()
@@ -662,7 +652,6 @@ def test_init_optional_submodule(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
     parallel_mod.to_empty(device="cuda")
     parallel_mod.init_weights()
@@ -711,7 +700,6 @@ def test_init_data_assign_raises(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
     parallel_mod.to_empty(device="cuda")
     with pytest.raises(RuntimeError, match=r"Cannot use `.data = ...` on a DTensor"):

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -105,7 +105,6 @@ def test_forward_input_validation_integration(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
 
     with pytest.raises(ValueError, match="shape"):
@@ -216,7 +215,6 @@ def test_dict_input_integration(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=sample_inputs,
         out_shardings=(Shard(0),),
-        compile=False,
     )
     parallel_mod.to_empty(device="cuda")
     parallel_mod.init_weights()

--- a/tests/test_optimize_placement.py
+++ b/tests/test_optimize_placement.py
@@ -334,7 +334,6 @@ def test_in_graph_tensor_ctor(device_mesh_1d):
         device_mesh_1d,
         sample_inputs=(x,),
         out_shardings=(Shard(0),),
-        compile=False,
     )
     parallel_mod.to_empty(device="cuda")
     parallel_mod.init_weights()

--- a/tests/test_propagation_rules.py
+++ b/tests/test_propagation_rules.py
@@ -9,6 +9,7 @@ from torch.distributed.fsdp import MixedPrecisionPolicy
 from torch.distributed.tensor.placement_types import Shard
 
 from autoparallel.api import AutoParallel
+from autoparallel.compile import autoparallel_backend
 
 
 def test_permute_layernorm_stride_handling(device_mesh_1d):
@@ -54,9 +55,7 @@ def test_permute_layernorm_stride_handling(device_mesh_1d):
     )
 
     # This should not raise an AssertionError about tensor_meta stride mismatch.
-    with AutoParallel(
-        model, input_fn, device_mesh_1d, mp_policy, compile=True
-    ) as autop:
+    with AutoParallel(model, input_fn, device_mesh_1d, mp_policy) as autop:
         x_sharding = (Shard(0),)
         y_sharding = (Shard(0),)
 
@@ -76,6 +75,8 @@ def test_permute_layernorm_stride_handling(device_mesh_1d):
             torch.nn.init.ones_(param)
         elif "bias" in name:
             torch.nn.init.zeros_(param)
+
+    parallel_mod = torch.compile(parallel_mod, backend=autoparallel_backend())
 
     # Test forward pass execution works
     local_batch_size = batch_size // torch.distributed.get_world_size()
@@ -116,9 +117,7 @@ def test_iota(device_mesh_1d):
         param_dtype=torch.float32, reduce_dtype=torch.float32
     )
 
-    with AutoParallel(
-        model, input_fn, device_mesh_1d, mp_policy, compile=True
-    ) as autop:
+    with AutoParallel(model, input_fn, device_mesh_1d, mp_policy) as autop:
         autop.add_input_constraints([(Shard(0),)])
         autop.add_output_constraints([(Shard(0),)])
         sharding_placement = autop.optimize_placement()
@@ -126,6 +125,8 @@ def test_iota(device_mesh_1d):
 
     parallel_mod.to_empty(device="cuda")
     torch.nn.init.ones_(parallel_mod.embed.weight)
+
+    parallel_mod = torch.compile(parallel_mod, backend=autoparallel_backend())
 
     local_batch = batch_size // torch.distributed.get_world_size()
     x = torch.ones(local_batch, seq_len, dim, device="cuda")
@@ -175,9 +176,7 @@ def test_index_put(device_mesh_1d):
         param_dtype=torch.bfloat16, reduce_dtype=torch.float32
     )
 
-    with AutoParallel(
-        model, input_fn, device_mesh_1d, mp_policy, compile=True
-    ) as autop:
+    with AutoParallel(model, input_fn, device_mesh_1d, mp_policy) as autop:
         autop.add_input_constraints([(Shard(0),)])
         sharding_placement = autop.optimize_placement()
         autop.apply_placement(sharding_placement)


### PR DESCRIPTION
Make compilation a composable, downstream concern: users call torch.compile() on the module AP returns, optionally using the new inductor_config() context manager for AP-optimized passes (activation checkpointing, overlap scheduling).

The key insight is that AP already partitions the joint graph into fwd/bwd via aot_compile_joint_with_descriptors. The returned module's forward() is a normal callable -- torch.compile() traces it with Dynamo, AOTAutograd creates a fresh joint graph, and Inductor's min-cut partitioner operates on that new graph (not AP's original). AC recomputation tags (MUST_RECOMPUTE/MUST_SAVE from FSDP all-gather tagging) are structural after AP's partitioner runs, so they survive the torch.compile round-trip.

Examples that previously used compile=True now use:
  with inductor_config():
      parallel_mod = torch.compile(parallel_mod)

Tests that previously used compile=True are updated similarly. Three obsolete tests in test_api.py (overlap scheduling under compile, compile_true smoke test, inference-with-compile) are removed since they tested the old in-AP compile path.

Depends on [pytorch/pytorch#179649](https://github.com/pytorch/pytorch/pull/179661) which fixes torch.compile over pre-partitioned AOTAutograd graphs containing
graphsafe_run_with_rng_state (from selective activation checkpointing).

<!-- ps-id: fb58a4ab-f887-4e79-bea8-56ae48f6f36f -->