### PR TITLE
Enable `repeated_subgraphs` by default for faster solver times

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -235,7 +235,7 @@ class AutoParallel:
         dynamic: bool = False,
         numerics_logger: NumericsLogger | None = None,
         cost_model: Any = "nccl",
-        repeated_subgraphs: bool = False,
+        repeated_subgraphs: bool = True,
     ):
         self.stack = ExitStack()
         self.fake_mode = (


### PR DESCRIPTION
## Summary

Changes the default of `repeated_subgraphs` from False to True in AutoParallel.

## Rationale

repeated_subgraphs identifies identical subgraphs (e.g., repeated transformer layers) and constrains them to share the same sharding strategy in the ILP. This reduces the number of decision variables from `O(N)` to `O(N/K)` where `K` is the average cluster size, drastically cutting solver time on models with repeated structure — which is nearly all modern architectures.

The constraint it imposes — identical layers get identical strategies — is almost always desirable. It would be surprising and likely a solver artifact if different instances of the same layer picked different strategies. Correctness is preserved: the cost multiplier in the objective ensures the clustered ILP finds the same quality solution as the unclustered one.

The option is kept as a parameter for cases where users might want to disable it (e.g., debugging, or architectures where repeated layers should genuinely differ at pipeline boundaries).

Authored with Claude.