### PR TITLE
Add user documentation for strategy selection and MoE with local_map

### DIFF
--- a/docs/how_autoparallel_chooses_a_strategy.md
+++ b/docs/how_autoparallel_chooses_a_strategy.md
@@ -1,0 +1,337 @@
+# How AutoParallel Chooses a Strategy
+
+AutoParallel formulates sharding as a cost minimization problem. Each
+node in the computation graph has a finite set of valid sharding
+strategies. A strategy specifies the expected input placements, the
+output placement, and the redistribution costs from each predecessor's
+possible output placements. The ILP solver selects one strategy per node
+to minimize total cost across the entire graph simultaneously.
+
+This document explains what goes into that cost, how constraints shape
+the solution, and how to interpret and debug the optimizer's decisions.
+
+## The three cost components
+
+Every candidate strategy has a cost that is the sum of three components:
+compute, communication, and transition.
+
+### Compute cost
+
+The compute cost estimates how long an operation takes on a single GPU
+after sharding. In the current cost model, it is the maximum of two
+estimates:
+
+- **Compute time**: FLOPs divided by device throughput (currently
+  assuming 70% efficiency). For a bf16 matmul `[M, K] × [K, N]` on an
+  H100 (989 TFLOPS bf16), the compute time is
+  `2·M·K·N / (989e12 × 0.7)` microseconds.
+
+- **Memory time**: total bytes read and written, divided by device memory
+  bandwidth (currently assuming 70% efficiency). For the same matmul, the
+  memory cost is `(M·K + K·N + M·N) × 2 / (3.35 TB/s × 0.7)`
+  microseconds.
+
+The cost is `max(compute_time, memory_time)`, reflecting that a kernel
+is limited by whichever resource is the bottleneck. Large matmuls are
+compute-bound; small or pointwise ops are memory-bound.
+
+The current cost model applies a 7 μs kernel launch floor to prevent
+tiny operations from appearing "free." Without this, the solver would
+place hundreds of near-zero-cost pointwise ops in exotic placements with
+no penalty.
+
+These are hardware-informed approximations designed to capture the
+relative ranking of strategies, not exact kernel runtimes. View
+operations (`reshape`, `expand`, `permute`) have zero compute cost —
+they don't move data.
+
+### Communication cost
+
+When an operation's expected input placement doesn't match its
+producer's output placement, a collective communication is needed to
+redistribute the tensor. The communication cost estimates this
+redistribution time.
+
+By default, AutoParallel uses the **NCCL cost model**, which models
+actual NCCL algorithm selection:
+
+- **Algorithms**: Ring, Tree, CollNet Direct/Chain, NVLS, NVLS Tree
+- **Protocols**: LL (low latency), LL128, Simple
+- **Topology**: intra-node NVLink bandwidth vs inter-node network
+  bandwidth, with per-architecture constants for A100, H100, and B200
+
+The key practical consequence: intra-node communication (NVLink/NVSwitch)
+is much cheaper than inter-node communication (network). On an H100
+NVSwitch node, 8-way intra-node all-gather bandwidth is ~320 GB/s per
+GPU, while inter-node bandwidth might be 25-50 GB/s. This means the
+solver strongly prefers strategies that keep heavy communication within
+the node.
+
+The specific collectives and when they arise:
+
+| Redistribution | Collective | Example |
+|---|---|---|
+| `Shard(d)` → `Replicate` | All-gather | Gathering a sharded weight before matmul |
+| `Partial` → `Replicate` | All-reduce | Summing partial results |
+| `Partial` → `Shard(d)` | Reduce-scatter | Reducing and sharding gradients |
+| `Shard(d)` → `Shard(d')` | All-to-all | Switching sharding dimension |
+| `Replicate` → `Shard(d)` | No collective (local narrow) | Each rank takes its shard of the replicated tensor |
+
+Non-dim-0 sharding (`Shard(1)`, `Shard(2)`) adds a reshuffling penalty
+because the data must be rearranged in memory after the collective.
+
+### Transition cost
+
+A small tie-breaker penalty (currently 1.0) is applied whenever a
+producer and consumer disagree on placement. Without this, the solver
+might flip placements between adjacent operations when costs are nearly
+tied, producing a plan with unnecessary redistributions. The transition
+cost encourages placement stability through the graph.
+
+## The prefetch discount
+
+FSDP-style parallelism shards parameters across ranks and all-gathers
+them before each matmul. Naively, the solver would see the all-gather
+cost and prefer to replicate parameters instead. But in practice, the
+all-gather can overlap with the previous layer's compute — it's
+effectively free.
+
+`apply_prefetch_discount` models this overlap by scaling down
+communication costs for edges that can be prefetched:
+
+- **Forward**: edges where the producer is "parameter-derived" — meaning
+  its value comes from a model parameter, such as a weight cast or view
+  feeding a matmul. The all-gather for these can run during the previous
+  layer's forward compute.
+- **Backward**: edges into "terminal-derived" nodes — meaning gradient
+  reduction nodes at the end of the backward graph. The reduce-scatter
+  can run during the next layer's backward compute.
+
+The default scale is 0.0 (fully overlapped), meaning these collectives
+are treated as free. **This discount is not applied automatically** —
+you must call it explicitly on the `ShardingOptimizer` before solving:
+
+```python
+with AutoParallel(model, input_fn, mesh) as autop:
+    # ... add constraints ...
+    autop.sharding_optimizer.apply_prefetch_discount(scale=0.0)
+    sharding = autop.optimize_placement()
+```
+
+Without this call, the solver sees the full all-gather cost and may
+prefer replicating parameters over sharding them. With it, the solver
+treats FSDP parameter sharding as essentially free communication.
+
+## How constraints shape the solution
+
+The ILP solver minimizes cost subject to constraints. Some are internal
+(ensuring a valid sharding plan), and some are user-specified.
+
+### Internal constraints
+
+These are always active:
+
+- **Uniqueness**: each node selects exactly one coherent strategy across
+  all of its arguments
+- **Consistency**: for a given node, the strategy selected for each
+  argument must agree on the same output placement
+- **Flow**: producer and consumer strategies are linked through
+  redistribution costs. When placements differ, the optimizer accounts
+  for the required communication
+- **Forward-backward consistency**: matched forward and backward nodes
+  (e.g., a matmul and its corresponding gradient matmul) use the same
+  placement
+
+### User constraints
+
+These change the solution:
+
+**Input/output constraints** pin placements at the graph boundary — the
+model's inputs and outputs. If you specify
+`add_input_constraints([(Shard(0), Replicate())])`, the solver must shard
+the input's batch dimension on the first mesh axis. The solver optimizes
+everything in between.
+
+**Memory constraints** force parameter sharding. Without
+`add_parameter_memory_constraint()`, the solver might replicate all
+parameters (avoiding communication entirely). With it, the solver must
+shard parameters to fit within the memory budget, which triggers
+FSDP-style all-gathers before compute. The prefetch discount makes
+these all-gathers cheap, so the solver converges on an FSDP-like
+strategy naturally.
+
+**Node constraints** (`add_node_constraint`) force specific placements on
+individual operations. Use this when you know the right strategy for a
+particular layer and want the solver to optimize around it.
+
+**`with_sharding_constraint`** (in the model code itself) forces a
+specific intermediate placement. Unlike `add_node_constraint`, this is
+embedded in the model and doesn't require access to the
+`ShardingOptimizer`.
+
+## Reading the optimizer log
+
+After calling `optimize_placement(verbose=True)`, the log annotates
+each node in the graph with its chosen strategy and cost breakdown.
+
+Here's what a typical annotation looks like:
+
+```
+mm = torch.ops.aten.mm.default(view, wq_weight)  # placement=S(0)R, RS(1) -> S(0)S(1) cost=[(0.0, 42.3, 0), (0.0, 42.3, 0)]
+```
+
+The fields:
+
+- **`placement=S(0)R, RS(1) -> S(0)S(1)`**: the full sharding strategy.
+  The part before `->` lists the input placements (one per tensor input),
+  and the part after `->` is the output placement. Here, the first input
+  has placement `S(0)R` (Shard(0) on DP, Replicate on TP), the second
+  input (weight) has `RS(1)` (Replicate on DP, Shard(1) on TP), and
+  the output is `S(0)S(1)` (Shard(0) on DP, Shard(1) on TP).
+
+- **`cost=[(comm, compute, transition), ...]`**: one tuple per tensor
+  input argument. The `comm` component is specific to that argument
+  (the cost to redistribute that input from its producer's placement).
+  The `compute` component reflects the node's overall strategy cost,
+  repeated in each tuple for reporting convenience. The `transition`
+  component is 1 if this input required a placement change, 0 otherwise.
+  The total cost of a node is the sum across all its argument tuples.
+
+At the bottom of the log:
+
+```
+total_cost: 15234.50
+  comm_cost: 3421.20
+  compute_cost: 11802.30
+  transition_cost: 11.00
+```
+
+This is the full objective value summed across all nodes. Compare
+`comm_cost` vs `compute_cost` to understand whether the model is
+compute-bound or communication-bound at this configuration.
+
+## Debugging: a typical workflow
+
+When the optimizer makes a surprising choice, here's a systematic way
+to investigate:
+
+1. **Solve and read the log.** Call `optimize_placement(verbose=True)`
+   and scan the annotations. Look at the summary totals — is the
+   solution comm-dominated or compute-dominated?
+
+2. **Ask why a placement wasn't chosen.** If you expected a specific
+   placement, use `explain_placement` to compare it against the chosen
+   one:
+
+   ```python
+   autop.sharding_optimizer.explain_placement((Shard(0), Replicate()))
+   ```
+
+   This walks the graph and reports, per node, whether the target
+   placement is available and how its cost compares to the chosen one.
+
+3. **Inspect a specific node.** If a particular node's strategy looks
+   wrong, examine its redistribution cost matrix:
+
+   ```python
+   node = autop.gm.graph.find_nodes(
+       op="call_function", target=torch.ops.aten.mm.default
+   )[0]
+   autop.sharding_optimizer.print_costs_for_node(node, arg=0)
+   ```
+
+   This prints a matrix of redistribution costs from each possible
+   input placement (columns) to each possible output placement (rows).
+
+4. **Test a hypothesis.** Force the placement you think is better and
+   re-solve:
+
+   ```python
+   solution_a = autop.sharding_optimizer.get_solution()
+   autop.sharding_optimizer.add_node_constraint(node, (Shard(0), Shard(1)))
+   solution_b = autop.sharding_optimizer.get_solution()
+   autop.sharding_optimizer.diff_solutions(solution_a, solution_b)
+   ```
+
+   `diff_solutions` shows the cost impact and which nodes shifted.
+
+### `explain_placement` output
+
+```
+Node              Shape         Chosen    Ch.Comp  Ch.Comm  Tgt.Comp  Tgt.Comm  Status
+mm_1              [2048, 4096]  S(0)S(1)  42.3     0.0      84.6      0.0       CHOSEN CHEAPER
+layer_norm        [2048, 4096]  S(0)S(1)  12.1     0.0      N/A       N/A       UNAVAILABLE
+```
+
+Status values:
+- `CHOSEN CHEAPER`: the solver's choice has lower total cost
+- `TARGET CHEAPER`: the target is locally cheaper but wasn't chosen due
+  to global interactions (e.g., it forces expensive downstream
+  redistributions)
+- `UNAVAILABLE`: the target placement isn't a valid option for that
+  operation (e.g., can't shard a dimension that's too small)
+- `TIE`: costs are equal; other factors (transition penalties, global
+  interactions) determined the choice
+
+### `diff_solutions` output
+
+```
+Objective: 15234.5 -> 15891.2 (+656.7)
+  compute: 11802.3 -> 11802.3 (+0.0)
+  comm:    3421.2 -> 4077.9 (+656.7)
+  trans:   11.0 -> 11.0 (+0.0)
+
+Placement changes (12 nodes changed, 847 unchanged):
+  S(0)R -> S(0)S(1): 8 nodes
+  S(0)S(1) -> S(0)R: 4 nodes
+```
+
+This shows the cost impact of a constraint change and which nodes
+shifted placement. If the objective increased, the forced placement is
+more expensive than what the solver chose. If it decreased, you found
+an improvement (which may indicate a cost model inaccuracy worth
+investigating).
+
+## Common patterns the solver discovers
+
+### FSDP vs full replication
+
+Without memory constraints, the solver replicates all parameters — no
+communication needed. With `add_parameter_memory_constraint()`, it must
+shard parameters to fit within the budget. Combined with the prefetch
+discount (which makes the resulting all-gathers free), this naturally
+produces an FSDP-like strategy where parameters are sharded at rest
+and gathered before compute.
+
+### Sequence-parallel vs column-parallel
+
+On a 2D mesh (DP, TP), linear layers have two main TP strategies:
+
+- **Column-parallel**: activation replicated across TP, weight sharded
+  on output dimension
+- **Sequence-parallel**: activation sharded across TP on the sequence
+  dimension, weight replicated
+
+The crossover depends on a single ratio: tokens per DP rank (`M`) vs
+the layer's output dimension (`N`). When `M > N`, sequence-parallel
+reads less data. When `M < N`, column-parallel reads less data.
+
+This produces adaptive strategies: LLaMA3-8B at long sequences uses
+sequence-parallel everywhere, while LLaMA3-70B uses a hybrid (seq-par
+for attention, col-par for MLP) because the 70B MLP has a larger output
+dimension. See [adaptive_sharding.md](adaptive_sharding.md) for the
+full analysis.
+
+### Batch-size sensitivity
+
+Small batch sizes make the model compute-bound — communication costs are
+small relative to compute, so the solver favors TP (which reduces
+per-GPU compute). Large batch sizes make the model communication-bound —
+parameter all-gathers become the bottleneck, so the solver shifts toward
+pure DP (which avoids TP communication). The crossover depends on model
+size, sequence length, and hardware topology.
+
+## Further reading
+
+- [adaptive_sharding.md](adaptive_sharding.md) — detailed analysis of
+  the sequence-parallel vs column-parallel tradeoff for LLaMA3

--- a/docs/local_map_and_moe.md
+++ b/docs/local_map_and_moe.md
@@ -1,0 +1,430 @@
+# Using `local_map` for MoE and Custom Communication Patterns
+
+AutoParallel automatically shards models by analyzing the computation graph
+and finding optimal placements for every tensor. But some operations —
+particularly in Mixture-of-Experts (MoE) models — involve communication
+patterns that depend on runtime data. These can't be expressed through
+DTensor's placement primitives (`Shard`, `Replicate`, `Partial`), which
+describe static relationships between global and local tensor shapes.
+
+`local_map` is the composition mechanism for these cases. It lets you define
+a region where you manage communication manually, while AutoParallel
+optimizes everything outside it.
+
+## Prerequisites
+
+This document assumes a 2D mesh with data-parallel and expert-parallel
+dimensions:
+
+```python
+import torch
+from torch.distributed.tensor import DeviceMesh, DTensor
+from torch.distributed.tensor.placement_types import Shard, Replicate, Partial
+from autoparallel.api import AutoParallel
+from autoparallel.collectives import local_map, all_to_all, axis_size
+
+mesh = torch.distributed.device_mesh.init_device_mesh(
+    "cuda",
+    (dp_size, ep_size),
+    mesh_dim_names=("dp", "ep"),
+)
+```
+
+A few things to keep in mind throughout:
+
+- **Placement tuples follow mesh dimension order.** `(Shard(0), Replicate())`
+  means shard on dim 0 of "dp", replicate on "ep".
+- **Inside `local_map`, tensors are local shards.** They've already been
+  redistributed to match `in_placements` — you work with plain
+  `torch.Tensor`s, not DTensors.
+- **Use `autoparallel.collectives` for communication inside `local_map`**,
+  not raw `torch.distributed` ops. The wrappers in `autoparallel.collectives`
+  have correct `torch.autograd.Function` backward implementations so
+  gradients flow through collectives.
+
+## When DTensor placements are sufficient for MoE
+
+If routing is perfectly balanced — every token is routed to the same
+number of experts (fixed top-k) *and* every expert receives exactly the
+same number of tokens — then the all-to-all has equal split sizes, the
+permutation is a static reshape, and the expert computation is a batched
+matmul with a fixed batch dimension. All of this is expressible through
+DTensor placements, and AutoParallel can optimize it automatically without
+`local_map`.
+
+In practice, most MoE models don't enforce perfectly balanced routing.
+They use auxiliary losses or bias terms to *encourage* balance, but allow
+imbalance because forcing uniform routing would hurt model quality — the
+whole point of routing is that different tokens should go to different
+experts based on content. The rest of this document covers the general
+case where routing is data-dependent and imbalanced.
+
+## Why DTensor placements can't describe dynamic MoE routing
+
+DTensor's `Shard(dim)` means "divide this dimension evenly across ranks" —
+analogous to `torch.chunk`. Given the global shape and the mesh, you can
+compute the local shape on any rank without running the model.
+
+In an MoE layer with dynamic routing, a router sends each token to its
+top-k experts. The number of tokens each expert receives depends on the
+routing decisions, which are computed at runtime. After the all-to-all
+that dispatches tokens to experts, the local tensor on each rank contains
+a data-dependent number of tokens. No static placement annotation can
+describe this distribution.
+
+## What `local_map` does
+
+`local_map` wraps a function and declares what DTensor placements the
+inputs and outputs have. Inside the wrapped function, you work with
+regular (local) tensors and handle communication yourself. The optimizer
+treats the `local_map` region as an opaque operation with known input/output
+placements, and optimizes everything around it.
+
+```python
+from autoparallel.collectives import local_map
+
+result = local_map(
+    my_function,
+    # What placements the outputs will have (one tuple per output)
+    out_placements=((Shard(0), Shard(0)),),
+    # What placements the inputs should have (one tuple per input)
+    in_placements=(
+        (Shard(0), Shard(0)),       # tokens: sharded on batch across both DP and EP
+        (Replicate(), Shard(0)),    # expert weights: replicated on DP, one expert per EP rank
+    ),
+    redistribute_inputs=True,       # Automatically redistribute inputs to match in_placements
+    device_mesh=mesh,
+)(tokens, expert_weights)
+```
+
+Key points:
+- Each placement tuple has one entry per mesh dimension
+- `redistribute_inputs=True` means AutoParallel will insert the necessary
+  collectives to get inputs into the declared placements before entering
+  the region
+- Inside the function, tensors are plain local tensors — no DTensor wrapper
+- The function must return tensors whose shapes are consistent with the
+  declared `out_placements`
+
+## What belongs inside `local_map` for MoE
+
+The entire MoE dispatch block — from routing through expert computation
+to combining results — must live inside a single `local_map` region.
+This isn't just the communication primitives; it's everything in between
+too, because the intermediate tensors have distributions that only your
+code understands.
+
+Concretely, an MoE dispatch involves:
+
+1. **Routing**: compute expert assignments via top-k on router scores
+2. **Token permutation**: sort tokens by assigned expert
+3. **All-to-all (dispatch)**: send tokens to the rank that owns each expert
+4. **Expert computation**: run local experts on received tokens
+5. **All-to-all (combine)**: send results back to originating ranks
+6. **Token un-permutation**: restore original token order
+7. **Score weighting**: combine expert outputs weighted by router scores
+
+All 7 steps must be inside the `local_map`. After step 3, the tensor's
+first dimension means "tokens assigned to my experts, from all ranks" —
+a distribution that depends on routing decisions. Steps 1-2 produce the
+permutation that steps 3, 5, and 6 depend on. There's no point where you
+can draw a line and say "above here is auto-shardable, below is manual."
+
+The reason `local_map` works cleanly here is that the combine all-to-all
+(step 5) reverses the dispatch all-to-all (step 3), restoring the original
+token distribution. The output of the entire block has the same static
+placement as the input — the dynamic routing is fully contained within
+the region.
+
+## Minimal MoE example
+
+Here's a simplified MoE layer showing the pattern. The dense layers
+(gate projection, shared expert) are auto-sharded by AutoParallel.
+Only the expert dispatch block uses `local_map`.
+
+```python
+import torch
+from torch import nn
+from autoparallel.collectives import local_map, all_to_all, axis_size
+from torch.distributed.tensor.placement_types import Shard, Replicate
+
+
+def moe_dispatch(
+    x: torch.Tensor,              # (batch * seq, dim)
+    gate_scores: torch.Tensor,    # (batch * seq, num_experts)
+    expert_w1: torch.Tensor,      # (num_local_experts, dim, ffn_dim)
+    expert_w2: torch.Tensor,      # (num_local_experts, ffn_dim, dim)
+    top_k: int,
+    num_experts: int,
+    axis_name: str,
+) -> torch.Tensor:
+    """MoE dispatch: route tokens to experts, compute, and combine results.
+
+    Everything in this function runs on local tensors — no DTensor.
+    Communication is via explicit collective calls.
+    """
+    ep_size = axis_size(axis_name)
+    n_tokens = x.shape[0]
+    dim = x.shape[-1]
+
+    # 1. Route: pick top-k experts per token
+    top_scores, expert_indices = torch.topk(gate_scores, k=top_k, dim=-1)
+    top_scores = torch.softmax(top_scores, dim=-1)
+
+    # 2. Count tokens per expert and permute
+    num_tokens_per_expert = torch.histc(
+        expert_indices.flatten().float(), bins=num_experts, min=0, max=num_experts
+    ).int()
+
+    sorted_indices = torch.argsort(expert_indices.flatten(), stable=True)
+    token_indices = sorted_indices // top_k
+    score_indices = sorted_indices
+
+    routed_input = x[token_indices]
+    routed_scores = top_scores.flatten()[score_indices]
+
+    # 3. All-to-all dispatch: send tokens to expert-owning ranks
+    with torch.no_grad():
+        recv_counts = all_to_all(num_tokens_per_expert, None, None, axis_name)
+        send_splits = (
+            num_tokens_per_expert.view(ep_size, -1).sum(dim=1).cpu().tolist()
+        )
+        recv_splits = (
+            recv_counts.view(ep_size, -1).sum(dim=1).cpu().tolist()
+        )
+
+    routed_input = all_to_all(routed_input, recv_splits, send_splits, axis_name)
+
+    # 4. Expert computation (grouped matmul)
+    experts_per_rank = num_experts // ep_size
+    recv_counts_local = recv_counts.view(ep_size, experts_per_rank).sum(dim=0)
+    offsets = torch.cumsum(recv_counts_local, dim=0, dtype=torch.int32)
+    h = torch.nn.functional.silu(
+        torch._grouped_mm(routed_input, expert_w1.transpose(-2, -1), offs=offsets)
+    )
+    routed_output = torch._grouped_mm(h, expert_w2.transpose(-2, -1), offs=offsets)
+
+    # 5. All-to-all combine: send results back
+    routed_output = all_to_all(routed_output, send_splits, recv_splits, axis_name)
+
+    # 6-7. Un-permute and score-weight
+    out = torch.zeros(n_tokens, dim, dtype=x.dtype, device=x.device)
+    out.scatter_add_(0, token_indices.unsqueeze(-1).expand_as(routed_output),
+                     routed_output * routed_scores.unsqueeze(-1))
+    return out
+```
+
+## Wiring `local_map` into the model
+
+The model's forward method calls into the `local_map`-wrapped dispatch.
+Everything outside the dispatch — the router's gate projection, the shared
+expert FFN, residual connections — is a standard `nn.Module` operation
+that AutoParallel shards automatically.
+
+```python
+class MoELayer(nn.Module):
+    def __init__(self, dim, ffn_dim, num_experts, top_k, mesh):
+        super().__init__()
+        self.gate = nn.Linear(dim, num_experts, bias=False)
+        self.top_k = top_k
+        self.num_experts = num_experts
+        self.mesh = mesh
+
+        # Expert weights: each EP rank holds num_experts // ep_size experts
+        ep_size = mesh.size(mesh.mesh_dim_names.index("ep"))
+        local_experts = num_experts // ep_size
+        self.expert_w1 = nn.Parameter(torch.empty(local_experts, dim, ffn_dim))
+        self.expert_w2 = nn.Parameter(torch.empty(local_experts, ffn_dim, dim))
+
+    def forward(self, x):
+        bs, slen, dim = x.shape
+        x_flat = x.view(-1, dim)
+
+        # Gate projection — auto-sharded by AutoParallel
+        gate_scores = self.gate(x_flat)
+
+        # Expert dispatch — wrapped in local_map
+        #
+        # Placement contract:
+        # - x_flat, gate_scores: (Shard(0), Shard(0)) — batch-sharded on DP and EP
+        # - expert weights: (Replicate(), Shard(0)) — each EP rank has its local experts
+        # - output: (Shard(0), Shard(0)) — same as input
+        out = local_map(
+            moe_dispatch,
+            out_placements=((Shard(0), Shard(0)),),
+            in_placements=(
+                (Shard(0), Shard(0)),       # x_flat
+                (Shard(0), Shard(0)),       # gate_scores
+                (Replicate(), Shard(0)),    # expert_w1
+                (Replicate(), Shard(0)),    # expert_w2
+                None,                       # top_k (non-tensor)
+                None,                       # num_experts (non-tensor)
+                None,                       # axis_name (non-tensor)
+            ),
+            redistribute_inputs=True,
+            device_mesh=self.mesh,
+        )(x_flat, gate_scores, self.expert_w1, self.expert_w2,
+          self.top_k, self.num_experts, "ep")
+
+        return out.view(bs, slen, dim)
+```
+
+## How AutoParallel sees this
+
+From AutoParallel's perspective, the `local_map` call is a single node
+in the FX graph with declared input and output placements. The optimizer:
+
+1. Knows the inputs must be redistributed to match `in_placements`
+   (e.g., if `x_flat` arrives as `(Shard(0), Replicate())`, an all-gather
+   or redistribute will be inserted on the EP dimension)
+2. Knows the output has placement `(Shard(0), Shard(0))`
+3. Optimizes everything else — the gate projection, any shared expert,
+   residual connections, the rest of the transformer — jointly via ILP
+
+The MoE dispatch is a fixed cost in the optimization: AutoParallel doesn't
+try to optimize the communication inside `local_map`, but it does account
+for the redistribution cost to get inputs into the required placements.
+
+## Helpers in `autoparallel.collectives`
+
+AutoParallel provides collective wrappers that work inside `local_map`
+regions and have correct backward pass implementations:
+
+| Function | Forward | Backward |
+|---|---|---|
+| `all_gather(x, gather_dim, axis_name)` | All-gather on `gather_dim` | Reduce-scatter |
+| `reduce_scatter(x, scatter_dim, axis_name)` | Reduce-scatter on `scatter_dim` | All-gather |
+| `all_reduce(x, axis_name)` | Sum all-reduce | Sum all-reduce |
+| `all_to_all(x, out_splits, in_splits, axis_name)` | All-to-all | All-to-all (reversed splits) |
+| `axis_size(axis_name)` | Returns mesh size for named dim | — |
+
+These use `axis_name` (a mesh dimension name like `"ep"` or `"dp"`) to
+resolve the process group from the current mesh context. The
+`torch.autograd.Function` wrappers ensure gradients flow correctly through
+the collectives during backward.
+
+## `with_sharding_constraint` for simpler cases
+
+If you don't need custom communication but want to force a specific
+intermediate placement, use `with_sharding_constraint` instead of
+`local_map`. This is analogous to JAX's `with_sharding_constraint`:
+
+```python
+from autoparallel.collectives import with_sharding_constraint
+
+# Force activations to be sequence-sharded on the TP dimension
+x = with_sharding_constraint(x, (Shard(0), Shard(1)))
+```
+
+This inserts a redistribute if the current placement doesn't match,
+and constrains the optimizer to maintain this placement. Use it when
+the operation is expressible through DTensor but you want to override
+the optimizer's choice.
+
+## Putting it all together
+
+Here's how the `MoELayer` from above is used end-to-end with
+AutoParallel. The model contains both dense layers (auto-sharded) and
+the MoE dispatch (manual via `local_map`):
+
+```python
+from autoparallel.api import auto_parallel
+
+class MyModel(nn.Module):
+    def __init__(self, dim, ffn_dim, num_experts, top_k, mesh):
+        super().__init__()
+        self.embed = nn.Linear(dim, dim, bias=False)
+        self.moe = MoELayer(dim, ffn_dim, num_experts, top_k, mesh)
+        self.head = nn.Linear(dim, dim, bias=False)
+
+    def forward(self, x):
+        x = self.embed(x)
+        x = x + self.moe(x)
+        return self.head(x)
+
+# Create model on meta device
+with torch.device("meta"):
+    model = MyModel(dim=512, ffn_dim=2048, num_experts=64, top_k=2, mesh=mesh)
+
+batch_size = 8 * dp_size * ep_size
+seq_len = 1024
+
+sample_input = DTensor.from_local(
+    torch.randn(batch_size // (dp_size * ep_size), seq_len, 512),
+    mesh,
+    (Shard(0), Shard(0)),
+)
+
+parallel_model = auto_parallel(
+    model,
+    mesh,
+    sample_inputs=(sample_input,),
+    out_shardings=(Shard(0), Shard(0)),
+)
+
+parallel_model.to_empty(device="cuda")
+parallel_model.init_weights()
+
+# Run forward + backward with local batch
+local_batch = batch_size // (dp_size * ep_size)
+x = torch.randn(local_batch, seq_len, 512, device="cuda")
+out = parallel_model(x)
+out.sum().backward()
+```
+
+AutoParallel optimizes the sharding of `embed`, `head`, and the gate
+projection inside `MoELayer`. The `local_map` region is treated as a
+single op with fixed input/output placements.
+
+## Common pitfalls
+
+**Output shape must match `out_placements`.** The local tensor returned
+by your `local_map` function must have a shape consistent with the
+declared output placements and the global shape. If you return a tensor
+with an unexpected local shape, tracing or lowering will fail with a
+shape mismatch error.
+
+**Use `autoparallel.collectives`, not raw `torch.distributed`.** The
+wrappers in `autoparallel.collectives` (`all_to_all`, `all_gather`, etc.)
+have `torch.autograd.Function` backward implementations. If you call
+`torch.distributed.all_to_all_single` directly, gradients won't flow
+through the collective and backward will silently produce wrong results.
+
+**All-to-all split sizes must be globally consistent.** Each rank's
+`output_split_sizes` must match the corresponding `input_split_sizes` on
+the sending ranks. If they don't agree, the collective will hang or
+produce garbage. When computing splits from `num_tokens_per_expert`,
+make sure the all-to-all that exchanges token counts (step 3 in the
+example) completes before you use the received counts.
+
+**`num_experts` must be divisible by `ep_size`.** The examples above
+assume each EP rank owns `num_experts // ep_size` experts. If this
+doesn't divide evenly, you'll need to handle uneven expert assignment
+(some ranks own more experts than others), which complicates the split
+size computation and grouped matmul offsets.
+
+**Non-tensor arguments need `None` in `in_placements`.** For non-tensor
+arguments (ints, strings, etc.), set the corresponding `in_placements`
+entry to `None`. Missing or mismatched entries will cause placement
+validation errors.
+
+**`in_placements` maps to traced input order, not Python argument order.**
+`in_placements` is a 1:1 mapping to the flattened inputs of the wrapped
+function as seen by the tracer. When using `local_map` as a decorator
+(rather than calling it inline), Dynamo may reorder captured variables
+(closed-over tensors) before explicit arguments during tracing. If
+placements seem misaligned, check the actual argument order in the
+traced graph.
+
+## Summary
+
+| Scenario | Mechanism |
+|---|---|
+| Standard ops (linear, attention, pointwise) | Automatic — AutoParallel handles it |
+| Force a specific intermediate sharding | `with_sharding_constraint` |
+| Data-dependent communication (MoE routing, custom all-to-all patterns) | `local_map` |
+
+The key insight: `local_map` isn't a workaround — it's the designed
+composition point between automatic and manual parallelism. AutoParallel
+optimizes the dense parts of your model globally, and you handle the
+parts where the communication pattern is determined by runtime data.


### PR DESCRIPTION
## Summary

Add two new docs to help users understand and use AutoParallel:

- **`docs/how_autoparallel_chooses_a_strategy.md`** — explains the ILP cost model (compute, communication, transition costs), how constraints shape the solution, how to read the optimizer log, and a step-by-step debugging workflow using `explain_placement`, `print_costs_for_node`, and `diff_solutions`.

- **`docs/local_map_and_moe.md`** — explains when and how to use `local_map` for operations with data-dependent communication patterns (MoE token routing). Covers the conceptual boundary between what DTensor placements can express and what requires manual communication, with a minimal MoE example and an end-to-end `auto_parallel` invocation.

Authored with Claude.