### PR TITLE
Fix pytree input validation and use solved placements for forward validation

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -563,9 +563,7 @@ class AutoParallel:
         def forward(self, *args):
             # Flatten pytree args (e.g. dicts, nested structures) to tensor
             # leaves, matching how Dynamo flattened the inputs during tracing.
-            import torch.utils._pytree as pytree
-
-            flat_args, _ = pytree.tree_flatten(args)
+            flat_args, _ = torch.utils._pytree.tree_flatten(args)
             _check_forward_args(flat_args, expected_inputs)
             # NB: don't close over the parameters/buffers, as the user may
             # reassign the module!

--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -404,8 +404,6 @@ class AutoParallel:
         t0 = time.perf_counter()
         self._assert_entered()
 
-        if sharding_placement is None:
-            sharding_placement = self.sharding_placement
         # TODO: what kind of updates do we have to do?
         #  - graph obvs
         #  - flat_args / updated_flat_args
@@ -485,8 +483,7 @@ class AutoParallel:
             sharded_buffer_dict,
         )
 
-    def apply_placement(self, sharding_placement=None):
-
+    def apply_placement(self, sharding_placement):
         sharded_param_dict, sharded_buffer_dict = self._apply_placement_common(
             sharding_placement
         )
@@ -546,12 +543,30 @@ class AutoParallel:
         graph_param_fqns = list(self.joint_with_descriptors.params_spec)
         graph_buffer_fqns = list(self.joint_with_descriptors.buffers_spec)
 
+        # Extract solved input placements from the solution dict.
+        # This is the ground truth for what the compiled graph expects.
+        from torch._functorch._aot_autograd.fx_utils import (
+            get_plain_input_and_grad_nodes,
+        )
+
+        input_nodes = get_plain_input_and_grad_nodes(self.gm.graph)
+        solved_input_placements = []
+        for desc in sorted(input_nodes, key=lambda d: d.idx):
+            node, _grad_node = input_nodes[desc]
+            strategy = sharding_placement[node]
+            solved_input_placements.append(tuple(strategy.output_specs.placements))
+
         expected_inputs = _compute_expected_inputs(
-            self._traced_inputs, self.input_constraints, self.mesh
+            self._traced_inputs, solved_input_placements, self.mesh
         )
 
         def forward(self, *args):
-            _check_forward_args(args, expected_inputs)
+            # Flatten pytree args (e.g. dicts, nested structures) to tensor
+            # leaves, matching how Dynamo flattened the inputs during tracing.
+            import torch.utils._pytree as pytree
+
+            flat_args, _ = pytree.tree_flatten(args)
+            _check_forward_args(flat_args, expected_inputs)
             # NB: don't close over the parameters/buffers, as the user may
             # reassign the module!
             # Use the exact param/buffer FQNs that the compiled graph
@@ -559,7 +574,7 @@ class AutoParallel:
             params = [
                 self.get_parameter(fqn).to_local() for fqn in graph_param_fqns
             ] + [self.get_buffer(fqn).to_local() for fqn in graph_buffer_fqns]
-            boxed_args = [*params, *args]
+            boxed_args = [*params, *flat_args]
             del params
             if torch.is_grad_enabled():
                 # NB: don't do self.parallel_model_fn work around Dynamo bug
