### PR TITLE
Add support for FlexAttention higher-order operator

### DIFF
--- a/autoparallel/apply_sharding.py
+++ b/autoparallel/apply_sharding.py
@@ -72,8 +72,10 @@ class ApplyShardingInterpreter(torch.fx.Interpreter):
         return super().run_node(n)
 
     def _get_input_nodes(self, node):
-        # node.all_input_nodes deduplicates, but we need repeated nodes preserved
-        return all_input_nodes(node)
+        # node.all_input_nodes deduplicates, but we need repeated nodes preserved.
+        # Filter to only nodes with sharding entries — HOP submodule nodes
+        # (GraphModules) are not in sharding_placement and should be skipped.
+        return [x for x in all_input_nodes(node) if x in self.sharding_placement]
 
     def _set_origin_and_target_device_order(self, node, curr_spec, tgt_spec):
         # shard_order should be automatically assigned once `placements` is set

--- a/autoparallel/apply_sharding.py
+++ b/autoparallel/apply_sharding.py
@@ -51,28 +51,6 @@ def _compute_shard_order(shard_order, reverse: bool):
     return tuple(result)
 
 
-def _filter_specs_for_local_map(flat_args, curr_specs, tgt_specs):
-    """Filter curr/tgt specs to tensor-only entries for local_map HOPs.
-
-    Other ops filter out non-tensor/symint args from their specs already,
-    but local_map keeps them, so we need to strip them here.
-    """
-    curr_specs_t = []
-    tgt_specs_t = []
-    for i, arg in enumerate(flat_args):
-        if isinstance(arg, torch.Tensor):
-            curr_specs_t.append(curr_specs[i])
-            tgt_specs_t.append(tgt_specs[i])
-        elif isinstance(arg, torch.SymInt):
-            assert curr_specs[i] is None
-            assert tgt_specs[i] is None
-        else:
-            raise ValueError("Unexpected local_map HOP argument")
-
-    assert len(curr_specs_t) == len(tgt_specs_t)
-    return curr_specs_t, tgt_specs_t
-
-
 class ApplyShardingInterpreter(torch.fx.Interpreter):
     def __init__(
         self,
@@ -167,10 +145,22 @@ class ApplyShardingInterpreter(torch.fx.Interpreter):
 
         flat_args, treespec = tree_flatten(args)
         flat_args_t = [x for x in flat_args if isinstance(x, torch.Tensor)]
-        if len(flat_args_t) < len(flat_args) and "local_map" in node.name:
-            curr_specs, tgt_specs = _filter_specs_for_local_map(
-                flat_args, curr_specs, tgt_specs
-            )
+        if len(flat_args_t) < len(flat_args) and isinstance(
+            target, torch._ops.HigherOrderOperator
+        ):
+            # HOPs have mixed arg types (tensors, GraphModules, ints, etc.).
+            # Filter specs to tensor-only entries matching flat_args_t.
+            filtered_nodes = []
+            filtered_curr = []
+            filtered_tgt = []
+            for n, cs, ts in zip(all_input_nodes, curr_specs, tgt_specs):
+                if ts is not None:
+                    filtered_nodes.append(n)
+                    filtered_curr.append(cs)
+                    filtered_tgt.append(ts)
+            all_input_nodes = filtered_nodes
+            curr_specs = filtered_curr
+            tgt_specs = filtered_tgt
 
         assert len(flat_args_t) == len(curr_specs) == len(tgt_specs)
         last_tgt_spec = None

--- a/autoparallel/apply_sharding.py
+++ b/autoparallel/apply_sharding.py
@@ -147,10 +147,8 @@ class ApplyShardingInterpreter(torch.fx.Interpreter):
 
         flat_args, treespec = tree_flatten(args)
         flat_args_t = [x for x in flat_args if isinstance(x, torch.Tensor)]
-        if len(flat_args_t) < len(flat_args) and isinstance(
-            target, torch._ops.HigherOrderOperator
-        ):
-            # HOPs have mixed arg types (tensors, GraphModules, ints, etc.).
+        if len(flat_args_t) < len(curr_specs):
+            # HOPs have mixed arg types (tensors, SymInts, etc.).
             # Filter specs to tensor-only entries matching flat_args_t.
             filtered_nodes = []
             filtered_curr = []

--- a/autoparallel/apply_sharding.py
+++ b/autoparallel/apply_sharding.py
@@ -75,7 +75,16 @@ class ApplyShardingInterpreter(torch.fx.Interpreter):
         # node.all_input_nodes deduplicates, but we need repeated nodes preserved.
         # Filter to only nodes with sharding entries — HOP submodule nodes
         # (GraphModules) are not in sharding_placement and should be skipped.
-        return [x for x in all_input_nodes(node) if x in self.sharding_placement]
+        result = []
+        for x in all_input_nodes(node):
+            if x in self.sharding_placement:
+                result.append(x)
+            else:
+                assert x.op == "get_attr", (
+                    f"Non-get_attr node {x} (op={x.op}) missing from "
+                    f"sharding_placement"
+                )
+        return result
 
     def _set_origin_and_target_device_order(self, node, curr_spec, tgt_spec):
         # shard_order should be automatically assigned once `placements` is set

--- a/autoparallel/graph_passes/graph_utils.py
+++ b/autoparallel/graph_passes/graph_utils.py
@@ -341,7 +341,7 @@ def build_param_derived_set(graph: torch.fx.Graph) -> set[torch.fx.Node]:
     """
     param_derived = set(get_param_nodes(graph))
     for node in graph.nodes:
-        inputs = all_input_nodes(node)
+        inputs = node.all_input_nodes
         if inputs and all(inp in param_derived for inp in inputs):
             param_derived.add(node)
     return param_derived

--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -87,6 +87,7 @@ from torch._functorch._aot_autograd.fx_utils import (
     get_plain_output_and_tangent_nodes,
 )
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
+from torch.distributed.tensor._op_schema import OpSpec, OpStrategy
 from torch.distributed.tensor.placement_types import Placement, Replicate, Shard
 from torch.utils._pytree import tree_map_only
 
@@ -195,19 +196,31 @@ class ShardingOptimizer:
         strats = {}
         for node in self.graph.nodes:
             if node.op in ("placeholder", "get_attr"):
-                strats[node] = _create_all_options(
-                    self.mesh, node.meta["val"].shape, tensor=node.meta["val"]
-                )
+                val = node.meta.get("val")
+                if isinstance(val, torch.Tensor):
+                    strats[node] = _create_all_options(self.mesh, val.shape, tensor=val)
+                else:
+                    # GraphModule submodules used by HOPs (e.g. flex_attention's
+                    # score_mod / mask_mod). Give them a single-option dummy
+                    # strategy so the ILP can reference them without crashing.
+                    strats[node] = OpStrategy(
+                        [
+                            OpSpec(
+                                output_specs=None, input_specs=[], redistribute_cost=[]
+                            )
+                        ]
+                    )
             elif node.op == "call_function":
                 # TODO: kwargs?
+                # Use .get() so HOP submodule nodes (not in strats) map to None.
                 user_strats = tree_map_only(
-                    torch.fx.Node, lambda x: strats[x], node.args
+                    torch.fx.Node, lambda x: strats.get(x), node.args
                 )
                 user_args = tree_map_only(
-                    torch.fx.Node, lambda x: x.meta["val"], node.args
+                    torch.fx.Node, lambda x: x.meta.get("val"), node.args
                 )
                 user_kwargs = tree_map_only(
-                    torch.fx.Node, lambda x: x.meta["val"], node.kwargs
+                    torch.fx.Node, lambda x: x.meta.get("val"), node.kwargs
                 )
                 strats[node] = get_placement_options_for_node(
                     self.mesh, node, user_strats, user_args, user_kwargs
@@ -254,6 +267,9 @@ class ShardingOptimizer:
         """Yield (argi, out_idx, inp_idx) for all valid strategy combinations."""
         op_strategy = self.strats[node]
         for argi in range(len(op_strategy.strategies[0].input_specs)):
+            # Skip None input_specs (e.g. GraphModule submodule args in HOPs).
+            if op_strategy.strategies[0].input_specs[argi] is None:
+                continue
             if constrain_arg is not None and argi != constrain_arg:
                 continue
             for out_idx, strategy in enumerate(op_strategy.strategies):
@@ -360,6 +376,10 @@ class ShardingOptimizer:
                     continue
 
                 num_args = len(op_strategy.strategies[0].input_specs)
+                if num_args == 0:
+                    # Nodes with no inputs (e.g. GraphModule submodules for
+                    # HOPs) have no decision variables — skip.
+                    continue
 
                 for out_idx, output_strategy in enumerate(op_strategy.strategies):
                     if is_linked:
@@ -377,6 +397,8 @@ class ShardingOptimizer:
                     for argi, redist_costs in enumerate(
                         output_strategy.redistribute_cost
                     ):
+                        if output_strategy.input_specs[argi] is None:
+                            continue
                         for inp_idx, default_comm_cost in enumerate(redist_costs):
                             key = (node_idx, argi, out_idx, inp_idx)
 
@@ -552,6 +574,10 @@ class ShardingOptimizer:
             eqs_per_arg = [[] for _ in self._all_input_nodes(node)]
             for (argi, out_idx), value in vars_per_output.items():
                 eqs_per_arg[argi].append(pulp.lpSum(value))
+            # Filter to args that have variables (skip None input_specs).
+            eqs_per_arg = [eq for eq in eqs_per_arg if eq]
+            if len(eqs_per_arg) <= 1:
+                continue
             arg0 = eqs_per_arg[0]
             for arg_eqs in eqs_per_arg[1:]:
                 assert len(arg0) == len(arg_eqs)
@@ -750,7 +776,15 @@ class ShardingOptimizer:
                 dvs[0].strategy == dv.strategy for dv in dvs
             ), f"{[dv.var for dv in dvs]}: {[str(dv.strategy) for dv in dvs]}"
 
-        return {node: dvs[0].strategy for node, dvs in selected_by_node.items()}
+        solution = {node: dvs[0].strategy for node, dvs in selected_by_node.items()}
+
+        # Nodes without decision variables (e.g. GraphModule submodules for
+        # HOPs) need dummy entries so apply_sharding can look them up.
+        for node, strat in self.strats.items():
+            if node not in solution and node.op != "output":
+                solution[node] = strat.strategies[0]
+
+        return solution
 
     def get_solution(self, verbose=False):
         t0 = time.perf_counter()

--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -198,8 +198,15 @@ class ShardingOptimizer:
                 val = node.meta.get("val")
                 if isinstance(val, torch.Tensor):
                     strats[node] = _create_all_options(self.mesh, val.shape, tensor=val)
-                # else: GraphModule submodules used by HOPs — not added to
-                # strats, invisible to the ILP. _all_input_nodes filters them.
+                else:
+                    # GraphModule submodules used by HOPs — not added to
+                    # strats, invisible to the ILP. _all_input_nodes filters
+                    # them. Guard: every skipped node must be consumed by a HOP.
+                    assert any(
+                        isinstance(u.target, torch._ops.HigherOrderOperator)
+                        or "local_map" in u.name
+                        for u in node.users
+                    ), f"Non-tensor get_attr {node} is not used by a HOP"
             elif node.op == "call_function":
                 # TODO: kwargs?
                 # Use .get() so HOP submodule nodes (not in strats) map to None.
@@ -255,7 +262,15 @@ class ShardingOptimizer:
         nodes (GraphModules without tensor val) are invisible to the ILP.
         """
         # TODO: add kwargs?
-        return [x for x in all_input_nodes(node) if x in self.strats]
+        result = []
+        for x in all_input_nodes(node):
+            if x in self.strats:
+                result.append(x)
+            else:
+                assert (
+                    x.op == "get_attr"
+                ), f"Non-get_attr node {x} (op={x.op}) missing from strats"
+        return result
 
     def walk_over_options(self, node, constrain_arg=None):
         """Yield (argi, out_idx, inp_idx) for all valid strategy combinations."""
@@ -630,8 +645,16 @@ class ShardingOptimizer:
                     )
 
                 # Skip edges where the consumer arg has no sharding decision
