### PR TITLE
Improve newcomer documentation and docs discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ mix) and applies it — no manual parallelism code required.
 > [issue tracker](https://github.com/pytorch-labs/autoparallel/issues) before
 > starting work.
 
+New to AutoParallel? Start with the [Getting Started guide](docs/getting_started.md).
+
 ## Requirements
 
 - Python >= 3.10
@@ -39,13 +41,33 @@ python examples/example_hf.py --model gpt2 --mesh 8
 
 You should see log output ending with `Forward + backward OK`.
 
-For more examples (LLaMA-3, pipeline parallelism, distributed checkpointing),
+For more examples (LLaMA-3, distributed checkpointing, `local_map` / MoE),
 see the [`examples/`](examples/) directory.
+
+## Documentation
+
+Start here if you're new to AutoParallel:
+
+- [Getting Started](docs/getting_started.md)
+- [Basic Concepts](docs/basic_concepts.md)
+- [API Walkthrough](docs/api_walkthrough.md)
+
+Troubleshooting and common questions:
+
+- [Troubleshooting](docs/troubleshooting.md)
+- [FAQ](docs/faq.md)
+
+Deeper explanations and advanced topics:
+
+- [How AutoParallel Chooses a Strategy](docs/how_autoparallel_chooses_a_strategy.md)
+- [Adaptive Sharding: Sequence-Parallel vs Column-Parallel](docs/adaptive_sharding.md)
+- [Using `local_map` for MoE and Custom Communication Patterns](docs/local_map_and_moe.md)
+- [Documentation Index](docs/README.md)
 
 ## Developing
 
 ```bash
-cd autoparallel
+# Run from the repository root
 pip install -e .
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# AutoParallel Documentation
+
+This directory contains newcomer guides, conceptual background, troubleshooting
+notes, and deeper explanations of how AutoParallel chooses sharding strategies.
+
+If you're new to the project, use the reading order below.
+
+## Start here
+
+- [Getting Started](getting_started.md)
+- [Basic Concepts](basic_concepts.md)
+- [API Walkthrough](api_walkthrough.md)
+
+## Troubleshooting and reference
+
+- [Troubleshooting](troubleshooting.md)
+- [FAQ](faq.md)
+
+## How AutoParallel works
+
+- [How AutoParallel Chooses a Strategy](how_autoparallel_chooses_a_strategy.md)
+- [Adaptive Sharding: Sequence-Parallel vs Column-Parallel](adaptive_sharding.md)
+
+## Advanced usage
+
+- [Using `local_map` for MoE and Custom Communication Patterns](local_map_and_moe.md)

--- a/docs/api_walkthrough.md
+++ b/docs/api_walkthrough.md
@@ -1,0 +1,321 @@
+# API Walkthrough
+
+This guide walks through the full lifecycle of using AutoParallel and explains
+when to use the simple helper versus the full context-manager API.
+
+## Choose the API
+
+Use:
+
+- `auto_parallel(...)` when you want the shortest path to a parallelized module
+- `AutoParallel(...)` when you want to add constraints, inspect logs, or debug
+  specific optimizer decisions
+
+## Workflow overview
+
+Most usage follows this sequence:
+
+1. Create or load a model.
+2. Define a `DeviceMesh`.
+3. Provide example inputs.
+4. Tell AutoParallel how inputs and outputs are sharded.
+5. Optionally add a parameter memory constraint.
+6. Optimize placements.
+7. Apply placements and materialize the returned module.
+8. Initialize or load weights.
+9. Run eager or compiled execution.
+
+## Simple API: `auto_parallel(...)`
+
+The simple API is a wrapper around the full API.
+
+```python
+from autoparallel import auto_parallel
+
+parallel_model = auto_parallel(
+    model,
+    mesh,
+    sample_inputs=(sample_x,),
+    out_shardings=(Shard(0), Replicate()),
+    mp_policy=mp_policy,
+    parameter_memory_budget=(None, None),
+    dynamic=False,
+)
+```
+
+### Arguments
+
+#### `model`
+
+The `nn.Module` to parallelize. It may be constructed on the meta device.
+
+#### `mesh`
+
+A `DeviceMesh` that defines the distributed topology.
+
+#### `sample_inputs`
+
+Either:
+
+- a pytree of sample inputs, or
+- a callable returning that pytree
+
+Leaf tensors may be:
+
+- ordinary `torch.Tensor`: assumed replicated on all mesh dimensions
+- `DTensor`: placements are extracted and used as input constraints
+
+Using DTensor sample inputs is usually the clearest way to express input
+sharding.
+
+#### `out_shardings`
+
+A pytree matching the model output structure. Each leaf is a placement tuple.
+
+Examples:
+
+```python
+out_shardings=(Shard(0),)
+out_shardings=(Shard(0), Replicate())
+out_shardings={"logits": (Shard(0),), "loss": (Replicate(),)}
+```
+
+#### `mp_policy`
+
+Optional `MixedPrecisionPolicy` used when building the parallelized model.
+
+#### `parameter_memory_budget`
+
+Optional `(low, high)` pair controlling parameter memory constraints. Passing
+`(None, None)` uses the current default bounds and is often appropriate for
+training workloads.
+
+#### `dynamic`
+
+If `True`, AutoParallel traces with symbolic dimensions so the returned module
+accepts variable batch sizes more easily.
+
+## Full API: `AutoParallel(...)`
+
+Use the full API when you want to control the optimization process.
+
+```python
+from autoparallel import AutoParallel
+
+with AutoParallel(model, input_fn, mesh, mp_policy=mp_policy) as autop:
+    autop.add_input_constraints([(Shard(0), Replicate())])
+    autop.add_output_constraints([(Shard(0), Replicate())])
+    autop.add_parameter_memory_constraint(low=None, high=None)
+
+    sharding = autop.optimize_placement(verbose=True)
+    parallel_model = autop.apply_placement(sharding)
+```
+
+## Step-by-step with the full API
+
+### 1. Define `input_fn()`
+
+`input_fn()` is called during tracing and must return global-shaped example
+inputs.
+
+```python
+def input_fn():
+    global_batch = 64
+    seq_len = 128
+    hidden_dim = 4096
+    return torch.randn(global_batch, seq_len, hidden_dim, device="cuda")
+```
+
+A common mistake is to return a per-rank local batch here. During tracing,
+AutoParallel wants the global logical input.
+
+### 2. Add input constraints
+
+```python
+autop.add_input_constraints([(Shard(0), Replicate())])
+```
+
+This says the runtime input is batch-sharded across the first mesh dimension and
+replicated across the second.
+
+### 3. Add output constraints
+
+```python
+autop.add_output_constraints([(Shard(0), Replicate())])
+```
+
+For a first experiment, constraining outputs to match inputs is often the most
+predictable option.
+
+### 4. Add parameter memory constraints
+
+```python
+autop.add_parameter_memory_constraint(low=None, high=None)
+```
+
+Without this, the optimizer may choose to replicate parameters if that lowers
+communication cost.
+
+### 5. Optimize placements
+
+```python
+sharding = autop.optimize_placement(verbose=True)
+```
+
+This solves the global optimization problem. With `verbose=True`, the optimizer
+log is emitted through Python logging and structured tracing.
+
+### 6. Apply placements
+
+```python
+parallel_model = autop.apply_placement(sharding)
+```
+
+This builds the parallelized module from the chosen strategy.
+
+## Runtime model lifecycle
+
+After either API returns a parallelized module, the normal sequence is:
+
+```python
+parallel_model.to_empty(device="cuda")
+# initialize or load weights
+out = parallel_model(local_x)
+out.sum().backward()
+```
+
+A few important details:
+
+- The returned module expects local per-rank inputs.
+- If the original model was built on meta, you must initialize or load weights
+  after `to_empty`.
+- The module can be compiled with `torch.compile` and
+  `autoparallel_backend()`.
+
+## Running the script with multiple GPUs
+
+AutoParallel does not launch distributed workers itself. For a real run, launch
+your script with the usual PyTorch distributed launcher and make sure the world
+size matches the mesh size.
+
+Examples:
+
+```bash
+torchrun --nproc_per_node=4 my_script.py
+torchrun --nproc_per_node=8 my_script.py
+```
+
+Typical mapping:
+
+- mesh `(4,)` -> world size 4
+- mesh `(2, 4)` -> world size 8
+
+The fake-process-group examples in `examples/` are useful for quick smoke tests
+on one machine, but they are not substitutes for a real multi-process launch.
+
+## Seeing optimizer logs
+
+`optimize_placement(verbose=True)` sends the human-readable optimizer log
+through Python logging. If you want to see it in a small standalone script,
+configure logging explicitly:
+
+```python
+import logging
+
+logging.basicConfig(level=logging.INFO)
+```
+
+## Example: simple API with DTensor inputs
+
+```python
+import torch
+from torch import nn
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.fsdp import MixedPrecisionPolicy
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor.placement_types import Replicate, Shard
+
+from autoparallel import auto_parallel
+
+
+class ToyBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.up = nn.Linear(1024, 4096, bias=False)
+        self.down = nn.Linear(4096, 1024, bias=False)
+
+    def forward(self, x):
+        return self.down(torch.relu(self.up(x)))
+
+
+mesh = init_device_mesh("cuda", (2, 4), mesh_dim_names=("dp", "tp"))
+
+with torch.device("meta"):
+    model = ToyBlock()
+
+sample_x = DTensor.from_local(
+    torch.randn(8, 128, 1024),
+    mesh,
+    [Shard(0), Replicate()],
+)
+
+parallel_model = auto_parallel(
+    model,
+    mesh,
+    sample_inputs=(sample_x,),
+    out_shardings=(Shard(0), Replicate()),
+    mp_policy=MixedPrecisionPolicy(
+        param_dtype=torch.bfloat16,
+        reduce_dtype=torch.float32,
+    ),
+    parameter_memory_budget=(None, None),
+)
+```
+
+## Example: compile after parallelization
+
+```python
+from autoparallel import autoparallel_backend
+
+parallel_model = torch.compile(
+    parallel_model,
+    backend=autoparallel_backend(),
+)
+```
+
+Compilation is not required for correctness, but it is the intended path for
+more optimized execution.
+
+## When to use optimizer internals
+
+The full API exposes `autop.sharding_optimizer`, which is useful when:
+
+- a chosen placement surprises you
+- the optimization is infeasible
+- you want to compare two constrained solutions
+- you want to inspect redistribution costs for a specific node
+
+Useful methods documented elsewhere include:
+
+- `apply_prefetch_discount(...)`
+- `explain_placement(...)`
+- `print_costs_for_node(...)`
+- `diff_solutions(...)`
+
+See [How AutoParallel Chooses a Strategy](how_autoparallel_chooses_a_strategy.md)
+for the optimizer-focused workflow.
+
+## Which API should you start with?
+
+Start with `auto_parallel(...)` if:
+
+- you are validating basic support for a model
+- you already know the desired input and output sharding
+- you do not need verbose optimizer inspection yet
+
+Start with `AutoParallel(...)` if:
+
+- your first run failed
+- you want to control constraints explicitly
+- you want to understand or change the chosen plan
+- you are doing research or development on optimizer behavior

--- a/docs/basic_concepts.md
+++ b/docs/basic_concepts.md
@@ -1,0 +1,229 @@
+# Basic Concepts
+
+This page introduces the minimum set of concepts you need to read AutoParallel
+logs and use the API effectively.
+
+## Mental model
+
+AutoParallel works in four stages:
+
+1. **Trace the model** into a joint forward/backward FX graph.
+2. **Enumerate valid sharding strategies** for each graph node.
+3. **Solve a global optimization problem** to choose one strategy per node.
+4. **Apply the chosen placements** to produce a parallelized module.
+
+A useful shorthand is:
+
+```text
+model -> graph -> candidate shardings -> optimized plan -> parallel module
+```
+
+## Device mesh
+
+A `DeviceMesh` describes the logical arrangement of ranks that AutoParallel is
+allowed to use.
+
+Examples:
+
+- 1D mesh: `(8,)`
+- 2D mesh: `(dp, tp) = (4, 8)`
+
+```python
+mesh = torch.distributed.device_mesh.init_device_mesh(
+    "cuda",
+    (4, 8),
+    mesh_dim_names=("dp", "tp"),
+)
+```
+
+The mesh dimensions matter because placements are written in mesh order. On the
+2D mesh above:
+
+- `(Shard(0), Replicate())` means shard on batch over `dp`, replicate over `tp`
+- `(Replicate(), Shard(1))` means replicate over `dp`, shard tensor dim 1 over `tp`
+
+## DTensor placements
+
+AutoParallel uses the same placement vocabulary as DTensor.
+
+### `Replicate()`
+
+Each rank holds the full tensor.
+
+### `Shard(dim)`
+
+The tensor is partitioned evenly along tensor dimension `dim` across the
+corresponding mesh dimension.
+
+Example on a `(dp, tp)` mesh:
+
+```python
+(Shard(0), Replicate())
+```
+
+means “shard tensor dim 0 across `dp`, but replicate across `tp`.”
+
+### `Partial()`
+
+Each rank holds a partial contribution that still needs a reduction to become a
+fully valid value. This often appears around distributed matmuls and gradient
+aggregation. In logs or debugging output, you may also see this written in a
+more explicit form such as `P(sum)`.
+
+## Global shape vs local shape
+
+This is one of the most important distinctions for newcomers.
+
+### During tracing
+
+AutoParallel reasons about **global** tensors.
+
+- `input_fn()` in the full API should return global-shaped tensors.
+- `sample_inputs` in the simple API describe global inputs too, even when passed
+  as DTensors constructed from local shards.
+
+### During execution
+
+The returned parallel module runs on **local** tensors per rank.
+
+If your global batch is 32 and the input is sharded on batch across 4 DP ranks,
+then each rank should receive local batch 8 at runtime.
+
+## Input constraints and output constraints
+
+These tell AutoParallel what sharding must hold at the graph boundary.
+
+Typical first constraint on a 1D or `(dp, tp)` mesh:
+
+```python
+(Shard(0),)              # 1D mesh
+(Shard(0), Replicate())  # 2D mesh
+```
+
+This says “shard the input batch on the first mesh dimension.”
+
+Why constraints matter:
+
+- They encode what data layout your training loop provides.
+- They reduce ambiguity for the optimizer.
+- They make logs much easier to interpret.
+
+## Parameter memory constraint
+
+Without a parameter memory constraint, the optimizer may decide that replicating
+parameters everywhere is cheapest because it avoids communication.
+
+In many training settings, that is not what you want. Adding a parameter memory
+constraint forces the optimizer to consider parameter sharding.
+
+With the full API:
+
+```python
+autop.add_parameter_memory_constraint(low=None, high=None)
+```
+
+With the simple API:
+
+```python
+parameter_memory_budget=(None, None)
+```
+
+In the current implementation, `low=None, high=None` means “use the default
+bounds,” which effectively pushes parameter memory toward being divided across
+ranks.
+
+## What the optimizer is choosing
+
+For each graph node, AutoParallel considers valid strategies such as:
+
+- replicated inputs with replicated outputs
+- sharded activations with replicated weights
+- sharded weights with replicated activations
+- partial outputs that later reduce
+
+The optimizer is not choosing layer by layer independently. It solves for the
+whole graph at once, so a strategy that looks locally expensive may still be
+chosen if it reduces redistributions elsewhere.
+
+## Redistribution
+
+When one node produces a tensor in one placement and the next node expects a
+different placement, AutoParallel inserts a redistribution.
+
+Typical cases:
+
+- `Shard -> Replicate`: all-gather
+- `Partial -> Replicate`: all-reduce
+- `Partial -> Shard`: reduce-scatter
+- `Shard(dim_a) -> Shard(dim_b)`: all-to-all
+
+These redistributions are a major part of the optimizer's cost model.
+
+## Why AutoParallel sometimes makes surprising choices
+
+A few common reasons:
+
+- A placement reduces communication later in the graph.
+- An intra-node communication is much cheaper than an inter-node one.
+- The parameter memory constraint is missing, so replication looks cheap.
+- The output constraint forces a layout that changes the best internal plan.
+- The model contains operations for which only a limited set of placements is
+  currently implemented.
+
+If you want the full explanation of the objective and constraints, read
+[How AutoParallel Chooses a Strategy](how_autoparallel_chooses_a_strategy.md).
+
+## `auto_parallel(...)` vs `AutoParallel(...)`
+
+### `auto_parallel(...)`
+
+Use this when you already know:
+
+- the sample inputs
+- the desired output sharding
+- whether you want a parameter memory budget
+
+It is the easier entry point.
+
+### `AutoParallel(...)`
+
+Use this when you need to:
+
+- set input/output constraints explicitly
+- inspect verbose optimizer logs
+- use `autop.sharding_optimizer` helpers directly
+- experiment with constraints and re-solve
+
+## Meta models and materialization
+
+It is common to construct large models on the meta device before parallelizing:
+
+```python
+with torch.device("meta"):
+    model = MyModel(...)
+```
+
+The returned parallel module must then be materialized on a real device:
+
+```python
+parallel_model.to_empty(device="cuda")
+```
+
+At that point, parameters still need real values. You must initialize them or
+load a checkpoint before real training or inference.
+
+## Compilation
+
+The parallelized module runs eagerly by default. For better execution behavior,
+you can compile it with the AutoParallel backend:
+
+```python
+from autoparallel import autoparallel_backend
+
+parallel_model = torch.compile(
+    parallel_model,
+    backend=autoparallel_backend(),
+)
+```
+
+This is optional for getting started, but common in real use.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,143 @@
+# FAQ
+
+## Is AutoParallel stable?
+
+No. It is explicitly experimental. Expect missing features, unsupported cases,
+and API changes.
+
+## Do I need multiple GPUs to try it?
+
+Not necessarily for the tracing and optimization pipeline. The
+`examples/example_hf.py` script uses a fake process group so you can exercise
+much of the flow on a single machine.
+
+For real execution, you still need CUDA hardware appropriate for the mesh you
+want to run.
+
+## Should I start with `auto_parallel(...)` or `AutoParallel(...)`?
+
+Start with `auto_parallel(...)` if you want the shortest path to a working
+parallelized module.
+
+Start with `AutoParallel(...)` if you need:
+
+- explicit input/output constraints
+- verbose logs
+- direct access to optimizer utilities
+- iterative debugging of the chosen plan
+
+## How do I run my script on multiple GPUs?
+
+Use PyTorch's normal distributed launcher, typically `torchrun`, and make sure
+the world size matches the product of your mesh dimensions.
+
+Examples:
+
+```bash
+torchrun --nproc_per_node=4 my_script.py
+torchrun --nproc_per_node=8 my_script.py
+```
+
+Typical mapping:
+
+- mesh `(4,)` -> world size 4
+- mesh `(2, 4)` -> world size 8
+
+The fake-process-group examples in `examples/` are helpful for smoke tests, but
+they are not real multi-process distributed launches.
+
+## What models work best today?
+
+Standard transformer-style models and other graphs built mostly from common
+PyTorch ops are the best fit.
+
+Advanced custom communication patterns are possible, but usually require manual
+composition through `local_map`.
+
+## What if my model has MoE or custom all-to-all communication?
+
+Use `local_map` for the region where communication depends on runtime data.
+AutoParallel can still optimize the surrounding dense parts of the model.
+
+See [Using `local_map` for MoE and Custom Communication Patterns](local_map_and_moe.md).
+
+## What is the difference between a global input and a local runtime input?
+
+During tracing, AutoParallel reasons about the global logical input.
+
+At runtime, each rank passes only its local shard to the returned parallel
+module.
+
+This is the most common source of confusion for first-time users.
+
+## Why does the optimizer choose replication when I expected sharding?
+
+Often because no parameter memory constraint was added. Without that, full
+replication may be cheapest in the optimizer's cost model.
+
+Use:
+
+- `autop.add_parameter_memory_constraint(low=None, high=None)` in the full API
+- `parameter_memory_budget=(None, None)` in the simple API
+
+## Do I need to build the model on the meta device?
+
+No, but it is often convenient for large models.
+
+If you do build on meta, the returned parallel module must later be materialized
+with `to_empty(device="cuda")` and then initialized or loaded from a checkpoint.
+
+## Does AutoParallel compile the model automatically?
+
+No. The returned module runs eagerly unless you explicitly compile it:
+
+```python
+parallel_model = torch.compile(
+    parallel_model,
+    backend=autoparallel_backend(),
+)
+```
+
+## I used `verbose=True`, but I do not see the optimizer log. Why?
+
+The verbose optimizer report is emitted through Python logging. In a standalone
+script, configure logging explicitly:
+
+```python
+import logging
+
+logging.basicConfig(level=logging.INFO)
+```
+
+## What does `sample_inputs` do in the simple API?
+
+It provides example inputs for tracing and also communicates input sharding.
+
+- Plain `Tensor` leaves are treated as replicated.
+- `DTensor` leaves carry placement information.
+
+## What does `out_shardings` mean?
+
+It specifies the required sharding at the model output boundary. The structure
+must match the model output structure.
+
+## Why is PyTorch nightly required?
+
+AutoParallel relies on evolving PyTorch export, fake tensor, AOTAutograd,
+Inductor, and DTensor functionality. Stable releases may not yet contain the
+APIs or behavior the project expects.
+
+## Is this for training only, or inference too?
+
+The project is primarily oriented around training-oriented graph analysis and
+sharding decisions, but the generated module also has a forward-only path for
+inference. In practice, training is the more developed mental model for the
+current docs and examples.
+
+## Where should I go after the FAQ?
+
+- [Getting Started](getting_started.md)
+- [Basic Concepts](basic_concepts.md)
+- [API Walkthrough](api_walkthrough.md)
+- [Troubleshooting](troubleshooting.md)
+- [How AutoParallel Chooses a Strategy](how_autoparallel_chooses_a_strategy.md)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,267 @@
+# Getting Started with AutoParallel
+
+AutoParallel automatically chooses sharding strategies for a PyTorch model,
+then applies them to produce a distributed module. Instead of manually deciding
+where to use FSDP, tensor parallelism, or intermediate redistributions, you
+provide a model, a device mesh, and example inputs; AutoParallel traces the
+joint forward/backward graph, solves for a low-cost sharding plan, and returns a
+parallelized module.
+
+This guide is the best place to start if you are new to the project.
+
+## What AutoParallel is good at today
+
+AutoParallel is currently most useful when all of the following are true:
+
+- You already have a PyTorch `nn.Module` training workload.
+- You are comfortable with PyTorch distributed concepts such as `DeviceMesh`
+  and DTensor placements.
+- You want AutoParallel to choose among parameter sharding, activation sharding,
+  and tensor parallel layouts for standard transformer-style computation.
+- You are okay using experimental APIs and PyTorch nightly.
+
+If you are trying to understand why the optimizer chose a specific strategy,
+read [How AutoParallel Chooses a Strategy](how_autoparallel_chooses_a_strategy.md)
+after this guide.
+
+## Requirements
+
+- Python 3.10+
+- PyTorch nightly newer than 2.10
+- CUDA GPUs for real execution
+
+Install AutoParallel from GitHub:
+
+```bash
+pip install git+https://github.com/pytorch-labs/autoparallel.git
+```
+
+For local development:
+
+```bash
+pip install -e .
+```
+
+## The two APIs
+
+AutoParallel exposes two ways to use the library:
+
+- `auto_parallel(...)`: the simpler API; best for first use
+- `AutoParallel(...)`: the full context-manager API; use this when you want to
+  add constraints, inspect logs, or call optimizer utilities directly
+
+Most newcomers should start with `auto_parallel(...)`, then switch to the full
+API when they need more control.
+
+## Your first successful run
+
+The easiest way to get a feel for the project is the HuggingFace example:
+
+```bash
+pip install transformers
+python examples/example_hf.py --model gpt2 --mesh 8
+```
+
+That example uses a fake process group so you can exercise the AutoParallel
+pipeline on a single machine without launching a real multi-process job. It is
+best thought of as a convenient single-process smoke test for tracing,
+optimization, and module construction, not as a real 8-rank training launch. A
+successful run ends with:
+
+```text
+Forward + backward OK
+```
+
+## Minimal example with the simple API
+
+The `auto_parallel(...)` helper takes:
+
+- a model
+- a `DeviceMesh`
+- sample inputs for tracing
+- the desired output sharding
+
+```python
+import torch
+from torch import nn
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.fsdp import MixedPrecisionPolicy
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor.placement_types import Replicate, Shard
+
+from autoparallel import auto_parallel
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, hidden_dim: int):
+        super().__init__()
+        self.w1 = nn.Linear(dim, hidden_dim, bias=False)
+        self.w2 = nn.Linear(hidden_dim, dim, bias=False)
+
+    def forward(self, x):
+        return self.w2(torch.relu(self.w1(x)))
+
+
+mesh = init_device_mesh("cuda", (4,), mesh_dim_names=("dp",))
+
+with torch.device("meta"):
+    model = MLP(dim=1024, hidden_dim=4096)
+
+local_batch = 8
+seq_len = 128
+sample_x = DTensor.from_local(
+    torch.randn(local_batch, seq_len, 1024),
+    mesh,
+    [Shard(0)],
+)
+
+parallel_model = auto_parallel(
+    model,
+    mesh,
+    sample_inputs=(sample_x,),
+    out_shardings=(Shard(0),),
+    mp_policy=MixedPrecisionPolicy(
+        param_dtype=torch.bfloat16,
+        reduce_dtype=torch.float32,
+    ),
+    parameter_memory_budget=(None, None),
+)
+
+parallel_model.to_empty(device="cuda")
+# Initialize or load weights here if the model was constructed on meta.
+
+x = torch.randn(local_batch, seq_len, 1024, device="cuda")
+out = parallel_model(x)
+out.sum().backward()
+```
+
+This example assumes a real 4-rank CUDA setup. In practice, that usually means
+launching the script with `torchrun` on a machine with at least 4 visible GPUs.
+If you only want a first smoke test on one machine without a real distributed
+launch, use `examples/example_hf.py`, which sets up a fake process group for
+you.
+
+### What the example is doing
+
+- The `DTensor` sample input tells AutoParallel that the global input is sharded
+  on batch dimension 0 across the mesh.
+- `out_shardings=(Shard(0),)` asks for the output to stay batch-sharded.
+- `parameter_memory_budget=(None, None)` applies the default parameter memory
+  constraint through the simple API. This usually matters in training settings,
+  because otherwise the optimizer may prefer to replicate parameters.
+- `parallel_model.to_empty(device="cuda")` materializes the returned module on
+  CUDA. If you built the original model on the meta device, you must then
+  initialize or load its parameters before real execution.
+
+## Minimal example with the full API
+
+Use the full `AutoParallel` API when you want explicit control over constraints
+or verbose optimizer logs.
+
+```python
+import torch
+from torch import nn
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.fsdp import MixedPrecisionPolicy
+from torch.distributed.tensor.placement_types import Replicate, Shard
+
+from autoparallel import AutoParallel
+
+
+class Block(nn.Module):
+    def __init__(self, dim: int, hidden_dim: int):
+        super().__init__()
+        self.w1 = nn.Linear(dim, hidden_dim, bias=False)
+        self.w2 = nn.Linear(hidden_dim, dim, bias=False)
+
+    def forward(self, x):
+        return self.w2(torch.relu(self.w1(x)))
+
+
+mesh = init_device_mesh("cuda", (4,), mesh_dim_names=("dp",))
+
+with torch.device("meta"):
+    model = Block(1024, 4096)
+
+
+def input_fn():
+    global_batch = 32
+    seq_len = 128
+    return torch.randn(global_batch, seq_len, 1024, device="cuda")
+
+
+mp_policy = MixedPrecisionPolicy(
+    param_dtype=torch.bfloat16,
+    reduce_dtype=torch.float32,
+)
+
+with AutoParallel(model, input_fn, mesh, mp_policy=mp_policy) as autop:
+    autop.add_input_constraints([(Shard(0),)])
+    autop.add_output_constraints([(Shard(0),)])
+    autop.add_parameter_memory_constraint(low=None, high=None)
+
+    sharding = autop.optimize_placement(verbose=True)
+    parallel_model = autop.apply_placement(sharding)
+
+parallel_model.to_empty(device="cuda")
+# Initialize or load weights here.
+```
+
+The important distinction is that `input_fn()` returns global-shaped tensors,
+while the resulting parallel module expects each rank to receive its local shard
+at runtime.
+
+This full-API example also assumes a real distributed run. If your mesh is
+`(4,)`, you typically launch 4 processes:
+
+```bash
+torchrun --nproc_per_node=4 my_script.py
+```
+
+For a 2D mesh like `(2, 4)`, the product of the mesh dimensions must match the
+world size. On a single node, that would usually mean:
+
+```bash
+torchrun --nproc_per_node=8 my_script.py
+```
+
+AutoParallel does not launch processes for you; it assumes your distributed job
+has already been launched and that the mesh matches the active world size.
+
+## Logging and verbose optimizer output
+
+When you call `optimize_placement(verbose=True)`, AutoParallel emits the
+optimizer log through Python logging. If your script has not configured
+logging, you may not see much output.
+
+For ad hoc debugging, add:
+
+```python
+import logging
+
+logging.basicConfig(level=logging.INFO)
+```
+
+Some examples in this repository use `logging.DEBUG` to show even more detail.
+
+## Recommended first workflow
+
+For a first experiment, use this checklist:
+
+1. Start with a small model or one of the examples.
+2. Use a 1D mesh first, usually with batch sharding on mesh dim 0.
+3. Constrain both inputs and outputs explicitly.
+4. Add a parameter memory constraint for training.
+5. Run `optimize_placement(verbose=True)` and inspect the log.
+6. Only after that, move to a 2D mesh or custom constraints.
+
+## What to read next
+
+- [Basic Concepts](basic_concepts.md): core ideas and terminology
+- [API Walkthrough](api_walkthrough.md): end-to-end lifecycle with both APIs
+- [Troubleshooting](troubleshooting.md): common errors and what they usually mean
+- [FAQ](faq.md): quick answers to common questions
+- [How AutoParallel Chooses a Strategy](how_autoparallel_chooses_a_strategy.md):
+  deeper explanation of the optimizer
+- [Using `local_map` for MoE and Custom Communication Patterns](local_map_and_moe.md):
+  advanced integration for dynamic communication patterns

--- a/docs/how_autoparallel_chooses_a_strategy.md
+++ b/docs/how_autoparallel_chooses_a_strategy.md
@@ -10,6 +10,14 @@ to minimize total cost across the entire graph simultaneously.
 This document explains what goes into that cost, how constraints shape
 the solution, and how to interpret and debug the optimizer's decisions.
 
+This is an explanation-oriented document for users who already have a
+basic working mental model of AutoParallel. If you are new to the
+project, start with:
+
+- [Getting Started](getting_started.md)
+- [Basic Concepts](basic_concepts.md)
+- [API Walkthrough](api_walkthrough.md)
+
 ## The three cost components
 
 Every candidate strategy has a cost that is the sum of three components:
@@ -333,5 +341,13 @@ size, sequence length, and hardware topology.
 
 ## Further reading
 
+- [Getting Started](getting_started.md) — first-use setup and recommended
+  workflow
+- [API Walkthrough](api_walkthrough.md) — end-to-end usage of the simple
+  and full APIs
+- [Troubleshooting](troubleshooting.md) — common failure modes and
+  debugging steps
 - [adaptive_sharding.md](adaptive_sharding.md) — detailed analysis of
   the sequence-parallel vs column-parallel tradeoff for LLaMA3
+- [local_map_and_moe.md](local_map_and_moe.md) — advanced composition
+  for MoE and custom communication patterns

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,220 @@
+# Troubleshooting
+
+AutoParallel is still experimental, so failures are not unusual. This guide
+covers the most common failure modes and what they usually mean.
+
+## First debugging step
+
+If you are using the full API, start here:
+
+```python
+sharding = autop.optimize_placement(verbose=True)
+```
+
+The verbose log is the fastest way to answer:
+
+- what placements were available
+- what placements were chosen
+- whether communication or compute dominated
+- whether constraints made the problem infeasible
+
+The verbose report is emitted through Python logging. If your script has not
+configured logging, add:
+
+```python
+import logging
+
+logging.basicConfig(level=logging.INFO)
+```
+
+## The optimizer cannot find a feasible solution
+
+Typical error:
+
+```text
+The sharding optimizer could not find a feasible solution.
+```
+
+Usually this means one of the following:
+
+- input and output constraints contradict available strategies
+- the device mesh is too small for the requested sharding
+- a forced placement is unsupported for some operation in the graph
+
+What to try:
+
+1. Remove output constraints first.
+2. Relax custom node constraints.
+3. Start with a 1D mesh.
+4. Use only batch sharding on the input.
+5. Re-run with `verbose=True` and inspect the warning log.
+
+## The optimizer replicated all parameters
+
+Symptom:
+
+- the chosen plan looks mostly replicated
+- you expected FSDP-style parameter sharding but do not see it
+
+Most common cause:
+
+- no parameter memory constraint was added
+
+Fix:
+
+Full API:
+
+```python
+autop.add_parameter_memory_constraint(low=None, high=None)
+```
+
+Simple API:
+
+```python
+parameter_memory_budget=(None, None)
+```
+
+If you are reading the optimizer docs closely, also note that the prefetch
+discount is not applied automatically. For more detail, see
+[How AutoParallel Chooses a Strategy](how_autoparallel_chooses_a_strategy.md).
+
+## My first run failed during tracing
+
+Common causes:
+
+- unsupported or not-yet-handled PyTorch operators
+- Python-side control flow that does not export cleanly
+- inputs whose structure or types differ between tracing and execution
+- custom communication performed directly in the model graph
+
+What to try:
+
+- Start from one of the examples and gradually move toward your model.
+- Reduce the model to the smallest failing submodule.
+- Replace unsupported custom communication with `local_map` if the pattern is
+  intentionally manual.
+- Make sure `input_fn()` or `sample_inputs` matches the true runtime input
+  structure.
+
+## Local/global shape confusion
+
+Symptom:
+
+- shape checks fail at runtime
+- the compiled module rejects inputs that look "correct"
+
+Common cause:
+
+- the tracing inputs were treated as local instead of global, or vice versa
+
+Rule of thumb:
+
+- `input_fn()` in the full API returns global logical inputs
+- runtime execution uses local per-rank inputs
+- `DTensor.from_local(...)` in the simple API still describes a global input
+  placement, even though you provide a local shard to build the DTensor
+
+If in doubt, start with a global batch size that divides cleanly across the mesh
+and verify the expected local batch manually.
+
+## The runtime model exists, but outputs are garbage or unstable
+
+Possible causes:
+
+- the model was created on meta and never initialized
+- `to_empty(device="cuda")` was called, but weights were neither loaded nor
+  initialized afterward
+- an uninitialized model happened to run numerically
+
+Fix:
+
+After `to_empty`, initialize or load the parameters before real training or
+inference.
+
+## Runtime input checking fails
+
+The generated parallel module validates runtime inputs against the traced input
+signature. Failures usually mean:
+
+- wrong number of tensor leaves
+- wrong dtype
+- wrong local shape
+- pytree structure changed between tracing and execution
+
+Fixes:
+
+- Keep the exact same argument structure.
+- Keep non-tensor arguments in the same positions.
+- Check whether the runtime input should be local or global.
+- Recreate `sample_inputs` or `input_fn()` from the actual training step.
+
+## `local_map` shape mismatch or placement mismatch
+
+If you are using `local_map`, common causes include:
+
+- returned local tensor shape does not match declared `out_placements`
+- `in_placements` entries do not line up with traced input order
+- non-tensor arguments are missing `None` entries in `in_placements`
+
+What to check:
+
+- Every output placement matches the actual local tensor shape.
+- Every non-tensor argument has `None` in `in_placements`.
+- If using a decorator form, inspect the traced graph order if placements seem
+  shifted.
+
+For the full MoE/custom communication workflow, see
+[Using `local_map` for MoE and Custom Communication Patterns](local_map_and_moe.md).
+
+## Hanging collectives in custom code
+
+Most often this comes from using raw `torch.distributed` collectives inside a
+`local_map` region or from inconsistent split sizes in `all_to_all`.
+
+Use `autoparallel.collectives` wrappers instead of raw distributed calls inside
+`local_map`, and verify that all split sizes match across ranks. The main
+wrappers are `all_gather`, `reduce_scatter`, `all_reduce`, and `all_to_all`;
+see [Using `local_map` for MoE and Custom Communication Patterns](local_map_and_moe.md)
+for a concrete example.
+
+## Version or environment issues
+
+Typical signs:
+
+- import-time errors
+- missing internal APIs
+- tracing/export failures that look unrelated to your model
+
+Checklist:
+
+- Use Python 3.10+
+- Use a recent enough PyTorch nightly
+- Re-test on the exact example scripts in `examples/`
+
+Because AutoParallel depends on internal and evolving PyTorch machinery,
+mismatched versions can fail in ways that look like user mistakes.
+
+## How to reduce a bug report
+
+A good bug report usually includes:
+
+- the exact PyTorch version and commit/nightly date
+- CUDA and GPU type
+- mesh shape and mesh dim names
+- whether you used `auto_parallel` or `AutoParallel`
+- a minimal model that reproduces the issue
+- the exact constraints used
+- the verbose optimizer log if optimization succeeded but looked wrong
+
+## Practical debugging sequence
+
+When something is off, this order is usually fastest:
+
+1. Try a smaller model or submodule.
+2. Use a 1D mesh.
+3. Constrain only the input batch sharding.
+4. Add the parameter memory constraint.
+5. Run `optimize_placement(verbose=True)`.
+6. Only then add output constraints, 2D meshes, or custom placement overrides.
+7. Once the script logic is sound, switch from a fake-process-group smoke test
+   to a real `torchrun` launch.


### PR DESCRIPTION
This PR builds out a newcomer-facing documentation path for AutoParallel and makes it easier to discover from the repo landing page.

The easiest way to review it is in three steps. First, read the root `README.md`, which now points new users directly to the documentation and fixes a few stale or confusing references. Then read `docs/README.md` plus the new core guides: `docs/getting_started.md`, `docs/basic_concepts.md`, `docs/api_walkthrough.md`, `docs/troubleshooting.md`, and `docs/faq.md`. Finally, look at the smaller follow-up edits to `docs/how_autoparallel_chooses_a_strategy.md`, which now better positions itself as an advanced explanation and links back into the beginner docs.

The main goal is to give first-time users a clearer path from “what is this project?” to “how do I run it?” to “how do I debug it when something goes wrong?” The new docs also make a few important operational points explicit, including the distinction between fake-process-group smoke tests and real distributed runs, the need to use `torchrun` for multi-GPU execution, and the fact that `optimize_placement(verbose=True)` emits output through Python logging.

Authored with Claude.