### PR TITLE
Add preliminary XPU support using `torch.accelerator`

### DIFF
--- a/autoparallel/cost_models/compute_estimation.py
+++ b/autoparallel/cost_models/compute_estimation.py
@@ -237,12 +237,27 @@ DEVICE_LIMITS: Tuple[DeviceLimit, ...] = (
             torch.int8: 5033.2,
         },
     ),
+    # Intel Max 1550
+    DeviceLimit(
+        "Max 1550",
+        # Assuming 1600 MHz and torch.xpu.get_device_properties("xpu").max_compute_units=448
+        "https://www.intel.com/content/www/us/en/docs/oneapi/optimization-guide-gpu/2025-0/intel-xe-gpu-architecture.html",
+        sm=(-1, -1),
+        gmem_bandwidth=3.3 * (1024**4),
+        gemm_tflops={
+            torch.float64: 46,
+            torch.float32: 46,
+            torch.float16: 367,
+            torch.bfloat16: 367,
+            torch.int8: 734,
+        },
+    ),
 )
 
 
 def _get_device_limit():
     device = None
-    device_name = torch.cuda.get_device_name(device)
+    device_name = torch.get_device_module().get_device_name(device)
 
     # Find matching device limit
     device_limit = None
@@ -501,13 +516,13 @@ def benchmark_fn(fn, *args, **kwargs):
         fn(*args, **kwargs)
 
     num_iters = 10
-    start_event = torch.cuda.Event(enable_timing=True)
-    end_event = torch.cuda.Event(enable_timing=True)
-    start_event.record(torch.cuda.current_stream())
+    start_event = torch.Event(enable_timing=True)
+    end_event = torch.Event(enable_timing=True)
+    start_event.record(torch.accelerator.current_stream())
     for _ in range(num_iters):
         fn(*args, **kwargs)
-    end_event.record(torch.cuda.current_stream())
-    torch.cuda.synchronize()
+    end_event.record(torch.accelerator.current_stream())
+    torch.accelerator.synchronize()
     total_op_time = start_event.elapsed_time(end_event)
     mean_op_time_ms = total_op_time / num_iters
     mean_op_time_us = mean_op_time_ms * 1e3

--- a/autoparallel/graph_passes/auto_bucketing.py
+++ b/autoparallel/graph_passes/auto_bucketing.py
@@ -146,7 +146,7 @@ def configure_inductor_for_autobucketing(mode: str = "aten"):
     # allow configuring inductor comms optimizations from torchtitan commandline
     if mode == "aten":
         torch._inductor.config.aten_distributed_optimizations.enable_overlap_scheduling = (
-            True
+            torch.cuda.is_available() # Disable overlap scheduling for non-CUDA devices
         )
         torch._inductor.config.aten_distributed_optimizations.collective_bucketing = (
             True

--- a/autoparallel/graph_passes/auto_bucketing.py
+++ b/autoparallel/graph_passes/auto_bucketing.py
@@ -146,7 +146,7 @@ def configure_inductor_for_autobucketing(mode: str = "aten"):
     # allow configuring inductor comms optimizations from torchtitan commandline
     if mode == "aten":
         torch._inductor.config.aten_distributed_optimizations.enable_overlap_scheduling = (
-            torch.cuda.is_available() # Disable overlap scheduling for non-CUDA devices
+            torch.cuda.is_available()  # Disable overlap scheduling for non-CUDA devices
         )
         torch._inductor.config.aten_distributed_optimizations.collective_bucketing = (
             True

--- a/autoparallel/graph_passes/autobucketing_inductor/estimation_utils.py
+++ b/autoparallel/graph_passes/autobucketing_inductor/estimation_utils.py
@@ -97,7 +97,7 @@ def benchmark_comm_func(
     estimate: bool,
 ) -> float:
     rank = c10d.distributed_c10d.get_rank()
-    device = torch.device(f"cuda:{rank:d}")
+    device = torch.device(rank)
 
     if comm_func_name == "torch.ops._c10d_functional.all_gather_into_tensor.default":
         input_args = {"input_tensor": tensor_input, "output_tensor": tensor_output}
@@ -118,17 +118,17 @@ def benchmark_comm_func(
             comm_func(**input_args)
         comm_time = cm.estimated_time
     else:
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         comm_func(**input_args, group=process_group)
 
         nruns = 2
         comm_time = 0
         for _ in range(nruns):
             c10d.barrier()
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize()
 
-            start_evt = torch.cuda.Event(enable_timing=True)
-            end_evt = torch.cuda.Event(enable_timing=True)
+            start_evt = torch.Event(enable_timing=True)
+            end_evt = torch.Event(enable_timing=True)
             start_evt.record()
             comm_func(**input_args, group=process_group)
             end_evt.record()
@@ -381,15 +381,15 @@ def benchmark_extern_node(
             args, kwargs = pytree.tree_unflatten(flat_args, args_property)
             func(*args, **kwargs)
             num_iters = 3
-            start_event = torch.cuda.Event(enable_timing=True)
-            end_event = torch.cuda.Event(enable_timing=True)
+            start_event = torch.Event(enable_timing=True)
+            end_event = torch.Event(enable_timing=True)
             cpu_start = time.time()
-            start_event.record(torch.cuda.current_stream())
+            start_event.record(torch.accelerator.current_stream())
             for _ in range(num_iters):
                 func(*args, **kwargs)
-            end_event.record(torch.cuda.current_stream())
+            end_event.record(torch.accelerator.current_stream())
             cpu_end = time.time()
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize()
             cpu_time = cpu_end - cpu_start
             total_op_time = start_event.elapsed_time(end_event) - cpu_time
             mean_op_time = total_op_time / num_iters


### PR DESCRIPTION
This PR switches CUDA-specific calls to the `torch.accelerator` API to allow for use with XPU devices.