### PR TITLE
Support inference mode by extracting forward-only graph from joint graph

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -497,6 +497,48 @@ class AutoParallel:
             bw_compiler=self.compiler_fn,
         )
 
+        # Build a forward-only graph for inference (no backward, no
+        # activation saves).  Compilation is lazy — only paid on first
+        # call under torch.no_grad().
+        from .graph_passes.extract_forward import extract_forward_graph
+
+        fw_metadata = self.joint_with_descriptors._aot_state.fw_metadata
+        # num_forward_returns includes mutation outputs + user outputs +
+        # intermediate bases.  For now we only support the common case
+        # where there are no mutations or intermediate bases.
+        assert (
+            fw_metadata.num_mutated_inp_runtime_indices == 0
+        ), "Inference path does not support models with input mutations"
+        assert (
+            fw_metadata.num_intermediate_bases == 0
+        ), "Inference path does not support models with intermediate bases"
+        num_fwd_outputs = fw_metadata.num_forward_returns
+        fwd_only_gm = extract_forward_graph(self.parallel_gm, num_fwd_outputs)
+        compiler_fn = self.compiler_fn
+        out_spec = self.joint_with_descriptors.out_spec
+
+        _inference_fn_cache = None
+
+        def _get_inference_fn():
+            nonlocal _inference_fn_cache
+            if _inference_fn_cache is not None:
+                return _inference_fn_cache
+            example_inputs = [
+                n.meta["val"] for n in fwd_only_gm.graph.nodes if n.op == "placeholder"
+            ]
+            compiled = compiler_fn(fwd_only_gm, example_inputs)
+
+            # compiler_fn returns a boxed callable (takes a list of args).
+            # The graph output is always a tuple; use out_spec to
+            # reconstruct the original model output structure.
+            def inference_fn(args):
+                graph_out = compiled(args)
+                flat = list(graph_out)
+                return torch.utils._pytree.tree_unflatten(flat, out_spec)
+
+            _inference_fn_cache = inference_fn
+            return _inference_fn_cache
+
         # TODO: this probably belongs in the AOTAutograd API
         # TODO: pytree handling
         # Capture the exact FQNs the compiled graph expects as primals.
@@ -520,8 +562,11 @@ class AutoParallel:
             ] + [self.get_buffer(fqn).to_local() for fqn in graph_buffer_fqns]
             boxed_args = [*params, *args]
             del params
-            # NB: don't do self.parallel_model_fn work around Dynamo bug
-            out = parallel_model_fn(boxed_args)
+            if torch.is_grad_enabled():
+                # NB: don't do self.parallel_model_fn work around Dynamo bug
+                out = parallel_model_fn(boxed_args)
+            else:
+                out = _get_inference_fn()(boxed_args)
             return out
 
         self.parallel_model = make_parallel_module(

--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -503,18 +503,10 @@ class AutoParallel:
         from .graph_passes.extract_forward import extract_forward_graph
 
         fw_metadata = self.joint_with_descriptors._aot_state.fw_metadata
-        # num_forward_returns includes mutation outputs + user outputs +
-        # intermediate bases.  For now we only support the common case
-        # where there are no mutations or intermediate bases.
-        assert (
-            fw_metadata.num_mutated_inp_runtime_indices == 0
-        ), "Inference path does not support models with input mutations"
-        assert (
-            fw_metadata.num_intermediate_bases == 0
-        ), "Inference path does not support models with intermediate bases"
         num_fwd_outputs = fw_metadata.num_forward_returns
         fwd_only_gm = extract_forward_graph(self.parallel_gm, num_fwd_outputs)
         compiler_fn = self.compiler_fn
+        aot_config = self.joint_with_descriptors._aot_state.aot_config
         out_spec = self.joint_with_descriptors.out_spec
 
         _inference_fn_cache = None
@@ -528,13 +520,20 @@ class AutoParallel:
             ]
             compiled = compiler_fn(fwd_only_gm, example_inputs)
 
-            # compiler_fn returns a boxed callable (takes a list of args).
-            # The graph output is always a tuple; use out_spec to
-            # reconstruct the original model output structure.
+            # Wrap with RuntimeWrapper to handle mutation write-back
+            # (e.g. buffer updates like BatchNorm running stats), output
+            # alias handling, and intermediate base stripping.
+            from torch._functorch._aot_autograd.runtime_wrappers import RuntimeWrapper
+
+            wrapped = RuntimeWrapper(
+                indices_of_inps_to_detach=[],
+                trace_joint=False,
+                disable_amp=False,
+            ).post_compile(compiled, aot_config, runtime_metadata=fw_metadata)
+
             def inference_fn(args):
