### PR TITLE
Fix mypy errors for Graph.owning_module nullability

### DIFF
--- a/autoparallel/graph_passes/async_tp/asynctp.py
+++ b/autoparallel/graph_passes/async_tp/asynctp.py
@@ -1272,7 +1272,7 @@ def micro_pipeline_tp_pass(
             "name": "asynctp_pre_graph",
             "encoding": "string",
         },
-        payload_fn=lambda: graph.owning_module.print_readable(
+        payload_fn=lambda: graph.owning_module.print_readable(  # type: ignore[union-attr]
             print_output=False, include_stride=True
         ),
     )
@@ -1323,7 +1323,7 @@ def micro_pipeline_tp_pass(
             "name": "asynctp_post_graph",
             "encoding": "string",
         },
-        payload_fn=lambda: graph.owning_module.print_readable(
+        payload_fn=lambda: graph.owning_module.print_readable(  # type: ignore[union-attr]
             print_output=False, include_stride=True
         ),
     )

--- a/autoparallel/graph_passes/auto_bucketing.py
+++ b/autoparallel/graph_passes/auto_bucketing.py
@@ -116,6 +116,7 @@ class aten_autobucketing_config:
 def aten_autobucketing_reordering_pass(
     gm: torch.fx.Graph, configs: "aten_autobucketing_config"
 ) -> torch.fx.GraphModule:
+    assert gm.owning_module is not None
     new_gm = schedule_overlap_bucketing(
         gm.owning_module,
         collective_bucketing=configs.collective_bucketing,


### PR DESCRIPTION
Graph.owning_module is typed as GraphModule | None. Add an assert in auto_bucketing where the value is passed to schedule_overlap_bucketing, and type: ignore on the two logging-only usages in asynctp.

<!-- ps-id: e278d92b-fd1c-4286-ba2f-75324aef1f68 -->