### PR TITLE
Recover orphaned getitem siblings in graph clustering

### DIFF
--- a/autoparallel/graph_passes/graph_clustering.py
+++ b/autoparallel/graph_passes/graph_clustering.py
@@ -106,19 +106,31 @@ def _extend_with_sibling_getitems(
     node_to_duplicates: dict[Node, IdenticalNodes],
     strategies: dict[Node, OpStrategy],
     topological_ranking: dict[Node, int],
-) -> None:
+) -> set[Node]:
     """Extend region groups with unclaimed getitem siblings of clustered nodes.
 
     The backward-BFS expansion only reaches getitem users that happen to be on
     the main data path.  Sibling tuple projections (e.g. logsumexp, RNG state
     from SDPA) are left orphaned even though their producer is already aligned
-    across regions.  This post-pass recovers them.
+    across regions.  This post-pass recovers them in two ways:
+
+    1. If a getitem's producer is already in a region, find matching unclaimed
+       getitems across all other regions and append them in-place.
+    2. If a getitem's producer is NOT in any region but its duplicate getitems
+       (from node_to_duplicates) ARE clustered, create a small bridge group
+       that links the orphan to a clustered sibling. This handles the case
+       where the BFS created N-1 regions out of N identical layers.
+
+    Returns the set of bridge root nodes — already-clustered nodes that are
+    reused as the root region of a bridge group and therefore intentionally
+    appear in two groups.
     """
     claimed: set[Node] = set()
     for region_group in region_groups:
         for region in region_group:
             claimed.update(region)
 
+    # Case 1: extend existing regions with unclaimed getitem siblings.
     for region_group in region_groups:
         root_region = region_group[0]
         num_regions = len(region_group)