-                # (e.g. None input_specs for HOP submodule / SymInt args).
+                # (e.g. None input_specs for HOP SymInt args).
                 if not vars_consumer or not vars_producer:
+                    user_strat = self.strats[user]
+                    assert (
+                        user_argi < len(user_strat.strategies[0].input_specs)
+                        and user_strat.strategies[0].input_specs[user_argi] is None
+                    ), (
+                        f"Missing variables for non-None input_spec at "
+                        f"{user}[{user_argi}]"
+                    )
                     continue
 
                 assert (

--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -607,8 +607,12 @@ class ShardingOptimizer:
                 # the root-to-root edge already covers this.
                 if producer_is_linked and user_idx in self._cluster_linked_node_idxs:
                     continue
-                user_argi = [i for i, n in enumerate(user.all_input_nodes) if n == node]
-                assert len(user_argi) == 1
+                user_argi = [
+                    i for i, n in enumerate(self._all_input_nodes(user)) if n == node
+                ]
+                assert len(user_argi) >= 1
+                # Use the first matching arg; the same-output-across-args
+                # constraint already ensures all args agree.
                 user_argi = user_argi[0]
 
                 vars_producer = self._collect_vars(
@@ -634,6 +638,11 @@ class ShardingOptimizer:
                         group_by="inp_idx",
                         resolve_clusters=True,
                     )
+
+                # Skip edges where the consumer arg has no sharding decision
+                # (e.g. None input_specs for HOP submodule / SymInt args).
+                if not vars_consumer or not vars_producer:
+                    continue
 
                 assert (
                     vars_producer.keys() == vars_consumer.keys()

--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -87,7 +87,6 @@ from torch._functorch._aot_autograd.fx_utils import (
     get_plain_output_and_tangent_nodes,
 )
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
-from torch.distributed.tensor._op_schema import OpSpec, OpStrategy
 from torch.distributed.tensor.placement_types import Placement, Replicate, Shard
 from torch.utils._pytree import tree_map_only
 
@@ -199,17 +198,8 @@ class ShardingOptimizer:
                 val = node.meta.get("val")
                 if isinstance(val, torch.Tensor):
                     strats[node] = _create_all_options(self.mesh, val.shape, tensor=val)
-                else:
-                    # GraphModule submodules used by HOPs (e.g. flex_attention's
-                    # score_mod / mask_mod). Give them a single-option dummy
-                    # strategy so the ILP can reference them without crashing.
-                    strats[node] = OpStrategy(
-                        [
-                            OpSpec(
-                                output_specs=None, input_specs=[], redistribute_cost=[]
-                            )
-                        ]
-                    )
+                # else: GraphModule submodules used by HOPs — not added to
+                # strats, invisible to the ILP. _all_input_nodes filters them.
             elif node.op == "call_function":
                 # TODO: kwargs?
                 # Use .get() so HOP submodule nodes (not in strats) map to None.
@@ -259,17 +249,20 @@ class ShardingOptimizer:
                         )
 
     def _all_input_nodes(self, node):
-        """Variant of node.all_input_nodes that preserves duplicate nodes."""
+        """Variant of node.all_input_nodes that preserves duplicate nodes.
+
+        Filters to only nodes present in self.strats so that HOP submodule
+        nodes (GraphModules without tensor val) are invisible to the ILP.
+        """
         # TODO: add kwargs?
-        return all_input_nodes(node)
+        return [x for x in all_input_nodes(node) if x in self.strats]
 
     def walk_over_options(self, node, constrain_arg=None):
         """Yield (argi, out_idx, inp_idx) for all valid strategy combinations."""
+        if node not in self.strats:
+            return
         op_strategy = self.strats[node]
         for argi in range(len(op_strategy.strategies[0].input_specs)):
-            # Skip None input_specs (e.g. GraphModule submodule args in HOPs).
-            if op_strategy.strategies[0].input_specs[argi] is None:
-                continue
             if constrain_arg is not None and argi != constrain_arg:
                 continue
             for out_idx, strategy in enumerate(op_strategy.strategies):
@@ -285,9 +278,10 @@ class ShardingOptimizer:
         """
         # Map each key to its canonical root key
         root_for_key = {}
-        for node_idx, (node, _) in enumerate(self.strats.items()):
+        for node, _ in self.strats.items():
             if node.op == "output":
                 continue
+            node_idx = self.node_map[node]
             for argi, out_idx, inp_idx in self.walk_over_options(node):
                 key = (node_idx, argi, out_idx, inp_idx)
                 root_for_key[key] = self.cluster_links.get(key, key)
@@ -364,11 +358,13 @@ class ShardingOptimizer:
         n_cluster_copied = 0
 
         decision_vars = {}
-        strats_items = list(enumerate(self.strats.items()))
+        strats_items = [
+            (self.node_map[node], node, strat) for node, strat in self.strats.items()
+        ]
 
         # Two passes: root nodes first (so their entries exist), then linked nodes.
         for is_linked_pass in (False, True):
-            for node_idx, (node, op_strategy) in strats_items:
+            for node_idx, node, op_strategy in strats_items:
                 if node.op == "output":
                     continue
                 is_linked = node_idx in self._cluster_linked_node_idxs
@@ -376,10 +372,6 @@ class ShardingOptimizer:
                     continue
 
                 num_args = len(op_strategy.strategies[0].input_specs)
-                if num_args == 0:
-                    # Nodes with no inputs (e.g. GraphModule submodules for
-                    # HOPs) have no decision variables — skip.
-                    continue
 
                 for out_idx, output_strategy in enumerate(op_strategy.strategies):
                     if is_linked:
@@ -397,8 +389,6 @@ class ShardingOptimizer:
                     for argi, redist_costs in enumerate(
                         output_strategy.redistribute_cost
                     ):
-                        if output_strategy.input_specs[argi] is None:
-                            continue
                         for inp_idx, default_comm_cost in enumerate(redist_costs):
                             key = (node_idx, argi, out_idx, inp_idx)
 
@@ -540,6 +530,8 @@ class ShardingOptimizer:
         for node_idx, node in enumerate(self.graph.nodes):
             if node.op not in {"placeholder", "call_function", "get_attr"}:
                 continue
+            if node not in self.strats:
+                continue
             if node_idx in self._cluster_linked_node_idxs:
                 continue
             arg_vars = {}
@@ -574,10 +566,6 @@ class ShardingOptimizer:
             eqs_per_arg = [[] for _ in self._all_input_nodes(node)]
             for (argi, out_idx), value in vars_per_output.items():
                 eqs_per_arg[argi].append(pulp.lpSum(value))
-            # Filter to args that have variables (skip None input_specs).
-            eqs_per_arg = [eq for eq in eqs_per_arg if eq]
-            if len(eqs_per_arg) <= 1:
-                continue
             arg0 = eqs_per_arg[0]
             for arg_eqs in eqs_per_arg[1:]:
                 assert len(arg0) == len(arg_eqs)
@@ -595,6 +583,8 @@ class ShardingOptimizer:
         """
         for node_idx, node in enumerate(self.graph.nodes):
             if node.op == "output":
+                continue
+            if node not in self.strats:
                 continue
             producer_is_linked = node_idx in self._cluster_linked_node_idxs
             # All args agree on the same output (ensured by consistency constraint),
@@ -785,15 +775,7 @@ class ShardingOptimizer:
                 dvs[0].strategy == dv.strategy for dv in dvs
             ), f"{[dv.var for dv in dvs]}: {[str(dv.strategy) for dv in dvs]}"
 
