### PR TITLE
Trim non-pipeline input grads before caching in bwd_cache

### DIFF
--- a/autoparallel/graph_passes/graph_pp_runner.py
+++ b/autoparallel/graph_passes/graph_pp_runner.py
@@ -672,6 +672,9 @@ def _post_backward_common(
         stage_index_to_stage: Dictionary mapping stage indices to GraphPipelineStage objects.
         is_prev_stage_on_this_rank: True if the previous stage exists on this rank.
     """
+    assert bw_stage._stage_meta.inputs is not None
+    num_fwd_args = len(bw_stage._stage_meta.inputs)
+    input_grads = input_grads[:num_fwd_args]
     bw_stage.bwd_cache[bw_mb_index] = (
         tuple(input_grads) if not isinstance(input_grads, tuple) else input_grads
     )


### PR DESCRIPTION
The backward graph may produce gradients for inputs beyond the pipeline activations (e.g. labels when loss is fused into the last stage). get_bwd_send_ops zips bwd_cache with grad_send_info using strict=True, and grad_send_info only has entries for pipeline activation inputs, so extra grads cause a ValueError.

Mirror the trimming that upstream PipelineStage does at torch/distributed/pipelining/stage.py:997.

Authored with Claude.