@@ -172,6 +184,58 @@ def _extend_with_sibling_getitems(
 
         for region in region_group:
             region.sort(key=lambda n: topological_ranking[n])
+
+    # Case 2: create bridge groups for orphaned getitems whose duplicates
+    # are already clustered. Each bridge group pairs one clustered sibling
+    # (as the root region) with the orphan, so create_cluster_links maps
+    # the orphan's decision variables to the root's.
+    bridge_roots: set[Node] = set()
+    seen_dup_groups: set[int] = set()
+    for node in strategies:
+        if node.target is not operator.getitem:
+            continue
+        if node in claimed:
+            continue
+        if node not in node_to_duplicates:
+            continue
+        dups = node_to_duplicates[node]
+        group_id = id(dups)
+        if group_id in seen_dup_groups:
+            continue
+        seen_dup_groups.add(group_id)
+
+        if len(dups) < 2:
+            continue
+        if not all(d in strategies for d in dups):
+            continue
+
+        # Find one claimed duplicate to serve as the root.
+        root = None
+        for d in dups:
+            if d in claimed:
+                root = d
+                break
+        if root is None:
+            continue
+
+        # Create a bridge group: [[root], [orphan1], [orphan2], ...]
+        bridge = [[root]]
+        for d in dups:
+            if d not in claimed:
+                bridge.append([d])
+                claimed.add(d)
+        if len(bridge) < 2:
+            continue
+        bridge.sort(key=lambda r: topological_ranking[r[0]])
+        # Ensure the root is first (create_cluster_links uses region[0]
+        # as the root).
+        root_idx = next(i for i, r in enumerate(bridge) if r[0] is root)
+        if root_idx != 0:
+            bridge[0], bridge[root_idx] = bridge[root_idx], bridge[0]
+        region_groups.append(bridge)
+        bridge_roots.add(root)
+
+    return bridge_roots
 
 
 def get_identical_regions(
@@ -258,6 +322,7 @@ def get_identical_regions(
     # overlap.
     t = time.time()
     seen_nodes: set[Node] = set()
+    expanded_groups: list[list[Region]] = []
     for region_group in region_groups:
         # NOTE: this seems like it's missing in the original implementation
         # from PyTorch. Given that fully_expand_region_group doesn't check
@@ -277,12 +342,13 @@ def get_identical_regions(
         # sort topologically
         for region in region_group:
             region.sort(key=lambda n: topological_ranking[n])
+        expanded_groups.append(region_group)
 
     region_groups = [
-        region_group for region_group in region_groups if len(region_group[0]) > 1
+        region_group for region_group in expanded_groups if len(region_group[0]) > 1
     ]
 
-    _extend_with_sibling_getitems(
+    bridge_roots = _extend_with_sibling_getitems(
         region_groups, node_to_duplicates, strategies, topological_ranking
     )
 
@@ -292,12 +358,14 @@ def get_identical_regions(
     region_groups.sort(key=lambda rg: topological_ranking[rg[0][0]])
     logger.debug(f"Expanded regions in {time.time() - t} s")
 
-    # sanity check that we don't have duplicate nodes
+    # sanity check that we don't have duplicate nodes.
+    # Bridge roots are already-clustered nodes reused as root regions in
+    # bridge groups (case 2 above); they intentionally appear in two groups.
     seen_nodes.clear()
     for region_group in region_groups:
         for region in region_group:
             for node in region:
-                if node in seen_nodes:
+                if node in seen_nodes and node not in bridge_roots:
                     raise RuntimeError(f"Duplicate node {node} in region group")
                 seen_nodes.add(node)
     return region_groups

--- a/autoparallel/graph_passes/graph_clustering.py
+++ b/autoparallel/graph_passes/graph_clustering.py
@@ -11,7 +11,7 @@ import logging
 import math
 import time
 from collections import defaultdict
-from typing import Optional
+from typing import Optional, cast
 
 import torch
 from torch._dynamo.graph_region_tracker import (
@@ -99,6 +99,79 @@ def _hash_node(node, strategies, input_pickler):
         ),
     )
     return sha256_hash(input_pickler.dumps(key))
+
+
+def _extend_with_sibling_getitems(
+    region_groups: list[list[Region]],
+    node_to_duplicates: dict[Node, IdenticalNodes],
+    strategies: dict[Node, OpStrategy],
+    topological_ranking: dict[Node, int],
+) -> None:
+    """Extend region groups with unclaimed getitem siblings of clustered nodes.
+
+    The backward-BFS expansion only reaches getitem users that happen to be on
+    the main data path.  Sibling tuple projections (e.g. logsumexp, RNG state
+    from SDPA) are left orphaned even though their producer is already aligned
+    across regions.  This post-pass recovers them.
+    """
+    claimed: set[Node] = set()
+    for region_group in region_groups:
+        for region in region_group:
+            claimed.update(region)
+
+    for region_group in region_groups:
+        root_region = region_group[0]
+        num_regions = len(region_group)
+
+        for pos in range(len(root_region)):
+            root_producer = root_region[pos]
+            getitems_by_idx: dict[int, list[Node]] = defaultdict(list)
+            for user in root_producer.users:
+                if (
+                    user.target is operator.getitem
+                    and user not in claimed
+                    and user in strategies
+                ):
+                    getitems_by_idx[cast(int, user.args[1])].append(user)
+
+            for k, root_matches in getitems_by_idx.items():
+                if len(root_matches) != 1:
+                    continue
+                root_getitem = root_matches[0]
+                if root_getitem not in node_to_duplicates:
+                    continue
+                root_dups = node_to_duplicates[root_getitem]
+                root_phase = root_getitem.meta.get("partitioner_tag")
+
+                candidates = [root_getitem]
+                valid = True
+                for other_region in region_group[1:]:
+                    other_producer = other_region[pos]
+                    matches = [
+                        user
+                        for user in other_producer.users
+                        if (
+                            user.target is operator.getitem
+                            and user.args[1] == k
+                            and user not in claimed
+                            and user in strategies
+                            and user in node_to_duplicates
+                            and node_to_duplicates[user] is root_dups
+                            and user.meta.get("partitioner_tag") == root_phase
+                        )
+                    ]
+                    if len(matches) != 1:
+                        valid = False
+                        break
+                    candidates.append(matches[0])
+
+                if valid and len(candidates) == num_regions:
+                    for region, getitem_node in zip(region_group, candidates):
+                        region.append(getitem_node)
+                        claimed.add(getitem_node)
+
+        for region in region_group:
+            region.sort(key=lambda n: topological_ranking[n])
 
 
 def get_identical_regions(
@@ -208,6 +281,10 @@ def get_identical_regions(
     region_groups = [
         region_group for region_group in region_groups if len(region_group[0]) > 1
     ]
+
+    _extend_with_sibling_getitems(
+        region_groups, node_to_duplicates, strategies, topological_ranking
+    )
 
     # sort everything so that we have nodes in topological ranking
     for region_group in region_groups:

--- a/tests/test_graph_clustering.py
+++ b/tests/test_graph_clustering.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 
+import operator
 import re
 from collections import Counter
 
@@ -151,3 +152,78 @@ def test_clustering_no_forward_backward_mixing(device_mesh_2d):
             tags = set(n.meta.get("partitioner_tag") for n in region)
             tags.discard(None)
             assert len(tags) <= 1, f"Cluster group {i}, region {j} mixes phases: {tags}"
+
+
+def test_getitem_siblings_are_clustered(device_mesh_2d):
+    """Getitem nodes that project sibling outputs from tuple-returning ops
+    (e.g. SDPA returning (output, logsumexp, rng_state)) should be clustered
+    together with their producer when the producer is already clustered."""
+    n_layers = 4
+    autop, _ = _setup_llama_autop(device_mesh_2d, n_layers=n_layers)
+    with autop:
+        x_sharding = (Shard(0), Replicate())
+        out_sharding = (Shard(0), Shard(2))
+        autop.add_input_constraints([x_sharding])
+        autop.add_output_constraints([out_sharding])
+
+        graph = autop.sharding_optimizer.graph
+        strats = autop.sharding_optimizer.strats
+        clusters = get_identical_regions(graph, strats)
+
+    clustered_nodes = set()
+    for group in clusters:
+        for region in group:
+            clustered_nodes.update(region)
+
+    # Find all getitem nodes that have strategies and belong to layers
+    unclustered_getitems = []
+    for node in graph.nodes:
+        if node.target is not operator.getitem:
+            continue
+        if node not in strats:
+            continue
+        layer_idx = _get_layer_index(node)
+        if layer_idx is not None and node not in clustered_nodes:
+            unclustered_getitems.append(node)
+
+    assert len(unclustered_getitems) == 0, (
+        f"{len(unclustered_getitems)} getitem nodes in layers are not clustered: "
+        f"{[n.name for n in unclustered_getitems[:5]]}"
+    )
+
+
+def test_getitem_siblings_cluster_consistency(device_mesh_2d):
+    """Getitem siblings added by _extend_with_sibling_getitems should appear
+    in the same cluster group as their producer, with one per region."""
+    n_layers = 4
+    autop, _ = _setup_llama_autop(device_mesh_2d, n_layers=n_layers)
+    with autop:
+        x_sharding = (Shard(0), Replicate())
+        out_sharding = (Shard(0), Shard(2))
+        autop.add_input_constraints([x_sharding])
+        autop.add_output_constraints([out_sharding])
+
+        graph = autop.sharding_optimizer.graph
+        strats = autop.sharding_optimizer.strats
+        clusters = get_identical_regions(graph, strats)
+
+    for i, group in enumerate(clusters):
+        num_regions = len(group)
+        # Collect all getitem nodes across all regions in this group
+        getitems_in_group = []
+        for region in group:
+            for node in region:
+                if node.target is operator.getitem:
+                    getitems_in_group.append(node)
+
+        if not getitems_in_group:
+            continue
+
+        # Each getitem index should appear exactly once per region
+        # Group getitems by their tuple index
+        by_index = Counter(n.args[1] for n in getitems_in_group)
+        for idx, count in by_index.items():
+            assert count == num_regions, (
+                f"Cluster group {i}: getitem[{idx}] appears {count} times "
+                f"but there are {num_regions} regions"
+            )


### PR DESCRIPTION
The backward-BFS region expansion in `get_identical_regions` only reaches getitem nodes on the main data path. Sibling tuple projections — like the logsumexp or RNG state outputs from SDPA — get left unclustered even though their producer is already aligned across regions.

`_extend_with_sibling_getitems` is a conservative post-pass that scans each clustered producer for unclaimed getitem users, verifies they have matching duplicates (same identity group, same phase, same tuple index) across all regions in the group, and appends them. If any validation check fails, it leaves the getitems alone.

Authored with Claude.