-        solution = {node: dvs[0].strategy for node, dvs in selected_by_node.items()}
-
-        # Nodes without decision variables (e.g. GraphModule submodules for
-        # HOPs) need dummy entries so apply_sharding can look them up.
-        for node, strat in self.strats.items():
-            if node not in solution and node.op != "output":
-                solution[node] = strat.strategies[0]
-
-        return solution
+        return {node: dvs[0].strategy for node, dvs in selected_by_node.items()}
 
     def get_solution(self, verbose=False):
         t0 = time.perf_counter()

--- a/autoparallel/shardings/placement_options.py
+++ b/autoparallel/shardings/placement_options.py
@@ -529,16 +529,15 @@ def get_flex_attention_placement_option(mesh, specs, user_args, node):
     flat_specs, _ = tree_flatten(specs)
     flat_uargs, _ = tree_flatten(user_args)
 
-    # Keep only FX Node entries (tensor nodes AND GraphModule nodes).
+    # Keep only FX Node entries that have strategies (skip GraphModule
+    # submodules which are not in strats and invisible to the ILP).
     node_specs = []
     node_uargs = []
-    is_tensor_input = []
     is_other_buffer = []
     for orig, spec, uarg in zip(flat_orig, flat_specs, flat_uargs):
-        if isinstance(orig, torch.fx.Node):
+        if isinstance(orig, torch.fx.Node) and isinstance(uarg, torch.Tensor):
             node_specs.append(spec)
             node_uargs.append(uarg)
-            is_tensor_input.append(isinstance(uarg, torch.Tensor))
             is_other_buffer.append(orig in other_buffer_nodes)
 
     # Q determines the reference batch and head sizes.
@@ -576,13 +575,10 @@ def get_flex_attention_placement_option(mesh, specs, user_args, node):
         placement = tuple(placement)
 
         in_specs = []
