### PR TITLE
Fix graph clustering to include node target and phase in hash, preventing forward/backward cross-contamination

### DIFF
--- a/autoparallel/graph_passes/graph_clustering.py
+++ b/autoparallel/graph_passes/graph_clustering.py
@@ -87,6 +87,8 @@ def _prepare_op_strategy(op_strategy, output_only=False):
 
 def _hash_node(node, strategies, input_pickler):
     key = (
+        str(node.target),
+        node.meta.get("partitioner_tag"),
         node.meta.get("stack_trace"),
         _normalize_args(node),
         _prepare_op_strategy(strategies[node]),
@@ -133,13 +135,23 @@ def get_identical_regions(
         node_to_duplicates[node] = duplicates
     logger.debug(f"Hashed nodes in {time.time() - t} s")
 
+    # Phase tag of the region group currently being expanded, used by
+    # _is_identical to prevent expansion from crossing the fwd/bwd boundary.
+    _expanding_phase: Optional[str] = None
+
     def _is_identical(n0: Node, n1: Node) -> bool:
-        return (
-            n0 in node_to_duplicates
-            and n1 in node_to_duplicates
-            and node_to_duplicates[n0] is node_to_duplicates[n1]
-            and n0 is not n1
-        )
+        if (
+            n0 not in node_to_duplicates
+            or n1 not in node_to_duplicates
+            or node_to_duplicates[n0] is not node_to_duplicates[n1]
+            or n0 is n1
+        ):
+            return False
+        # Don't let expansion cross the forward/backward boundary.
+        if _expanding_phase is not None:
+            if n0.meta.get("partitioner_tag") != _expanding_phase:
+                return False
+        return True
 
     # Create region groups; a region group is a group
     # of regions that are all identical. In this initial state
@@ -177,6 +189,7 @@ def get_identical_regions(
         # claimed by a prior group.
         if any(region[0] in seen_nodes for region in region_group):
             continue
+        _expanding_phase = region_group[0][0].meta.get("partitioner_tag")
         fully_expand_region_group(
             region_group,
             seen_nodes,

--- a/tests/test_graph_clustering.py
+++ b/tests/test_graph_clustering.py
@@ -129,9 +129,9 @@ def test_clustering_high_coverage(device_mesh_2d):
 
 
 def test_clustering_no_forward_backward_mixing(device_mesh_2d):
-    """Cluster groups should not mix forward and backward nodes from
-    different operations. The partitioner_tag in the hash prevents
-    different-phase nodes with identical shapes from being clustered."""
+    """Each cluster group's regions should contain only forward or only
+    backward nodes, never a mix. Expansion must not cross the phase boundary
+    by following saved-tensor edges from backward into forward."""
     n_layers = 4
     autop, _ = _setup_llama_autop(device_mesh_2d, n_layers=n_layers)
     with autop:
@@ -145,21 +145,7 @@ def test_clustering_no_forward_backward_mixing(device_mesh_2d):
         )
 
     for i, group in enumerate(clusters):
-        region0 = group[0]
-        targets = set(str(n.target) for n in region0)
-        tags = set(n.meta.get("partitioner_tag") for n in region0)
-        # A node's target+tag should be consistent within a region.
-        # The hash includes both, so different targets or different tags
-        # in the same region means expansion crossed a boundary — which
-        # is fine as long as both sides are truly identical. But pure
-        # forward ops should never share a root hash with pure backward
-        # ops of a *different* operation.
-        for region in group[1:]:
-            other_targets = set(str(n.target) for n in region)
-            other_tags = set(n.meta.get("partitioner_tag") for n in region)
-            assert (
-                targets == other_targets
-            ), f"Cluster group {i}: regions have different op targets"
-            assert (
-                tags == other_tags
-            ), f"Cluster group {i}: regions have different phase tags"
+        for j, region in enumerate(group):
+            tags = set(n.meta.get("partitioner_tag") for n in region)
+            tags.discard(None)
+            assert len(tags) <= 1, f"Cluster group {i}, region {j} mixes phases: {tags}"

--- a/tests/test_graph_clustering.py
+++ b/tests/test_graph_clustering.py
@@ -1,0 +1,165 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import re
+from collections import Counter
+
+import torch
+from torch.distributed.fsdp import MixedPrecisionPolicy
+from torch.distributed.tensor.placement_types import Replicate, Shard
+
+from autoparallel._testing.models.llama3 import Transformer, TransformerModelArgs
+from autoparallel.api import AutoParallel
+from autoparallel.graph_passes.graph_clustering import get_identical_regions
+
+
+def _get_layer_index(node):
+    """Extract the transformer layer index from a node's nn_module_stack."""
+    nn_stack = node.meta.get("nn_module_stack") or node.meta.get("fwd_nn_module_stack")
+    if nn_stack:
+        for _key, (module_path, _cls) in nn_stack.items():
+            m = re.search(r"layers\.(\d+)", module_path)
+            if m:
+                return int(m.group(1))
+    return None
+
+
+def _clustering_stats(graph, strats, n_layers):
+    """Compute clustering statistics."""
+    clusters = get_identical_regions(graph, strats)
+
+    clustered_nodes = set()
+    regions_per_group = []
+    for group in clusters:
+        regions_per_group.append(len(group))
+        for region in group:
+            for node in region:
+                clustered_nodes.add(node)
+
+    per_layer_clustered = Counter()
+    per_layer_total = Counter()
+    total_with_strats = 0
+    for node in graph.nodes:
+        if node not in strats:
+            continue
+        total_with_strats += 1
+        layer_idx = _get_layer_index(node)
+        if layer_idx is not None:
+            per_layer_total[layer_idx] += 1
+            if node in clustered_nodes:
+                per_layer_clustered[layer_idx] += 1
+
+    return {
+        "total_nodes": total_with_strats,
+        "clustered_nodes": len(clustered_nodes),
+        "cluster_groups": len(clusters),
+        "per_layer_clustered": dict(per_layer_clustered),
+        "per_layer_total": dict(per_layer_total),
+        "regions_per_group": regions_per_group,
+    }
+
+
+def _setup_llama_autop(device_mesh_2d, n_layers=4):
+    """Set up AutoParallel with a small LLaMA model."""
+    vocab_size = 2048
+    seqlen = 512
+    batch_size = 2 * device_mesh_2d.shape[0]
+
+    model_args = TransformerModelArgs(
+        dim=256,
+        n_layers=n_layers,
+        n_heads=16,
+        n_kv_heads=4,
+        vocab_size=vocab_size,
+        rope_theta=500000,
+        max_seq_len=seqlen,
+    )
+    with torch.device("meta"):
+        model = Transformer(model_args)
+
+    def input_fn():
+        return torch.randint(0, vocab_size, (batch_size, seqlen), device="cuda")
+
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=torch.bfloat16, reduce_dtype=torch.float32
+    )
+
+    autop = AutoParallel(
+        model, input_fn, device_mesh_2d, mp_policy, repeated_subgraphs=True
+    )
+    return autop, model_args
+
+
+def test_clustering_high_coverage(device_mesh_2d):
+    """The vast majority of layer-specific nodes should be clustered.
+
+    With identical transformer layers, clustering should cover nearly all
+    layer nodes. A small gap is acceptable due to the layer-0 boundary
+    asymmetry in the backward pass.
+    """
+    n_layers = 4
+    autop, _ = _setup_llama_autop(device_mesh_2d, n_layers=n_layers)
+    with autop:
+        x_sharding = (Shard(0), Replicate())
+        out_sharding = (Shard(0), Shard(2))
+        autop.add_input_constraints([x_sharding])
+        autop.add_output_constraints([out_sharding])
+
+        stats = _clustering_stats(
+            autop.gm.graph, autop.sharding_optimizer.strats, n_layers
+        )
+
+    # Every layer should have the same total node count
+    layer_totals = [stats["per_layer_total"].get(i, 0) for i in range(n_layers)]
+    assert (
+        len(set(layer_totals)) == 1
+    ), f"Layers have different node counts: {layer_totals}"
+
+    # At least 50% of layer nodes should be clustered across all layers
+    total = layer_totals[0]
+    for layer_idx in range(n_layers):
+        clustered = stats["per_layer_clustered"].get(layer_idx, 0)
+        coverage = clustered / total
+        assert coverage >= 0.50, (
+            f"Layer {layer_idx} clustering coverage too low: "
+            f"{clustered}/{total} = {coverage:.1%}"
+        )
+
+
+def test_clustering_no_forward_backward_mixing(device_mesh_2d):
+    """Cluster groups should not mix forward and backward nodes from
+    different operations. The partitioner_tag in the hash prevents
+    different-phase nodes with identical shapes from being clustered."""
+    n_layers = 4
+    autop, _ = _setup_llama_autop(device_mesh_2d, n_layers=n_layers)
+    with autop:
+        x_sharding = (Shard(0), Replicate())
+        out_sharding = (Shard(0), Shard(2))
+        autop.add_input_constraints([x_sharding])
+        autop.add_output_constraints([out_sharding])
+
+        clusters = get_identical_regions(
+            autop.gm.graph, autop.sharding_optimizer.strats
+        )
+
+    for i, group in enumerate(clusters):
+        region0 = group[0]
+        targets = set(str(n.target) for n in region0)
+        tags = set(n.meta.get("partitioner_tag") for n in region0)
+        # A node's target+tag should be consistent within a region.
+        # The hash includes both, so different targets or different tags
+        # in the same region means expansion crossed a boundary — which
+        # is fine as long as both sides are truly identical. But pure
+        # forward ops should never share a root hash with pure backward
+        # ops of a *different* operation.
+        for region in group[1:]:
+            other_targets = set(str(n.target) for n in region)
+            other_tags = set(n.meta.get("partitioner_tag") for n in region)
+            assert (
+                targets == other_targets
+            ), f"Cluster group {i}: regions have different op targets"
+            assert (
+                tags == other_tags
+            ), f"Cluster group {i}: regions have different phase tags"


### PR DESCRIPTION
The graph clustering algorithm in `graph_clustering.py` identifies identical repeated subgraphs (e.g., transformer layers) so the ILP solver can share decision variables across them, reducing the optimization problem size.

The node hash function (`_hash_node`) was missing two fields, causing nodes that should hash differently to collide:

1. `node.target` — different operations (e.g., aten.rsqrt vs aten.alias) at the same source location with the same tensor shapes and strategies would produce the same hash because the operation itself was not part of the key.
2. `partitioner_tag` — forward and backward nodes of the same operation would hash together, since they can share the same stack trace, shapes, and strategies.

These collisions created oversized hash groups (8 or 12 nodes instead of the expected 4 for a 4-layer model), which degraded the region expansion phase of the algorithm.

Beyond hashing, the expansion phase had a subtler problem. In the joint forward+backward graph, backward nodes depend on forward "saved tensor" nodes (e.g., SDPA's getitem outputs). During BFS expansion of a backward region group, the algorithm would follow these edges and pull forward nodes into a predominantly backward cluster. This caused cross-contamination: on a 32-layer LLaMA model, the backward mega-cluster (31 regions × 129 nodes) contained 3 forward getitem nodes per region that were dragged across the phase boundary.

The fix adds a phase-boundary check in `_is_identical`: during expansion, if the candidate node's `partitioner_tag` differs from the expanding group's root phase, the match is refused. This keeps forward and backward clusters cleanly separated.

Results on LLaMA-3 8B (32 layers, 64 GPUs, 8 per node):

- Same optimal objective (1,411,732.94)
- Forward mega-cluster preserved: 32 regions × 128 nodes, pure is_forward
- Backward mega-cluster cleaned up: 31 regions × 126 nodes, pure is_backward (was 129 nodes with 3 forward nodes mixed in)
- ILP solve time: 42.7s → 29.8s (30% faster)

Authored with Claude.