### PR TITLE
Move FSDP recompute tagging to the placement compile path

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -449,9 +449,6 @@ class AutoParallel:
         view_to_reshape(parallel_gm)
         functionalize_fresh_index_put_mutations(parallel_gm)
 
-        mark_fsdp_all_gather_recomputation(
-            parallel_gm.graph, self.reshard_after_forward
-        )
         t_ac = time.perf_counter()
         # now rename input/param/tangent/output/grad_param/grad_input nodes following
         # our convention
@@ -481,6 +478,10 @@ class AutoParallel:
     def apply_placement(self, sharding_placement):
         sharded_param_dict, sharded_buffer_dict = self._apply_placement_common(
             sharding_placement
+        )
+
+        mark_fsdp_all_gather_recomputation(
+            self.parallel_gm.graph, self.reshard_after_forward
         )
 
         self.parallel_model_fn = parallel_model_fn = aot_compile_joint_with_descriptors(

--- a/autoparallel/compile.py
+++ b/autoparallel/compile.py
@@ -12,6 +12,13 @@ from torch._inductor.compile_fx import compile_fx
 
 from .graph_passes.activation_checkpointing import ac_joint_pass
 
+_INDUCTOR_OVERLAP_PATCHES = {
+    "aten_distributed_optimizations.enable_overlap_scheduling": True,
+    "aten_distributed_optimizations.collective_bucketing": True,
+    "aten_distributed_optimizations.insert_overlap_deps": True,
+    "aten_distributed_optimizations.max_compute_pre_fetch": 10,
+}
+
 
 def _make_ac_joint_pass(
     ac_stage_size_in_GiB: Optional[Union[float, str]] = "auto",
@@ -44,21 +51,11 @@ def autoparallel_backend(
         overlap_scheduling: Enable comm/compute overlap scheduling.
     """
     functorch_patches = {}
-    inductor_patches = {}
+    inductor_patches = _INDUCTOR_OVERLAP_PATCHES if overlap_scheduling else {}
 
     if enable_ac:
         functorch_patches["joint_custom_pass"] = _make_ac_joint_pass(
             ac_stage_size_in_GiB
-        )
-
-    if overlap_scheduling:
-        inductor_patches.update(
-            {
-                "aten_distributed_optimizations.enable_overlap_scheduling": True,
-                "aten_distributed_optimizations.collective_bucketing": True,
-                "aten_distributed_optimizations.insert_overlap_deps": True,
-                "aten_distributed_optimizations.max_compute_pre_fetch": 10,
-            }
         )
 
     def backend(gm, example_inputs):


### PR DESCRIPTION
Stacked PRs:
 * #444
 * __->__#443


--- --- ---

### Move FSDP recompute tagging to the placement compile path


This moves mark_fsdp_all_gather_recomputation out of _apply_placement_common and into apply_placement, after the sharded graph has been cleaned up, traced, converted from view to reshape, functionalized for fresh index_put_ mutations, written back to joint descriptors, and prepared for AOT compilation. The common placement helper now only builds and normalizes the parallel graph, while the training compile path applies the FSDP all-gather recomputation tags immediately before invoking aot_compile_joint_with_descriptors.

Keeping the tag insertion at the apply_placement boundary makes the graph mutation order explicit: graph rewrites that affect structure happen first, descriptor state is refreshed, wait_tensor DCE behavior is installed, and then recompute metadata is added to the graph that the joint compiler consumes. This avoids mixing placement graph construction with compile-time recompute metadata and keeps the common helper usable for future placement flows that should not eagerly stamp FSDP recompute tags.

The compile backend behavior is otherwise unchanged, but the Inductor overlap-scheduling patch set is now centralized in _INDUCTOR_OVERLAP_PATCHES and selected directly when overlap_scheduling is enabled. That keeps autoparallel_backend focused on installing optional functorch AC and Inductor overlap config patches around compile_fx without rebuilding the same overlap dictionary on each backend construction.

Authored with Claude.