@@ -652,14 +667,16 @@ def auto_parallel(
         raw_inputs = sample_inputs
 
     # Extract metadata and placements (does not materialize tensors)
-    shapes, dtypes, input_placements, treespec = _extract_input_info(raw_inputs, mesh)
+    shapes, dtypes, input_placements, treespec, devices = _extract_input_info(
+        raw_inputs, mesh
+    )
 
     # Flatten out_shardings to list
     output_placements = _flatten_out_shardings(out_shardings)
 
     # Create input_fn that will be called inside FakeTensorMode
     # It creates fresh tensors (which become fake tensors inside FakeTensorMode)
-    input_fn = _make_input_fn(shapes, dtypes, treespec)
+    input_fn = _make_input_fn(shapes, dtypes, treespec, devices=devices)
 
     # Use AutoParallel context manager
     with AutoParallel(

--- a/autoparallel/input_validation.py
+++ b/autoparallel/input_validation.py
@@ -9,26 +9,32 @@ import torch
 from torch.distributed.tensor import DeviceMesh
 
 
-def _compute_expected_inputs(traced_inputs, input_constraints, mesh):
+def _compute_expected_inputs(traced_inputs, input_placements, mesh):
     """Compute expected runtime inputs by applying sharding to traced global shapes.
 
-    Returns a list of meta tensors (for tensor inputs) or raw values (for non-tensor inputs).
-    """
-    from torch.distributed.tensor.placement_types import Replicate, Shard
+    traced_inputs may contain pytree structures (dicts, nested tuples, etc.).
+    We flatten them to tensor leaves before applying sharding, since the compiled
+    graph operates on flat tensor args.
 
-    default_placement = (Shard(0),) + (Replicate(),) * (mesh.ndim - 1)
+    Args:
+        traced_inputs: The inputs used during tracing (may contain pytrees).
+        input_placements: A placement tuple for each tensor leaf, as determined
+            by the solver's solution.
+        mesh: The device mesh.
+
+    Returns a flat list of meta tensors (for tensor inputs) or raw values
+    (for non-tensor inputs).
+    """
+    import torch.utils._pytree as pytree
+    from torch.distributed.tensor.placement_types import Shard
+
+    flat_inputs, _ = pytree.tree_flatten(traced_inputs)
 
     result = []
     tensor_idx = 0
-    for inp in traced_inputs:
+    for inp in flat_inputs:
         if isinstance(inp, torch.Tensor):
-            if input_constraints is None:
-                placements = default_placement
-            else:
-                placements = input_constraints[tensor_idx]
-                if placements is None:
-                    placements = default_placement
-
+            placements = input_placements[tensor_idx]
             local_shape = list(inp.shape)
             for mesh_dim, placement in enumerate(placements):
                 if isinstance(placement, Shard):
@@ -75,7 +81,13 @@ def _check_forward_args(args, expected_inputs):
 
 def _extract_input_info(
     sample_inputs: Any, mesh: DeviceMesh
-) -> tuple[list[tuple[int, ...]], list[torch.dtype], list[tuple[Any, ...]], Any]:
+) -> tuple[
+    list[tuple[int, ...]],
+    list[torch.dtype],
+    list[tuple[Any, ...]],
+    Any,
+    list[torch.device],
+]:
     """
     Extract tensor metadata and placements from sample inputs (supports pytrees).
 
@@ -89,6 +101,7 @@ def _extract_input_info(
         - List of dtypes
         - List of placement tuples for each tensor leaf
         - TreeSpec for reconstructing the pytree structure
+        - List of devices for each tensor leaf
     """
     import torch.utils._pytree as pytree
     from torch.distributed.tensor import DTensor
@@ -99,6 +112,7 @@ def _extract_input_info(
     shapes = []
     dtypes = []
     input_placements = []
+    devices = []
 
     for inp in flat_inputs:
         if isinstance(inp, DTensor):
@@ -106,25 +120,28 @@ def _extract_input_info(
             shapes.append(tuple(inp.shape))
             dtypes.append(inp.dtype)
             input_placements.append(tuple(inp.placements))
+            devices.append(inp.device)
         elif isinstance(inp, torch.Tensor):
             shapes.append(tuple(inp.shape))
             dtypes.append(inp.dtype)
             input_placements.append(tuple(Replicate() for _ in range(mesh.ndim)))
+            devices.append(inp.device)
         else:
             raise TypeError(
                 f"sample_inputs leaves must be Tensor or DTensor, got {type(inp)}"
             )
 
-    return shapes, dtypes, input_placements, treespec
+    return shapes, dtypes, input_placements, treespec, devices
 
 
 def _make_input_fn(
     shapes: list[tuple[int, ...]],
     dtypes: list[torch.dtype],
     treespec: Any,
+    devices: list[torch.device],
 ) -> Callable[[], tuple[Any, ...]]:
     """
-    Create an input_fn that creates tensors with the given shapes/dtypes.
+    Create an input_fn that creates tensors with the given shapes/dtypes/devices.
 
     The returned function should be called inside FakeTensorMode.
     It creates new tensors (which will be fake tensors when called in FakeTensorMode).
@@ -137,8 +154,8 @@ def _make_input_fn(
     def input_fn() -> tuple[Any, ...]:
         # Create tensors inside FakeTensorMode - they'll be fake tensors
         tensors = [
-            torch.empty(shape, dtype=dtype, device="cuda")
-            for shape, dtype in zip(shapes, dtypes)
+            torch.empty(shape, dtype=dtype, device=device)
+            for shape, dtype, device in zip(shapes, dtypes, devices)
         ]
         result = pytree.tree_unflatten(tensors, treespec)
 

--- a/tests/test_flex_attention.py
+++ b/tests/test_flex_attention.py
@@ -319,8 +319,10 @@ def test_flex_attention_block_mask_sharding_matches_shape(device_mesh_1d):
 
     def _get_flex_attn_strat(model):
         x = _make_input(mesh, DIM)
-        shapes, dtypes, input_placements, treespec = _extract_input_info((x,), mesh)
-        input_fn = _make_input_fn(shapes, dtypes, treespec)
+        shapes, dtypes, input_placements, treespec, devices = _extract_input_info(
+            (x,), mesh
+        )
+        input_fn = _make_input_fn(shapes, dtypes, treespec, devices)
         output_placements = _flatten_out_shardings(_out_shardings(mesh))
 
         with AutoParallel(model, input_fn, mesh, compile=False) as autop:
@@ -407,8 +409,10 @@ def test_flex_attention_gqa_head_sharding(device_mesh_2d):
         model = FlexAttnGQAModel(DIM, N_HEADS, n_kv_heads)
 
     x = _make_input(mesh, DIM)
-    shapes, dtypes, input_placements, treespec = _extract_input_info((x,), mesh)
-    input_fn = _make_input_fn(shapes, dtypes, treespec)
+    shapes, dtypes, input_placements, treespec, devices = _extract_input_info(
+        (x,), mesh
+    )
+    input_fn = _make_input_fn(shapes, dtypes, treespec, devices)
     output_placements = _flatten_out_shardings(_out_shardings(mesh))
 
     with AutoParallel(model, input_fn, mesh, compile=False) as autop:
@@ -475,8 +479,10 @@ def test_flex_attention_other_buffers_replicated(device_mesh_1d):
     )
 
     x = _make_input(mesh, DIM)
-    shapes, dtypes, input_placements, treespec = _extract_input_info((x,), mesh)
-    input_fn = _make_input_fn(shapes, dtypes, treespec)
+    shapes, dtypes, input_placements, treespec, devices = _extract_input_info(
+        (x,), mesh
+    )
+    input_fn = _make_input_fn(shapes, dtypes, treespec, devices)
     output_placements = _flatten_out_shardings(_out_shardings(mesh))
 
     with AutoParallel(model, input_fn, mesh, compile=False) as autop:

--- a/tests/test_inference_path.py
+++ b/tests/test_inference_path.py
@@ -39,11 +39,11 @@ def _auto_parallel_with_internals(model, mesh, sample_inputs, out_shardings):
         _make_input_fn,
     )
 
-    shapes, dtypes, input_placements, treespec = _extract_input_info(
+    shapes, dtypes, input_placements, treespec, devices = _extract_input_info(
         sample_inputs, mesh
     )
     output_placements = _flatten_out_shardings(out_shardings)
-    input_fn = _make_input_fn(shapes, dtypes, treespec)
+    input_fn = _make_input_fn(shapes, dtypes, treespec, devices)
 
     with AutoParallel(model, input_fn, mesh, compile=False) as autop:
         autop.add_input_constraints(input_placements)

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -10,7 +10,12 @@ from torch.distributed.tensor import DTensor
 from torch.distributed.tensor.placement_types import Replicate, Shard
 
 from autoparallel.api import auto_parallel
-from autoparallel.input_validation import _check_forward_args, _compute_expected_inputs
+from autoparallel.input_validation import (
+    _check_forward_args,
+    _compute_expected_inputs,
+    _extract_input_info,
+    _make_input_fn,
+)
 
 
 def test_check_forward_args():
@@ -48,39 +53,27 @@ def test_check_forward_args_non_tensor_value():
 
 
 def test_compute_expected_inputs(device_mesh_1d):
-    """Test local shape computation from global shape + Shard constraint."""
+    """Test local shape computation from global shape + Shard placement."""
     mesh = device_mesh_1d
     world_size = mesh.size()
 
     traced = [torch.empty(512, 128, device="meta")]
-    constraints = [(Shard(0),)]
+    placements = [(Shard(0),)]
 
-    result = _compute_expected_inputs(traced, constraints, mesh)
+    result = _compute_expected_inputs(traced, placements, mesh)
     assert len(result) == 1
     assert result[0].shape == (512 // world_size, 128)
     assert result[0].dtype == torch.float32
 
 
-def test_compute_expected_inputs_default_constraints(device_mesh_1d):
-    """Test that None constraints default to Shard(0)."""
-    mesh = device_mesh_1d
-    world_size = mesh.size()
-
-    traced = [torch.empty(512, 128, device="meta")]
-
-    result = _compute_expected_inputs(traced, None, mesh)
-    assert len(result) == 1
-    assert result[0].shape == (512 // world_size, 128)
-
-
 def test_compute_expected_inputs_replicated(device_mesh_1d):
-    """Test that Replicate constraint leaves shape unchanged."""
+    """Test that Replicate placement leaves shape unchanged."""
     mesh = device_mesh_1d
 
     traced = [torch.empty(512, 128, device="meta")]
-    constraints = [(Replicate(),)]
+    placements = [(Replicate(),)]
 
-    result = _compute_expected_inputs(traced, constraints, mesh)
+    result = _compute_expected_inputs(traced, placements, mesh)
     assert len(result) == 1
     assert result[0].shape == (512, 128)
 
@@ -131,3 +124,101 @@ def test_forward_input_validation_integration(device_mesh_1d):
 
     with pytest.raises(TypeError, match="Tensor"):
         parallel_mod(42)
+
+
+def test_compute_expected_inputs_dict_pytree(device_mesh_1d):
+    """Test that dict pytree inputs are flattened before applying sharding."""
+    mesh = device_mesh_1d
+    world_size = mesh.size()
+
+    # Simulate traced_inputs containing a dict (as produced by build_joint_graph
+    # when the model takes a dict argument)
+    traced = [
+        {
+            "x": torch.empty(512, 128, device="meta"),
+            "y": torch.empty(512, 64, device="meta"),
+        }
+    ]
+    constraints = [(Shard(0),), (Shard(0),)]
+
+    result = _compute_expected_inputs(traced, constraints, mesh)
+    assert len(result) == 2
+    assert result[0].shape == (512 // world_size, 128)
+    assert result[1].shape == (512 // world_size, 64)
+
+
+def test_extract_input_info_dict(device_mesh_1d):
+    """Test that _extract_input_info handles dict inputs."""
+    mesh = device_mesh_1d
+    sample = {
+        "a": torch.rand(4, 8),
+        "b": torch.rand(4, 16),
+    }
+    shapes, dtypes, placements, treespec, devices = _extract_input_info(sample, mesh)
+    assert len(shapes) == 2
+    assert shapes[0] == (4, 8)
+    assert shapes[1] == (4, 16)
+    assert len(placements) == 2
+    assert len(devices) == 2
+    assert all(d == torch.device("cpu") for d in devices)
+
+
+def test_make_input_fn_dict_roundtrip(device_mesh_1d):
+    """Test that _make_input_fn reconstructs dict structure from treespec."""
+    mesh = device_mesh_1d
+    sample = {
+        "a": torch.rand(4, 8),
+        "b": torch.rand(4, 16),
+    }
+    shapes, dtypes, _, treespec, devices = _extract_input_info(sample, mesh)
+    input_fn = _make_input_fn(shapes, dtypes, treespec, devices)
+    result = input_fn()
+    # Dict is wrapped in a tuple
+    assert isinstance(result, tuple) and len(result) == 1
+    assert isinstance(result[0], dict)
+    assert set(result[0].keys()) == {"a", "b"}
+    assert result[0]["a"].shape == (4, 8)
+    assert result[0]["b"].shape == (4, 16)
+    # Verify per-tensor devices are preserved
+    assert result[0]["a"].device == torch.device("cpu")
+    assert result[0]["b"].device == torch.device("cpu")
+
+
+def test_dict_input_integration(device_mesh_1d):
+    """Integration test: auto_parallel with dict inputs."""
+    dim = 128
+    batch_size = 512
+    local_batch_size = batch_size // device_mesh_1d.size()
+
+    class DictModel(nn.Module):
+        def __init__(self, dim):
+            super().__init__()
+            self.linear = nn.Linear(dim, dim)
+
+        def forward(self, inputs):
+            return self.linear(inputs["x"])
+
+    with torch.device("meta"):
+        model = DictModel(dim)
+
+    x = DTensor.from_local(
+        torch.rand(local_batch_size, dim, device="cuda"),
+        device_mesh_1d,
+        [Shard(0)],
+    )
+    sample_inputs = {"x": x}
+    parallel_mod = auto_parallel(
+        model,
+        device_mesh_1d,
+        sample_inputs=sample_inputs,
+        out_shardings=(Shard(0),),
+        compile=False,
+    )
+
+    # Should work with correct dict input
+    out = parallel_mod({"x": torch.rand(local_batch_size, dim, device="cuda")})
+    assert out.shape == (local_batch_size, dim)
+
+    # Should reject wrong shape
+    with pytest.raises(ValueError, match="shape"):
+        parallel_mod({"x": torch.rand(local_batch_size + 1, dim, device="cuda")})

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -185,7 +185,7 @@ def test_make_input_fn_dict_roundtrip(device_mesh_1d):
 
 
 def test_dict_input_integration(device_mesh_1d):
-    """Integration test: auto_parallel with dict inputs."""
+    """Integration test: auto_parallel with dict inputs validates correctly."""
     dim = 128
     batch_size = 512
     local_batch_size = batch_size // device_mesh_1d.size()
@@ -197,6 +197,10 @@ def test_dict_input_integration(device_mesh_1d):
 
         def forward(self, inputs):
             return self.linear(inputs["x"])
+
+        def init_weights(self):
+            nn.init.ones_(self.linear.weight)
+            nn.init.zeros_(self.linear.bias)
 
     with torch.device("meta"):
         model = DictModel(dim)
@@ -214,11 +218,13 @@ def test_dict_input_integration(device_mesh_1d):
         out_shardings=(Shard(0),),
         compile=False,
     )
+    parallel_mod.to_empty(device="cuda")
+    parallel_mod.init_weights()
 
     # Should work with correct dict input
     out = parallel_mod({"x": torch.rand(local_batch_size, dim, device="cuda")})
     assert out.shape == (local_batch_size, dim)
 
-    # Should reject wrong shape
+    # Validation should reject wrong shape inside a dict
     with pytest.raises(ValueError, match="shape"):
         parallel_mod({"x": torch.rand(local_batch_size + 1, dim, device="cuda")})


### PR DESCRIPTION
The simple API (`auto_parallel`) advertised `pytree` support (dict inputs, nested structures) but had two bugs that broke it at runtime:

1. `_compute_expected_inputs` iterated over `traced_inputs` directly, so a dict element hit the non-tensor branch and sharding was never applied to its tensor leaves. The forward function similarly passed the raw `pytree` structure to the compiled graph, which expects flat tensor args.
2. Forward validation used `self.input_constraints` (the user's request) rather than the solver's solution to determine expected input shapes. If the user set no constraints and the solver chose something other than the hardcoded default `Shard(0)`, validation would reject correct inputs.

This PR fixes both by `pytree`-flattening inputs in `_compute_expected_inputs and forward()`, and by extracting the actual solved placements from the solution dict via `get_plain_input_and_grad_nodes`. This also removes the duplicated default placement logic from `_compute_expected_inputs`, making it a pure shape calculator.

Other cleanups along the way:
- `_extract_input_info` now returns per-tensor devices (previously `_make_input_fn` hardcoded `device="cuda"`)
- `apply_placement` takes `sharding_placement` as a required argument (every call site already passed it explicitly)

Authored with Claude.