### PR TITLE
Skip example_ds3_pp in CI

### DIFF
--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -81,4 +81,5 @@ jobs:
         pip install --quiet .
         python examples/example_dcp.py
         torchrun --standalone --nproc-per-node 4 examples/example_ds3_local_map.py
-        torchrun --standalone --nproc_per_node=4 examples/example_ds3_pp.py --use-loss-fn --fake-evaluate
+        # Skipped: graph PP is being moved out of AutoParallel shortly.
+        # torchrun --standalone --nproc_per_node=4 examples/example_ds3_pp.py --use-loss-fn --fake-evaluate


### PR DESCRIPTION
The pipeline parallel graph runner is being moved out of AutoParallel shortly. Skip this example in CI until the migration is complete.

<!-- ps-id: c40afb0b-3565-4023-9106-22ea4a93b4d0 -->