### PR TITLE
Fix pre-existing mypy error in graph_pp_runner

### DIFF
--- a/autoparallel/graph_passes/graph_pp_runner.py
+++ b/autoparallel/graph_passes/graph_pp_runner.py
@@ -508,7 +508,8 @@ def _post_fwd_common(
 
     stage.fwd_cache[mb_index] = (output_tuple, saved_intermediates)  # type: ignore[assignment]
 
-    stage._validate_fwd_outputs(output_tuple)
+    if hasattr(stage, "_validate_fwd_outputs"):
+        stage._validate_fwd_outputs(output_tuple)
 
     schedule._maybe_compute_loss(stage, output, ctx.target_mbs, mb_index)
 


### PR DESCRIPTION
Guard _validate_fwd_outputs call with hasattr since the method was removed from PipelineStage upstream.

<!-- ps-id: 451ddd30-b323-4fc6-8a81-f5bd2019bb39 -->