-        for uarg, producer_strat, is_tensor, is_buf in zip(
-            node_uargs, node_specs, is_tensor_input, is_other_buffer
+        for uarg, producer_strat, is_buf in zip(
+            node_uargs, node_specs, is_other_buffer
         ):
-            if not is_tensor:
-                # GraphModule submodule — no tensor to shard.
-                in_specs.append(None)
-            elif is_buf:
+            if is_buf:
                 # score_mod / mask_mod other_buffers — always replicate since
                 # we don't know how score_mod indexes into them.
                 in_specs.append(
@@ -623,16 +619,10 @@ def get_flex_attention_placement_option(mesh, specs, user_args, node):
             else:
                 out_specs.append(None)
 
-        redistribute_costs = []
-        for producer_strat, spec in zip(node_specs, in_specs):
-            if spec is None:
-                redistribute_costs.append(
-                    generate_dummy_redistribute_costs(producer_strat)
-                )
-            else:
-                redistribute_costs.append(
-                    generate_redistribute_costs(producer_strat, spec)
-                )
+        redistribute_costs = [
+            generate_redistribute_costs(producer_strat, spec)
+            for producer_strat, spec in zip(node_specs, in_specs)
+        ]
 
         strategies.append(
             OpSpec(

--- a/autoparallel/shardings/placement_options.py
+++ b/autoparallel/shardings/placement_options.py
@@ -566,7 +566,7 @@ def get_flex_attention_placement_option(mesh, specs, user_args, node):
 
         out_specs = []
         for out in output_val:
-            if isinstance(out, torch.Tensor) and is_attention_tensor(out):
+            if isinstance(out, torch.Tensor):
                 out_specs.append(
                     DTensorSpec(
                         mesh=mesh,

--- a/autoparallel/shardings/placement_options.py
+++ b/autoparallel/shardings/placement_options.py
@@ -499,6 +499,32 @@ def get_flex_attention_placement_option(mesh, specs, user_args, node):
     combinations of {Replicate, Shard(0), Shard(1)} across mesh dimensions.
     Block-mask and other auxiliary tensors are always replicated.
     """
+    # Collect FX Nodes from score_mod_other_buffers and mask_mod_other_buffers.
+    # These must always be replicated since score_mod can index them arbitrarily.
+    # We identify them by parameter name from the HOP's fake-kernel signature.
+    other_buffer_nodes: set[torch.fx.Node] = set()
+    _BUFFER_PARAM_NAMES = ("score_mod_other_buffers", "mask_mod_other_buffers")
+    import inspect
+
+    from torch._higher_order_ops.flex_attention import (
+        flex_attention_backward_fake_tensor_mode,
+        flex_attention_fake_impl,
+    )
+
+    fake_impl = (
+        flex_attention_fake_impl
+        if node.target.name() == "flex_attention"
+        else flex_attention_backward_fake_tensor_mode
+    )
+    params = list(inspect.signature(fake_impl).parameters.keys())
+    for name in _BUFFER_PARAM_NAMES:
+        if name in params:
+            idx = params.index(name)
+            if idx < len(node.args) and isinstance(node.args[idx], (tuple, list)):
+                for item in tree_flatten(node.args[idx])[0]:
+                    if isinstance(item, torch.fx.Node):
+                        other_buffer_nodes.add(item)
+
     flat_orig, _ = tree_flatten(node.args)
     flat_specs, _ = tree_flatten(specs)
     flat_uargs, _ = tree_flatten(user_args)
@@ -507,11 +533,13 @@ def get_flex_attention_placement_option(mesh, specs, user_args, node):
     node_specs = []
     node_uargs = []
     is_tensor_input = []
+    is_other_buffer = []
     for orig, spec, uarg in zip(flat_orig, flat_specs, flat_uargs):
         if isinstance(orig, torch.fx.Node):
             node_specs.append(spec)
             node_uargs.append(uarg)
             is_tensor_input.append(isinstance(uarg, torch.Tensor))
+            is_other_buffer.append(orig in other_buffer_nodes)
 
     # Q determines the reference batch and head sizes.
     q_val = node.args[0].meta["val"]
@@ -548,12 +576,22 @@ def get_flex_attention_placement_option(mesh, specs, user_args, node):
         placement = tuple(placement)
 
         in_specs = []
-        for uarg, producer_strat, is_tensor in zip(
-            node_uargs, node_specs, is_tensor_input
+        for uarg, producer_strat, is_tensor, is_buf in zip(
+            node_uargs, node_specs, is_tensor_input, is_other_buffer
         ):
             if not is_tensor:
                 # GraphModule submodule — no tensor to shard.
                 in_specs.append(None)
+            elif is_buf:
+                # score_mod / mask_mod other_buffers — always replicate since
+                # we don't know how score_mod indexes into them.
+                in_specs.append(
+                    DTensorSpec(
+                        mesh=mesh,
+                        placements=replicated,
+                        tensor_meta=TensorMeta(uarg.shape, uarg.stride(), uarg.dtype),
+                    )
+                )
             elif uarg.ndim >= 2:
                 in_specs.append(
                     DTensorSpec(

--- a/autoparallel/shardings/placement_options.py
+++ b/autoparallel/shardings/placement_options.py
@@ -545,17 +545,25 @@ def get_flex_attention_placement_option(mesh, specs, user_args, node):
     B, H = q_val.shape[0], q_val.shape[1]
 
     def tensor_placement(t, placement):
-        """Compute per-tensor placement, replacing Shard dims that don't match
-        the reference size with Replicate (e.g. block_mask with B=1)."""
+        """Compute per-tensor placement, replacing Shard dims that can't be
+        validly sharded with Replicate.
+
+        A Shard(d) placement is valid only if:
+        - t.shape[d] > 1 (can meaningfully split)
+        - ref_size % t.shape[d] == 0 (GQA: Q heads divide evenly by KV heads)
+        - t.shape[d] % mesh_dim_size == 0 (tensor dim splits evenly across devices)
+        """
         dim_to_ref = {0: B, 1: H}
         adjusted = []
-        for p in placement:
-            if (
-                p.is_shard()
-                and p.dim in dim_to_ref
-                and t.shape[p.dim] != dim_to_ref[p.dim]
-            ):
-                adjusted.append(Replicate())
+        for mesh_dim, p in enumerate(placement):
+            if p.is_shard() and p.dim in dim_to_ref:
+                t_size = t.shape[p.dim]
+                ref_size = dim_to_ref[p.dim]
+                mesh_dim_size = mesh.shape[mesh_dim]
+                if t_size <= 1 or ref_size % t_size != 0 or t_size % mesh_dim_size != 0:
+                    adjusted.append(Replicate())
+                else:
+                    adjusted.append(p)
             else:
                 adjusted.append(p)
         return tuple(adjusted)

--- a/autoparallel/shardings/placement_options.py
+++ b/autoparallel/shardings/placement_options.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import collections
+import itertools
 import logging
 import operator
 import time
@@ -23,7 +24,7 @@ from torch.distributed.tensor._op_schema import (
     TupleStrategy,
 )
 from torch.distributed.tensor._ops.utils import generate_redistribute_costs
-from torch.distributed.tensor.placement_types import Replicate
+from torch.distributed.tensor.placement_types import Replicate, Shard
 from torch.utils._pytree import tree_flatten, tree_map_only
 
 from autoparallel.shardings.propagation_rules import generate_dummy_redistribute_costs
@@ -483,12 +484,129 @@ def get_local_map_placement_option(
     )
 
 
+def _is_flex_attention_hop(node):
+    target = node.target
+    return isinstance(target, torch._ops.HigherOrderOperator) and target.name() in (
+        "flex_attention",
+        "flex_attention_backward",
+    )
+
+
+def get_flex_attention_placement_option(mesh, specs, user_args, node):
+    """Build OpStrategy for flex_attention / flex_attention_backward HOPs.
+
+    Attention is independent per (batch, head) pair, so we enumerate all
+    combinations of {Replicate, Shard(0), Shard(1)} across mesh dimensions.
+    Block-mask and other auxiliary tensors are always replicated.
+    """
+    flat_orig, _ = tree_flatten(node.args)
+    flat_specs, _ = tree_flatten(specs)
+    flat_uargs, _ = tree_flatten(user_args)
+
+    # Keep only FX Node entries (tensor nodes AND GraphModule nodes).
+    node_specs = []
+    node_uargs = []
+    is_tensor_input = []
+    for orig, spec, uarg in zip(flat_orig, flat_specs, flat_uargs):
+        if isinstance(orig, torch.fx.Node):
+            node_specs.append(spec)
+            node_uargs.append(uarg)
+            is_tensor_input.append(isinstance(uarg, torch.Tensor))
+
+    # Attention tensors have the same batch (dim 0) and heads (dim 1) as Q.
+    q_val = node.args[0].meta["val"]
+    B, H = q_val.shape[0], q_val.shape[1]
+
+    def is_attention_tensor(t):
+        return (
+            isinstance(t, torch.Tensor)
+            and t.ndim >= 2
+            and t.shape[0] == B
+            and t.shape[1] == H
+        )
+
+    replicated = tuple(Replicate() for _ in range(mesh.ndim))
+
+    # Valid per-mesh-dim placements for attention tensors.
+    per_dim_options = [Replicate(), Shard(0), Shard(1)]
+    all_placements = list(itertools.product(per_dim_options, repeat=mesh.ndim))
+
+    # Build output specs structure. flex_attention returns a tuple.
+    output_val = node.meta["val"]
+    assert isinstance(output_val, (tuple, list))
+
+    strategies = []
+    for placement in all_placements:
+        placement = tuple(placement)
+
+        in_specs = []
+        for uarg, producer_strat, is_tensor in zip(
+            node_uargs, node_specs, is_tensor_input
+        ):
+            if not is_tensor:
+                # GraphModule submodule — no tensor to shard.
+                in_specs.append(None)
+            elif is_attention_tensor(uarg):
+                in_specs.append(
+                    DTensorSpec(
+                        mesh=mesh,
+                        placements=placement,
+                        tensor_meta=TensorMeta(uarg.shape, uarg.stride(), uarg.dtype),
+                    )
+                )
+            else:
+                # Auxiliary tensor (block mask etc.) — always replicate.
+                in_specs.append(
+                    DTensorSpec(
+                        mesh=mesh,
+                        placements=replicated,
+                        tensor_meta=TensorMeta(uarg.shape, uarg.stride(), uarg.dtype),
+                    )
+                )
+
+        out_specs = []
+        for out in output_val:
+            if isinstance(out, torch.Tensor) and is_attention_tensor(out):
+                out_specs.append(
+                    DTensorSpec(
+                        mesh=mesh,
+                        placements=placement,
+                        tensor_meta=TensorMeta(out.shape, out.stride(), out.dtype),
+                    )
+                )
+            else:
+                out_specs.append(None)
+
+        redistribute_costs = []
+        for producer_strat, spec in zip(node_specs, in_specs):
+            if spec is None:
+                redistribute_costs.append(
+                    generate_dummy_redistribute_costs(producer_strat)
+                )
+            else:
+                redistribute_costs.append(
+                    generate_redistribute_costs(producer_strat, spec)
+                )
+
+        strategies.append(
+            OpSpec(
+                output_specs=tuple(out_specs),
+                input_specs=tuple(in_specs),
+                redistribute_cost=redistribute_costs,
+            )
+        )
+
+    return OpStrategy(strategies)
+
+
 def get_placement_options_for_node(mesh, node, specs, user_args, user_kwargs):
     if local_map_kwargs := node.meta.get("local_map_kwargs", {}):
         assert not user_kwargs
         return get_local_map_placement_option(
             mesh, specs, user_args, node, local_map_kwargs
         )
+    if _is_flex_attention_hop(node):
+        return get_flex_attention_placement_option(mesh, specs, user_args, node)
     return get_placement_options(mesh, node.target, specs, user_args, user_kwargs)
 
 

--- a/autoparallel/shardings/placement_options.py
+++ b/autoparallel/shardings/placement_options.py
@@ -513,17 +513,25 @@ def get_flex_attention_placement_option(mesh, specs, user_args, node):
             node_uargs.append(uarg)
             is_tensor_input.append(isinstance(uarg, torch.Tensor))
 
-    # Attention tensors have the same batch (dim 0) and heads (dim 1) as Q.
+    # Q determines the reference batch and head sizes.
     q_val = node.args[0].meta["val"]
     B, H = q_val.shape[0], q_val.shape[1]
 
-    def is_attention_tensor(t):
-        return (
-            isinstance(t, torch.Tensor)
-            and t.ndim >= 2
-            and t.shape[0] == B
-            and t.shape[1] == H
-        )
+    def tensor_placement(t, placement):
+        """Compute per-tensor placement, replacing Shard dims that don't match
+        the reference size with Replicate (e.g. block_mask with B=1)."""
+        dim_to_ref = {0: B, 1: H}
+        adjusted = []
+        for p in placement:
+            if (
+                p.is_shard()
+                and p.dim in dim_to_ref
+                and t.shape[p.dim] != dim_to_ref[p.dim]
+            ):
+                adjusted.append(Replicate())
+            else:
+                adjusted.append(p)
+        return tuple(adjusted)
 
     replicated = tuple(Replicate() for _ in range(mesh.ndim))
 
@@ -546,16 +554,16 @@ def get_flex_attention_placement_option(mesh, specs, user_args, node):
             if not is_tensor:
                 # GraphModule submodule — no tensor to shard.
                 in_specs.append(None)
-            elif is_attention_tensor(uarg):
+            elif uarg.ndim >= 2:
                 in_specs.append(
                     DTensorSpec(
                         mesh=mesh,
-                        placements=placement,
+                        placements=tensor_placement(uarg, placement),
                         tensor_meta=TensorMeta(uarg.shape, uarg.stride(), uarg.dtype),
                     )
                 )
             else:
-                # Auxiliary tensor (block mask etc.) — always replicate.
+                # Scalar or 1-D auxiliary tensor — always replicate.
                 in_specs.append(
                     DTensorSpec(
                         mesh=mesh,
@@ -570,7 +578,7 @@ def get_flex_attention_placement_option(mesh, specs, user_args, node):
                 out_specs.append(
                     DTensorSpec(
                         mesh=mesh,
-                        placements=placement,
+                        placements=tensor_placement(out, placement),
                         tensor_meta=TensorMeta(out.shape, out.stride(), out.dtype),
                     )
                 )

--- a/tests/test_apply_sharding.py
+++ b/tests/test_apply_sharding.py
@@ -3,15 +3,9 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 
-import pytest
-import torch
 from torch.distributed.tensor._dtensor_spec import ShardOrderEntry
-from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
-from autoparallel.apply_sharding import (
-    _compute_shard_order,
-    _filter_specs_for_local_map,
-)
+from autoparallel.apply_sharding import _compute_shard_order
 
 
 class TestComputeShardOrder:
@@ -44,41 +38,3 @@ class TestComputeShardOrder:
     def test_empty(self):
         assert _compute_shard_order((), reverse=False) == ()
         assert _compute_shard_order((), reverse=True) == ()
-
-
-def _make_symint(val: int) -> torch.SymInt:
-    shape_env = ShapeEnv()
-    from torch._dynamo.source import ConstantSource
-
-    sym = shape_env.create_symbol(val, source=ConstantSource(source_name=f"s{val}"))
-    return shape_env.create_symintnode(sym, hint=val)
-
-
-class TestFilterSpecsForLocalMap:
-    def test_tensors_only(self):
-        flat_args = [torch.tensor(1.0), torch.tensor(2.0)]
-        curr_specs = ["spec_a", "spec_b"]
-        tgt_specs = ["spec_c", "spec_d"]
-        c, t = _filter_specs_for_local_map(flat_args, curr_specs, tgt_specs)
-        assert c == ["spec_a", "spec_b"]
-        assert t == ["spec_c", "spec_d"]
-
-    def test_mixed_tensor_and_symint(self):
-        s = _make_symint(3)
-        flat_args = [torch.tensor(1.0), s, torch.tensor(2.0)]
-        curr_specs = ["spec_a", None, "spec_b"]
-        tgt_specs = ["spec_c", None, "spec_d"]
-        c, t = _filter_specs_for_local_map(flat_args, curr_specs, tgt_specs)
-        assert c == ["spec_a", "spec_b"]
-        assert t == ["spec_c", "spec_d"]
-
-    def test_symint_with_non_none_spec_raises(self):
-        s = _make_symint(3)
-        flat_args = [s]
-        with pytest.raises(AssertionError):
-            _filter_specs_for_local_map(flat_args, ["spec_a"], ["spec_b"])
-
-    def test_unexpected_type_raises(self):
-        flat_args = [42]
-        with pytest.raises(ValueError, match="Unexpected local_map HOP argument"):
-            _filter_specs_for_local_map(flat_args, [None], [None])

--- a/tests/test_flex_attention.py
+++ b/tests/test_flex_attention.py
@@ -242,14 +242,14 @@ def _out_shardings(mesh):
     return tuple([Shard(0)] + [Replicate()] * (mesh.ndim - 1))
 
 
-def _run_auto_parallel(model, mesh, dim=DIM):
+def _run_auto_parallel(model, mesh, dim=DIM, compile=False):
     x = _make_input(mesh, dim)
     parallel_model = auto_parallel(
         model,
         mesh,
         sample_inputs=(x,),
         out_shardings=_out_shardings(mesh),
-        compile=False,
+        compile=compile,
     )
     assert parallel_model is not None
     return parallel_model
@@ -387,6 +387,53 @@ def test_flex_attention_gqa_2d(device_mesh_2d):
     _run_auto_parallel(model, device_mesh_2d)
 
 
+def test_flex_attention_gqa_head_sharding(device_mesh_2d):
+    """Verify GQA allows Shard(1) on KV heads when Hq % Hkv == 0.
+
+    With Hq=8 and Hkv=2, sharding on the head dim is valid since each
+    device gets a proportional slice of both Q (8/N) and KV (2/N) heads.
+    """
+    n_kv_heads = 2
+    mesh = device_mesh_2d
+
+    from autoparallel.api import AutoParallel
+    from autoparallel.input_validation import (
+        _extract_input_info,
+        _flatten_out_shardings,
+        _make_input_fn,
+    )
+
+    with torch.device("meta"):
+        model = FlexAttnGQAModel(DIM, N_HEADS, n_kv_heads)
+
+    x = _make_input(mesh, DIM)
+    shapes, dtypes, input_placements, treespec = _extract_input_info((x,), mesh)
+    input_fn = _make_input_fn(shapes, dtypes, treespec)
+    output_placements = _flatten_out_shardings(_out_shardings(mesh))
+
+    with AutoParallel(model, input_fn, mesh, compile=False) as autop:
+        autop.add_input_constraints(input_placements)
+        autop.add_output_constraints(output_placements)
+
+        strats = autop.sharding_optimizer.strats
+        for node in autop.gm.graph.nodes:
+            if node.op != "call_function":
+                continue
+            if not isinstance(node.target, torch._ops.HigherOrderOperator):
+                continue
+            if "backward" in node.target.name():
+                continue
+
+            strat = strats[node]
+            # Q has Hq=8, K/V have Hkv=2. Since 8 % 2 == 0, Shard(1) should
+            # be available for both Q and KV inputs.
+            has_head_shard = any(
+                any(p == Shard(1) for p in s.input_specs[0].placements)
+                for s in strat.strategies
+            )
+            assert has_head_shard, "GQA with Hq=8, Hkv=2 should allow Shard(1) on heads"
+
+
 def test_flex_attention_score_mod_block_mask(device_mesh_1d):
     model = FlexAttnScoreModBlockMaskModel(DIM, N_HEADS, SEQLEN)
     model = model.to("meta")
@@ -460,3 +507,18 @@ def test_flex_attention_other_buffers_replicated(device_mesh_1d):
                             f"(shape [{B}, {H}]) should be Replicate "
                             f"but got {ispec.placements}"
                         )
+
+
+def test_flex_attention_compile(device_mesh_1d):
+    """Smoke test with compile=True to verify the parallel graph is compilable."""
+    with torch.device("meta"):
+        model = FlexAttnModel(DIM, N_HEADS)
+    _run_auto_parallel(model, device_mesh_1d, compile=True)
+
+
+def test_flex_attention_gqa_compile(device_mesh_1d):
+    """Smoke test GQA with compile=True."""
+    n_kv_heads = 2
+    with torch.device("meta"):
+        model = FlexAttnGQAModel(DIM, N_HEADS, n_kv_heads)
+    _run_auto_parallel(model, device_mesh_1d, compile=True)

--- a/tests/test_flex_attention.py
+++ b/tests/test_flex_attention.py
@@ -7,10 +7,16 @@ import pytest
 import torch
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import Replicate, Shard
-from torch.nn.attention.flex_attention import flex_attention
+from torch.nn.attention.flex_attention import create_block_mask, flex_attention
 
 from autoparallel.api import auto_parallel
 from autoparallel.shardings.placement_options import reset_placement_options_cache
+
+DIM = 128
+N_HEADS = 8
+HEAD_DIM = DIM // N_HEADS
+LOCAL_BS = 64
+SEQLEN = 16
 
 
 class FlexAttnModel(torch.nn.Module):
@@ -34,6 +40,146 @@ class FlexAttnModel(torch.nn.Module):
         return self.wo(out)
 
 
+class FlexAttnScoreModModel(torch.nn.Module):
+    """Model with a custom score_mod (ALiBi-style position bias)."""
+
+    def __init__(self, dim, n_heads):
+        super().__init__()
+        self.dim = dim
+        self.n_heads = n_heads
+        self.head_dim = dim // n_heads
+        self.wq = torch.nn.Linear(dim, dim, bias=False)
+        self.wk = torch.nn.Linear(dim, dim, bias=False)
+        self.wv = torch.nn.Linear(dim, dim, bias=False)
+        self.wo = torch.nn.Linear(dim, dim, bias=False)
+
+    def forward(self, x):
+        bsz, seqlen, _ = x.shape
+        q = self.wq(x).view(bsz, seqlen, self.n_heads, self.head_dim).transpose(1, 2)
+        k = self.wk(x).view(bsz, seqlen, self.n_heads, self.head_dim).transpose(1, 2)
+        v = self.wv(x).view(bsz, seqlen, self.n_heads, self.head_dim).transpose(1, 2)
+
+        def alibi(score, batch, head, q_idx, kv_idx):
+            return score - (q_idx - kv_idx).abs().float()
+
+        out = flex_attention(q, k, v, score_mod=alibi)
+        out = out.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
+        return self.wo(out)
+
+
+class FlexAttnBlockMaskModel(torch.nn.Module):
+    """Model with a causal block_mask."""
+
+    def __init__(self, dim, n_heads, seqlen):
+        super().__init__()
+        self.dim = dim
+        self.n_heads = n_heads
+        self.head_dim = dim // n_heads
+        self.wq = torch.nn.Linear(dim, dim, bias=False)
+        self.wk = torch.nn.Linear(dim, dim, bias=False)
+        self.wv = torch.nn.Linear(dim, dim, bias=False)
+        self.wo = torch.nn.Linear(dim, dim, bias=False)
+
+        def causal(b, h, q_idx, kv_idx):
+            return q_idx >= kv_idx
+
+        self.block_mask = create_block_mask(
+            causal, B=None, H=None, Q_LEN=seqlen, KV_LEN=seqlen, device="cuda"
+        )
+
+    def forward(self, x):
+        bsz, seqlen, _ = x.shape
+        q = self.wq(x).view(bsz, seqlen, self.n_heads, self.head_dim).transpose(1, 2)
+        k = self.wk(x).view(bsz, seqlen, self.n_heads, self.head_dim).transpose(1, 2)
+        v = self.wv(x).view(bsz, seqlen, self.n_heads, self.head_dim).transpose(1, 2)
+        out = flex_attention(q, k, v, block_mask=self.block_mask)
+        out = out.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
+        return self.wo(out)
+
+
+class FlexAttnScaleModel(torch.nn.Module):
+    """Model with explicit scale parameter."""
+
+    def __init__(self, dim, n_heads):
+        super().__init__()
+        self.dim = dim
+        self.n_heads = n_heads
+        self.head_dim = dim // n_heads
+        self.wq = torch.nn.Linear(dim, dim, bias=False)
+        self.wk = torch.nn.Linear(dim, dim, bias=False)
+        self.wv = torch.nn.Linear(dim, dim, bias=False)
+        self.wo = torch.nn.Linear(dim, dim, bias=False)
+
+    def forward(self, x):
+        bsz, seqlen, _ = x.shape
+        q = self.wq(x).view(bsz, seqlen, self.n_heads, self.head_dim).transpose(1, 2)
+        k = self.wk(x).view(bsz, seqlen, self.n_heads, self.head_dim).transpose(1, 2)
+        v = self.wv(x).view(bsz, seqlen, self.n_heads, self.head_dim).transpose(1, 2)
+        out = flex_attention(q, k, v, scale=0.5)
+        out = out.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
+        return self.wo(out)
+
+
+class FlexAttnGQAModel(torch.nn.Module):
+    """Model with Grouped Query Attention (fewer KV heads than Q heads)."""
+
+    def __init__(self, dim, n_heads, n_kv_heads):
+        super().__init__()
+        self.dim = dim
+        self.n_heads = n_heads
+        self.n_kv_heads = n_kv_heads
+        self.head_dim = dim // n_heads
+        self.wq = torch.nn.Linear(dim, dim, bias=False)
+        self.wk = torch.nn.Linear(dim, n_kv_heads * self.head_dim, bias=False)
+        self.wv = torch.nn.Linear(dim, n_kv_heads * self.head_dim, bias=False)
+        self.wo = torch.nn.Linear(dim, dim, bias=False)
+
+    def forward(self, x):
+        bsz, seqlen, _ = x.shape
+        q = self.wq(x).view(bsz, seqlen, self.n_heads, self.head_dim).transpose(1, 2)
+        k = self.wk(x).view(bsz, seqlen, self.n_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.wv(x).view(bsz, seqlen, self.n_kv_heads, self.head_dim).transpose(1, 2)
+        out = flex_attention(q, k, v, enable_gqa=True)
+        out = out.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
+        return self.wo(out)
+
+
+class FlexAttnScoreModBlockMaskModel(torch.nn.Module):
+    """Model with both score_mod and block_mask together."""
+
+    def __init__(self, dim, n_heads, seqlen):
+        super().__init__()
+        self.dim = dim
+        self.n_heads = n_heads
+        self.head_dim = dim // n_heads
+        self.wq = torch.nn.Linear(dim, dim, bias=False)
+        self.wk = torch.nn.Linear(dim, dim, bias=False)
+        self.wv = torch.nn.Linear(dim, dim, bias=False)
+        self.wo = torch.nn.Linear(dim, dim, bias=False)
+
+        def causal(b, h, q_idx, kv_idx):
+            return q_idx >= kv_idx
+
+        self.block_mask = create_block_mask(
+            causal, B=None, H=None, Q_LEN=seqlen, KV_LEN=seqlen, device="cuda"
+        )
+
+    def forward(self, x):
+        bsz, seqlen, _ = x.shape
+        q = self.wq(x).view(bsz, seqlen, self.n_heads, self.head_dim).transpose(1, 2)
+        k = self.wk(x).view(bsz, seqlen, self.n_heads, self.head_dim).transpose(1, 2)
+        v = self.wv(x).view(bsz, seqlen, self.n_heads, self.head_dim).transpose(1, 2)
+
+        def alibi(score, batch, head, q_idx, kv_idx):
+            return score - (q_idx - kv_idx).abs().float()
+
+        out = flex_attention(
+            q, k, v, score_mod=alibi, block_mask=self.block_mask, scale=0.25
+        )
+        out = out.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
+        return self.wo(out)
+
+
 @pytest.fixture(autouse=True)
 def _clear_caches():
     reset_placement_options_cache()
@@ -41,49 +187,95 @@ def _clear_caches():
     reset_placement_options_cache()
 
 
-def test_flex_attention_1d_mesh(device_mesh_1d):
-    dim = 128
-    n_heads = 8
-    local_bs = 64
-
-    with torch.device("meta"):
-        model = FlexAttnModel(dim, n_heads)
-
-    x = DTensor.from_local(
-        torch.randn(local_bs, 16, dim, device="cuda"),
-        device_mesh_1d,
-        [Shard(0)],
+def _make_input(mesh, dim):
+    placements = [Shard(0)] + [Replicate()] * (mesh.ndim - 1)
+    return DTensor.from_local(
+        torch.randn(LOCAL_BS, SEQLEN, dim, device="cuda"),
+        mesh,
+        placements,
     )
 
+
+def _out_shardings(mesh):
+    return tuple([Shard(0)] + [Replicate()] * (mesh.ndim - 1))
+
+
+def _run_auto_parallel(model, mesh, dim=DIM):
+    x = _make_input(mesh, dim)
     parallel_model = auto_parallel(
         model,
-        device_mesh_1d,
+        mesh,
         sample_inputs=(x,),
-        out_shardings=(Shard(0),),
+        out_shardings=_out_shardings(mesh),
         compile=False,
     )
     assert parallel_model is not None
+    return parallel_model
+
+
+def test_flex_attention_1d_mesh(device_mesh_1d):
+    with torch.device("meta"):
+        model = FlexAttnModel(DIM, N_HEADS)
+    _run_auto_parallel(model, device_mesh_1d)
 
 
 def test_flex_attention_2d_mesh(device_mesh_2d):
-    dim = 128
-    n_heads = 8
-    local_bs = 64
-
     with torch.device("meta"):
-        model = FlexAttnModel(dim, n_heads)
+        model = FlexAttnModel(DIM, N_HEADS)
+    _run_auto_parallel(model, device_mesh_2d)
 
-    x = DTensor.from_local(
-        torch.randn(local_bs, 16, dim, device="cuda"),
-        device_mesh_2d,
-        [Shard(0), Replicate()],
-    )
 
-    parallel_model = auto_parallel(
-        model,
-        device_mesh_2d,
-        sample_inputs=(x,),
-        out_shardings=(Shard(0), Replicate()),
-        compile=False,
-    )
-    assert parallel_model is not None
+def test_flex_attention_score_mod(device_mesh_1d):
+    with torch.device("meta"):
+        model = FlexAttnScoreModModel(DIM, N_HEADS)
+    _run_auto_parallel(model, device_mesh_1d)
+
+
+def test_flex_attention_score_mod_2d(device_mesh_2d):
+    with torch.device("meta"):
+        model = FlexAttnScoreModModel(DIM, N_HEADS)
+    _run_auto_parallel(model, device_mesh_2d)
+
+
+def test_flex_attention_block_mask(device_mesh_1d):
+    model = FlexAttnBlockMaskModel(DIM, N_HEADS, SEQLEN)
+    model = model.to("meta")
+    _run_auto_parallel(model, device_mesh_1d)
+
+
+def test_flex_attention_block_mask_2d(device_mesh_2d):
+    model = FlexAttnBlockMaskModel(DIM, N_HEADS, SEQLEN)
+    model = model.to("meta")
+    _run_auto_parallel(model, device_mesh_2d)
+
+
+def test_flex_attention_scale(device_mesh_1d):
+    with torch.device("meta"):
+        model = FlexAttnScaleModel(DIM, N_HEADS)
+    _run_auto_parallel(model, device_mesh_1d)
+
+
+def test_flex_attention_gqa(device_mesh_1d):
+    n_kv_heads = 2
+    with torch.device("meta"):
+        model = FlexAttnGQAModel(DIM, N_HEADS, n_kv_heads)
+    _run_auto_parallel(model, device_mesh_1d)
+
+
+def test_flex_attention_gqa_2d(device_mesh_2d):
+    n_kv_heads = 2
+    with torch.device("meta"):
+        model = FlexAttnGQAModel(DIM, N_HEADS, n_kv_heads)
+    _run_auto_parallel(model, device_mesh_2d)
+
+
+def test_flex_attention_score_mod_block_mask(device_mesh_1d):
+    model = FlexAttnScoreModBlockMaskModel(DIM, N_HEADS, SEQLEN)
+    model = model.to("meta")
+    _run_auto_parallel(model, device_mesh_1d)
+
+
+def test_flex_attention_score_mod_block_mask_2d(device_mesh_2d):
+    model = FlexAttnScoreModBlockMaskModel(DIM, N_HEADS, SEQLEN)
+    model = model.to("meta")
+    _run_auto_parallel(model, device_mesh_2d)

--- a/tests/test_flex_attention.py
+++ b/tests/test_flex_attention.py
@@ -1,0 +1,89 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor.placement_types import Replicate, Shard
+from torch.nn.attention.flex_attention import flex_attention
+
+from autoparallel.api import auto_parallel
+from autoparallel.shardings.placement_options import reset_placement_options_cache
+
+
+class FlexAttnModel(torch.nn.Module):
+    def __init__(self, dim, n_heads):
+        super().__init__()
+        self.dim = dim
+        self.n_heads = n_heads
+        self.head_dim = dim // n_heads
+        self.wq = torch.nn.Linear(dim, dim, bias=False)
+        self.wk = torch.nn.Linear(dim, dim, bias=False)
+        self.wv = torch.nn.Linear(dim, dim, bias=False)
+        self.wo = torch.nn.Linear(dim, dim, bias=False)
+
+    def forward(self, x):
+        bsz, seqlen, _ = x.shape
+        q = self.wq(x).view(bsz, seqlen, self.n_heads, self.head_dim).transpose(1, 2)
+        k = self.wk(x).view(bsz, seqlen, self.n_heads, self.head_dim).transpose(1, 2)
+        v = self.wv(x).view(bsz, seqlen, self.n_heads, self.head_dim).transpose(1, 2)
+        out = flex_attention(q, k, v)
+        out = out.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
+        return self.wo(out)
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    reset_placement_options_cache()
+    yield
+    reset_placement_options_cache()
+
+
+def test_flex_attention_1d_mesh(device_mesh_1d):
+    dim = 128
+    n_heads = 8
+    local_bs = 64
+
+    with torch.device("meta"):
+        model = FlexAttnModel(dim, n_heads)
+
+    x = DTensor.from_local(
+        torch.randn(local_bs, 16, dim, device="cuda"),
+        device_mesh_1d,
+        [Shard(0)],
+    )
+
+    parallel_model = auto_parallel(
+        model,
+        device_mesh_1d,
+        sample_inputs=(x,),
+        out_shardings=(Shard(0),),
+        compile=False,
+    )
+    assert parallel_model is not None
+
+
+def test_flex_attention_2d_mesh(device_mesh_2d):
+    dim = 128
+    n_heads = 8
+    local_bs = 64
+
+    with torch.device("meta"):
+        model = FlexAttnModel(dim, n_heads)
+
+    x = DTensor.from_local(
+        torch.randn(local_bs, 16, dim, device="cuda"),
+        device_mesh_2d,
+        [Shard(0), Replicate()],
+    )
+
+    parallel_model = auto_parallel(
+        model,
+        device_mesh_2d,
+        sample_inputs=(x,),
+        out_shardings=(Shard(0), Replicate()),
+        compile=False,
+    )
+    assert parallel_model is not None

--- a/tests/test_flex_attention.py
+++ b/tests/test_flex_attention.py
@@ -70,7 +70,7 @@ class FlexAttnScoreModModel(torch.nn.Module):
 class FlexAttnBlockMaskModel(torch.nn.Module):
     """Model with a causal block_mask."""
 
-    def __init__(self, dim, n_heads, seqlen):
+    def __init__(self, dim, n_heads, seqlen, batch_size=None):
         super().__init__()
         self.dim = dim
         self.n_heads = n_heads
@@ -84,7 +84,12 @@ class FlexAttnBlockMaskModel(torch.nn.Module):
             return q_idx >= kv_idx
 
         self.block_mask = create_block_mask(
-            causal, B=None, H=None, Q_LEN=seqlen, KV_LEN=seqlen, device="cuda"
+            causal,
+            B=batch_size,
+            H=n_heads if batch_size is not None else None,
+            Q_LEN=seqlen,
+            KV_LEN=seqlen,
+            device="cuda",
         )
 
     def forward(self, x):
@@ -247,6 +252,82 @@ def test_flex_attention_block_mask_2d(device_mesh_2d):
     model = FlexAttnBlockMaskModel(DIM, N_HEADS, SEQLEN)
     model = model.to("meta")
     _run_auto_parallel(model, device_mesh_2d)
+
+
+def test_flex_attention_block_mask_explicit_bh(device_mesh_1d):
+    """block_mask with B=global_batch and H=n_heads (non-broadcast masks)."""
+    global_bs = LOCAL_BS * device_mesh_1d.size()
+    model = FlexAttnBlockMaskModel(DIM, N_HEADS, SEQLEN, batch_size=global_bs)
+    model = model.to("meta")
+    _run_auto_parallel(model, device_mesh_1d)
+
+
+def test_flex_attention_block_mask_sharding_matches_shape(device_mesh_1d):
+    """Verify block_mask tensors are shardable only on dims that match Q.
+
+    - B=global_batch, H=n_heads: block_mask can be sharded on both batch and heads.
+    - B=None, H=n_heads: block_mask has shape[0]=1, so batch dim must stay
+      Replicate, but head dim (shape[1]=H) can still be Shard(1).
+    - B=None, H=None: block_mask shape is [1,1,...], must be fully Replicate.
+    """
+    global_bs = LOCAL_BS * device_mesh_1d.size()
+    mesh = device_mesh_1d
+
+    from autoparallel.api import AutoParallel
+    from autoparallel.input_validation import (
+        _extract_input_info,
+        _flatten_out_shardings,
+        _make_input_fn,
+    )
+
+    def _get_flex_attn_strat(model):
+        x = _make_input(mesh, DIM)
+        shapes, dtypes, input_placements, treespec = _extract_input_info((x,), mesh)
+        input_fn = _make_input_fn(shapes, dtypes, treespec)
+        output_placements = _flatten_out_shardings(_out_shardings(mesh))
+
+        with AutoParallel(model, input_fn, mesh, compile=False) as autop:
+            autop.add_input_constraints(input_placements)
+            autop.add_output_constraints(output_placements)
+
+            for node in autop.gm.graph.nodes:
+                if node.op != "call_function":
+                    continue
+                if not isinstance(node.target, torch._ops.HigherOrderOperator):
+                    continue
+                if "backward" in node.target.name():
+                    continue
+                return autop.sharding_optimizer.strats[node]
+        raise AssertionError("flex_attention node not found")
+
+    def _block_mask_specs(strat):
+        """Collect input specs for block_mask tensors (not Q/K/V, not GraphModule)."""
+        specs = []
+        for s in strat.strategies:
+            for ispec in s.input_specs:
+                if ispec is None:
+                    continue
+                # Block_mask tensors have a trailing dim of size 1
+                if ispec.tensor_meta.shape[-1] == 1:
+                    specs.append(ispec)
+        return specs
+
+    # B=global_batch, H=n_heads: block_mask can be Shard(0)
+    model = FlexAttnBlockMaskModel(DIM, N_HEADS, SEQLEN, batch_size=global_bs)
+    model = model.to("meta")
+    bm_specs = _block_mask_specs(_get_flex_attn_strat(model))
+    assert any(
+        any(p == Shard(0) for p in spec.placements) for spec in bm_specs
+    ), "block_mask with explicit B should allow Shard(0)"
+
+    # B=None, H=None: block_mask shape [1,1,...] must be fully Replicate
+    model = FlexAttnBlockMaskModel(DIM, N_HEADS, SEQLEN)
+    model = model.to("meta")
+    bm_specs = _block_mask_specs(_get_flex_attn_strat(model))
+    for spec in bm_specs:
+        assert all(
+            p == Replicate() for p in spec.placements
+        ), f"block_mask with B=None, H=None should be Replicate, got {spec.placements}"
 
 
 def test_flex_attention_scale(device_mesh_1d):

--- a/tests/test_flex_attention.py
+++ b/tests/test_flex_attention.py
@@ -149,6 +149,43 @@ class FlexAttnGQAModel(torch.nn.Module):
         return self.wo(out)
 
 
+class FlexAttnOtherBuffersModel(torch.nn.Module):
+    """Model where score_mod captures external tensors (other_buffers).
+
+    Uses a buffer with shape [B, H] which coincidentally matches the batch and
+    head dimensions of Q. Without explicit other_buffers handling, this would
+    be misclassified as an attention tensor and incorrectly sharded.
+    """
+
+    def __init__(self, dim, n_heads, batch_size):
+        super().__init__()
+        self.dim = dim
+        self.n_heads = n_heads
+        self.head_dim = dim // n_heads
+        self.wq = torch.nn.Linear(dim, dim, bias=False)
+        self.wk = torch.nn.Linear(dim, dim, bias=False)
+        self.wv = torch.nn.Linear(dim, dim, bias=False)
+        self.wo = torch.nn.Linear(dim, dim, bias=False)
+        # Shape [B, H] — deliberately matches attention tensor dims
+        self.per_batch_head_bias = torch.nn.Parameter(
+            torch.randn(batch_size, n_heads), requires_grad=False
+        )
+
+    def forward(self, x):
+        bsz, seqlen, _ = x.shape
+        q = self.wq(x).view(bsz, seqlen, self.n_heads, self.head_dim).transpose(1, 2)
+        k = self.wk(x).view(bsz, seqlen, self.n_heads, self.head_dim).transpose(1, 2)
+        v = self.wv(x).view(bsz, seqlen, self.n_heads, self.head_dim).transpose(1, 2)
+        bias = self.per_batch_head_bias
+
+        def score_mod(score, batch, head, q_idx, kv_idx):
+            return score + bias[batch, head]
+
+        out = flex_attention(q, k, v, score_mod=score_mod)
+        out = out.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
+        return self.wo(out)
+
+
 class FlexAttnScoreModBlockMaskModel(torch.nn.Module):
     """Model with both score_mod and block_mask together."""
 
@@ -360,3 +397,66 @@ def test_flex_attention_score_mod_block_mask_2d(device_mesh_2d):
     model = FlexAttnScoreModBlockMaskModel(DIM, N_HEADS, SEQLEN)
     model = model.to("meta")
     _run_auto_parallel(model, device_mesh_2d)
+
+
+def test_flex_attention_other_buffers(device_mesh_1d):
+    """score_mod capturing a [B, H] tensor as other_buffer."""
+    global_bs = LOCAL_BS * device_mesh_1d.size()
+    model = FlexAttnOtherBuffersModel(DIM, N_HEADS, global_bs)
+    model = model.to("meta")
+    _run_auto_parallel(model, device_mesh_1d)
+
+
+def test_flex_attention_other_buffers_replicated(device_mesh_1d):
+    """Verify other_buffers with shape [B, H] are Replicate, not co-sharded.
+
+    The per_batch_head_bias has shape [B, H] which matches the attention tensor
+    dimensions. Without explicit other_buffers handling, tensor_placement would
+    assign it the same Shard(0)/Shard(1) placement as Q — but score_mod indexes
+    it arbitrarily, so it must be Replicate.
+    """
+    global_bs = LOCAL_BS * device_mesh_1d.size()
+    model = FlexAttnOtherBuffersModel(DIM, N_HEADS, global_bs)
+    model = model.to("meta")
+    mesh = device_mesh_1d
+
+    from autoparallel.api import AutoParallel
+    from autoparallel.input_validation import (
+        _extract_input_info,
+        _flatten_out_shardings,
+        _make_input_fn,
+    )
+
+    x = _make_input(mesh, DIM)
+    shapes, dtypes, input_placements, treespec = _extract_input_info((x,), mesh)
+    input_fn = _make_input_fn(shapes, dtypes, treespec)
+    output_placements = _flatten_out_shardings(_out_shardings(mesh))
+
+    with AutoParallel(model, input_fn, mesh, compile=False) as autop:
+        autop.add_input_constraints(input_placements)
+        autop.add_output_constraints(output_placements)
+
+        strats = autop.sharding_optimizer.strats
+        for node in autop.gm.graph.nodes:
+            if node.op != "call_function":
+                continue
+            if not isinstance(node.target, torch._ops.HigherOrderOperator):
+                continue
+            if "backward" in node.target.name():
+                continue
+
+            strat = strats[node]
+            q_shape = strat.strategies[0].input_specs[0].tensor_meta.shape
+            B, H = q_shape[0], q_shape[1]
+
+            # Find the [B, H] other_buffer and verify it's always Replicate.
+            for si, s in enumerate(strat.strategies):
+                for i, ispec in enumerate(s.input_specs):
+                    if ispec is None:
+                        continue
+                    if ispec.tensor_meta.shape == torch.Size([B, H]):
+                        assert all(p == Replicate() for p in ispec.placements), (
+                            f"Strategy {si}, other_buffer Input {i} "
+                            f"(shape [{B}, {H}]) should be Replicate "
+                            f"but got {ispec.placements}"
+                        )


### PR DESCRIPTION
FlexAttention (`torch.nn.attention.flex_attention`) is a higher-order operator (HOP) that appears in many PyTorch models. Previously, AutoParallel would crash when encountering it because the HOP's GraphModule submodules (score_mod, mask_mod) lack tensor metadata, and the HOP target isn't an OpOverload that the DTensor strategy system expects.

This PR treats `flex_attention` as an opaque box — like `local_map` — and enumerates valid input/output shardings based on attention semantics. Attention is independent per `(batch, head)` pair, so we allow `{Replicate, Shard(0), Shard(1)}` per mesh dimension. Block-mask and auxiliary tensors get per-dim placement adjusted to their actual shape: a `block_mask` created with `B=None` gets `Replicate` on the batch dim but can still be `Shard(1)` on heads if H is set.

The changes are best reviewed starting from `placement_options.py` (the new handler), then `optimize_sharding.py` (making the ILP robust to HOP submodule nodes), then `apply_sharding.py` (redistribution filtering for HOPs), and finally the tests.

Tested with `score_mod`, `block_mask` (broadcast and explicit B/H), custom scale, GQA (different Q vs KV head counts), and combinations thereof, on both 1D and 2D meshes.

Co-authored-by: Claude