-                graph_out = compiled(args)
-                flat = list(graph_out)
-                return torch.utils._pytree.tree_unflatten(flat, out_spec)
+                flat_outs = wrapped(args)
+                return torch.utils._pytree.tree_unflatten(flat_outs, out_spec)
 
             _inference_fn_cache = inference_fn
             return _inference_fn_cache

--- a/autoparallel/graph_passes/extract_forward.py
+++ b/autoparallel/graph_passes/extract_forward.py
@@ -1,0 +1,57 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+
+import torch.fx
+import torch.utils._pytree as pytree
+
+
+def _reachable_from_output(graph: torch.fx.Graph) -> set[torch.fx.Node]:
+    """Return the set of nodes transitively reachable from the output node."""
+    output_node = next(n for n in graph.nodes if n.op == "output")
+    reachable: set[torch.fx.Node] = set()
+    worklist = [output_node]
+    while worklist:
+        node = worklist.pop()
+        if node in reachable:
+            continue
+        reachable.add(node)
+        for inp in node.all_input_nodes:
+            worklist.append(inp)
+    return reachable
+
+
+def extract_forward_graph(
+    joint_gm: torch.fx.GraphModule, num_fwd_outputs: int
+) -> torch.fx.GraphModule:
+    """Extract a forward-only graph from a joint forward+backward graph.
+
+    Trims the output to forward-only entries, then removes all nodes
+    not reachable from the trimmed output (backward nodes, tangent
+    placeholders, backward-only collectives, saved activations).
+    """
+    gm = copy.deepcopy(joint_gm)
+    graph = gm.graph
+
+    # The joint graph output is nested: ((fwd_outs...), (bwd_outs...)).
+    # Flatten to individual leaf nodes, keep only the first
+    # num_fwd_outputs leaves, and set them as a flat output tuple.
+    output_node = next(n for n in graph.nodes if n.op == "output")
+    flat_outputs = pytree.arg_tree_leaves(*output_node.args)
+    fwd_outputs = flat_outputs[:num_fwd_outputs]
+    output_node.args = (tuple(fwd_outputs),)
+
+    # Compute reachability from the trimmed output and remove
+    # everything else (backward nodes, tangent placeholders,
+    # backward-only collectives, etc.).
+    reachable = _reachable_from_output(graph)
+    for node in reversed(list(graph.nodes)):
+        if node not in reachable:
+            node.replace_all_uses_with(None)
+            graph.erase_node(node)
+
+    gm.recompile()
+    return gm

--- a/tests/test_inference_path.py
+++ b/tests/test_inference_path.py
@@ -1,0 +1,283 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from torch import nn
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor.placement_types import Shard
+
+from autoparallel.api import auto_parallel
+
+
+class LinearModel(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.linear = nn.Linear(dim, dim, bias=False)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class TwoOutputModel(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.a = nn.Linear(dim, dim, bias=False)
+        self.b = nn.Linear(dim, dim, bias=False)
+
+    def forward(self, x):
+        return self.a(x), self.b(x)
+
+
+def _auto_parallel_with_internals(model, mesh, sample_inputs, out_shardings):
+    """Like auto_parallel but also returns the AutoParallel instance."""
+    from autoparallel.api import (
+        AutoParallel,
+        _extract_input_info,
+        _flatten_out_shardings,
+        _make_input_fn,
+    )
+
+    shapes, dtypes, input_placements, treespec = _extract_input_info(
+        sample_inputs, mesh
+    )
+    output_placements = _flatten_out_shardings(out_shardings)
+    input_fn = _make_input_fn(shapes, dtypes, treespec)
+
+    with AutoParallel(model, input_fn, mesh, compile=False) as autop:
+        autop.add_input_constraints(input_placements)
+        autop.add_output_constraints(output_placements)
+        sharding_placement = autop.optimize_placement(verbose=False)
+        parallel_model = autop.apply_placement(sharding_placement)
+
+    return parallel_model, autop
+
+
+def _make_dtensor_input(dim, mesh):
+    local_bs = max(1, 32 // mesh.size())
+    return DTensor.from_local(
+        torch.rand(local_bs, dim, device="cuda"), mesh, [Shard(0)]
+    )
+
+
+# ---------------------------------------------------------------------------
+# extract_forward_graph unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_extract_forward_removes_tangent_placeholders(device_mesh_1d):
+    """Forward-only graph has no tangent placeholders."""
+    from autoparallel.graph_passes.extract_forward import extract_forward_graph
+
+    dim = 128
+    with torch.device("meta"):
+        model = LinearModel(dim)
+
+    x = _make_dtensor_input(dim, device_mesh_1d)
+    _, autop = _auto_parallel_with_internals(model, device_mesh_1d, (x,), (Shard(0),))
+
+    joint_gm = autop.parallel_gm
+    fw_metadata = autop.joint_with_descriptors._aot_state.fw_metadata
+    num_fwd_outputs = fw_metadata.num_forward_returns
+
+    # Sanity: joint graph should have tangent placeholders
+    joint_tangents = [
+        n
+        for n in joint_gm.graph.nodes
+        if n.op == "placeholder" and "tangents" in n.target
+    ]
+    assert len(joint_tangents) > 0
+
+    fwd_gm = extract_forward_graph(joint_gm, num_fwd_outputs)
+
+    fwd_tangents = [
+        n
+        for n in fwd_gm.graph.nodes
+        if n.op == "placeholder" and "tangents" in n.target
+    ]
+    assert len(fwd_tangents) == 0
+
+
+def test_extract_forward_output_count(device_mesh_1d):
+    """Forward-only graph output has exactly num_fwd_outputs entries."""
+    from autoparallel.graph_passes.extract_forward import extract_forward_graph
+
+    dim = 128
+    with torch.device("meta"):
+        model = TwoOutputModel(dim)
+
+    x = _make_dtensor_input(dim, device_mesh_1d)
+    _, autop = _auto_parallel_with_internals(
+        model, device_mesh_1d, (x,), ((Shard(0),), (Shard(0),))
+    )
+
+    joint_gm = autop.parallel_gm
+    fw_metadata = autop.joint_with_descriptors._aot_state.fw_metadata
+    num_fwd_outputs = fw_metadata.num_forward_returns
+
+    fwd_gm = extract_forward_graph(joint_gm, num_fwd_outputs)
+
+    output_node = next(n for n in fwd_gm.graph.nodes if n.op == "output")
+    fwd_outputs = output_node.args[0]
+    assert len(fwd_outputs) == num_fwd_outputs
+
+
+def test_extract_forward_fewer_nodes(device_mesh_1d):
+    """Forward-only graph should have strictly fewer nodes than joint graph."""
+    from autoparallel.graph_passes.extract_forward import extract_forward_graph
+
+    dim = 128
+    with torch.device("meta"):
+        model = LinearModel(dim)
+
+    x = _make_dtensor_input(dim, device_mesh_1d)
+    _, autop = _auto_parallel_with_internals(model, device_mesh_1d, (x,), (Shard(0),))
+
+    joint_gm = autop.parallel_gm
+    fw_metadata = autop.joint_with_descriptors._aot_state.fw_metadata
+    num_fwd_outputs = fw_metadata.num_forward_returns
+
+    fwd_gm = extract_forward_graph(joint_gm, num_fwd_outputs)
+
+    joint_count = sum(1 for _ in joint_gm.graph.nodes)
+    fwd_count = sum(1 for _ in fwd_gm.graph.nodes)
+    assert fwd_count < joint_count, (
+        f"Forward graph ({fwd_count} nodes) should be smaller than "
+        f"joint graph ({joint_count} nodes)"
+    )
+
+
+def test_extract_forward_does_not_mutate_original(device_mesh_1d):
+    """extract_forward_graph should not modify the original joint graph."""
+    from autoparallel.graph_passes.extract_forward import extract_forward_graph
+
+    dim = 128
+    with torch.device("meta"):
+        model = LinearModel(dim)
+
+    x = _make_dtensor_input(dim, device_mesh_1d)
+    _, autop = _auto_parallel_with_internals(model, device_mesh_1d, (x,), (Shard(0),))
+
+    joint_gm = autop.parallel_gm
+    fw_metadata = autop.joint_with_descriptors._aot_state.fw_metadata
+    num_fwd_outputs = fw_metadata.num_forward_returns
+
+    original_node_count = sum(1 for _ in joint_gm.graph.nodes)
+    _ = extract_forward_graph(joint_gm, num_fwd_outputs)
+    assert sum(1 for _ in joint_gm.graph.nodes) == original_node_count
+
+
+# ---------------------------------------------------------------------------
+# Inference calling convention tests
+# ---------------------------------------------------------------------------
+
+
+def test_inference_fn_produces_output(device_mesh_1d):
+    """Forward under no_grad should use the inference path and produce output."""
+    dim = 128
+    with torch.device("meta"):
+        model = LinearModel(dim)
+
+    x = _make_dtensor_input(dim, device_mesh_1d)
+    parallel_model = auto_parallel(
+        model,
+        device_mesh_1d,
+        sample_inputs=(x,),
+        out_shardings=(Shard(0),),
+        compile=False,
+    )
+    parallel_model.to_empty(device="cuda")
+    nn.init.ones_(parallel_model.linear.weight)
+
+    with torch.no_grad():
+        out = parallel_model(x.to_local())
+
+    assert out is not None
+    assert isinstance(out, torch.Tensor), f"Expected Tensor, got {type(out)}"
+
+
+def test_training_and_inference_same_output(device_mesh_1d):
+    """Training and inference paths should produce identical forward outputs."""
+    dim = 128
+    with torch.device("meta"):
+        model = LinearModel(dim)
+
+    x = _make_dtensor_input(dim, device_mesh_1d)
+    parallel_model = auto_parallel(
+        model,
+        device_mesh_1d,
+        sample_inputs=(x,),
+        out_shardings=(Shard(0),),
+        compile=False,
+    )
+    parallel_model.to_empty(device="cuda")
+    nn.init.ones_(parallel_model.linear.weight)
+
+    local_x = x.to_local()
+
+    train_out = parallel_model(local_x)
+    with torch.no_grad():
+        infer_out = parallel_model(local_x)
+
+    assert type(train_out) is type(
+        infer_out
+    ), f"Output types differ: train={type(train_out)}, infer={type(infer_out)}"
+    assert torch.equal(train_out, infer_out)
+
+
+def test_inference_no_grad_on_output(device_mesh_1d):
+    """Inference path output should not require grad."""
+    dim = 128
+    with torch.device("meta"):
+        model = LinearModel(dim)
+
+    x = _make_dtensor_input(dim, device_mesh_1d)
+    parallel_model = auto_parallel(
+        model,
+        device_mesh_1d,
+        sample_inputs=(x,),
+        out_shardings=(Shard(0),),
+        compile=False,
+    )
+    parallel_model.to_empty(device="cuda")
+    nn.init.ones_(parallel_model.linear.weight)
+
+    with torch.no_grad():
+        out = parallel_model(x.to_local())
+
+    assert isinstance(out, torch.Tensor), f"Expected Tensor, got {type(out)}"
+    assert not out.requires_grad
+
+
+def test_multi_output_inference(device_mesh_1d):
+    """Inference path works with multiple outputs and pytree unflattening."""
+    dim = 128
+    with torch.device("meta"):
+        model = TwoOutputModel(dim)
+
+    x = _make_dtensor_input(dim, device_mesh_1d)
+    parallel_model = auto_parallel(
+        model,
+        device_mesh_1d,
+        sample_inputs=(x,),
+        out_shardings=((Shard(0),), (Shard(0),)),
+        compile=False,
+    )
+    parallel_model.to_empty(device="cuda")
+    nn.init.ones_(parallel_model.a.weight)
+    nn.init.ones_(parallel_model.b.weight)
+
+    local_x = x.to_local()
+
+    train_out = parallel_model(local_x)
+    assert isinstance(train_out, tuple)
+    assert len(train_out) == 2
+
+    with torch.no_grad():
+        infer_out = parallel_model(local_x)
+
+    assert isinstance(infer_out, tuple), f"Expected tuple, got {type(infer_out)}"
+    assert len(infer_out) == 2
+    assert torch.equal(train_out[0], infer_out[0])
+    assert torch.equal(train_out[1], infer_out[1])


### PR DESCRIPTION
AutoParallel currently bakes the joint forward+backward graph into a single compiled function, so `torch.no_grad()` has no effect — activations are always saved for backward, wasting memory during inference/eval.

This PR adds an inference code path that derives a forward-only graph from the already-sharded joint graph. The key idea: trace once, optimize once, apply collectives once, then extract the inference graph by pruning. This avoids a second trace (and the divergence risk that comes with it) while keeping the same parameter placements and collective operations.

`extract_forward_graph` flattens the joint graph's nested output structure, keeps only the forward output leaves, then uses reachability analysis from the trimmed output to remove everything else — backward nodes, tangent placeholders, backward-only collectives, and saved activations. Reachability-based pruning sidesteps the complications of FX's DCE with side-effectful collective ops.

In `apply_placement`, the forward-only graph is extracted eagerly (cheap graph manipulation), but compilation through Inductor is lazy — only paid on first call under `no_grad()`. `ParallelModule.forward` dispatches on `torch.is_grad_enabled()` to pick the appropriate compiled function.

Both `AutoParallel` and `auto_parallel` APIs get inference support automatically.

Authored with Claude.