### PR TITLE
Support unused parameters and non-tensor placeholders in the sharding pipeline

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -494,7 +494,10 @@ class AutoParallel:
 
         fw_metadata = self.joint_with_descriptors._aot_state.fw_metadata
         num_fwd_outputs = fw_metadata.num_forward_returns
-        fwd_only_gm = extract_forward_graph(self.parallel_gm, num_fwd_outputs)
+        num_primals = len(fw_metadata.input_info)
+        fwd_only_gm = extract_forward_graph(
+            self.parallel_gm, num_fwd_outputs, num_primals
+        )
         compiler_fn = self.compiler_fn
         aot_config = self.joint_with_descriptors._aot_state.aot_config
         out_spec = self.joint_with_descriptors.out_spec
@@ -528,8 +531,6 @@ class AutoParallel:
             _inference_fn_cache = inference_fn
             return _inference_fn_cache
 
-        # TODO: this probably belongs in the AOTAutograd API
-        # TODO: pytree handling
         # Capture the exact FQNs the compiled graph expects as primals.
         # This avoids issues with aliased params/buffers where identity-based
         # dedup can break after init_weights reassigns tensors.

--- a/autoparallel/apply_sharding.py
+++ b/autoparallel/apply_sharding.py
@@ -364,8 +364,8 @@ def _make_local_args(gm, sharding_placement):
     for node in gm.graph.find_nodes(op="placeholder"):
         val = node.meta.get("val")
         if not isinstance(val, torch.Tensor):
-            # Non-tensor placeholders (e.g. unused params): pass through
-            # the original value so the interpreter gets the right arg count.
+            # Non-tensor placeholders (e.g. baked-in booleans/strings):
+            # pass through the original value so the arg count stays aligned.
             local_args.append(val)
             continue
         tensor = val

--- a/autoparallel/apply_sharding.py
+++ b/autoparallel/apply_sharding.py
@@ -362,7 +362,13 @@ def _make_local_args(gm, sharding_placement):
 
     local_args = []
     for node in gm.graph.find_nodes(op="placeholder"):
-        tensor = node.meta["val"]
+        val = node.meta.get("val")
+        if not isinstance(val, torch.Tensor):
+            # Non-tensor placeholders (e.g. unused params): pass through
+            # the original value so the interpreter gets the right arg count.
+            local_args.append(val)
+            continue
+        tensor = val
         tgt_spec = sharding_placement[node].input_specs[0]
         mesh = tgt_spec.mesh
         curr_placement = (Replicate(),) * mesh.ndim

--- a/autoparallel/graph_passes/extract_forward.py
+++ b/autoparallel/graph_passes/extract_forward.py
@@ -7,6 +7,7 @@ import copy
 
 import torch.fx
 import torch.utils._pytree as pytree
+from torch._subclasses.fake_tensor import unset_fake_temporarily
 
 
 def _reachable_from_output(graph: torch.fx.Graph) -> set[torch.fx.Node]:
@@ -25,7 +26,9 @@ def _reachable_from_output(graph: torch.fx.Graph) -> set[torch.fx.Node]:
 
 
 def extract_forward_graph(
-    joint_gm: torch.fx.GraphModule, num_fwd_outputs: int
+    joint_gm: torch.fx.GraphModule,
+    num_fwd_outputs: int,
+    num_primals: int | None = None,
 ) -> torch.fx.GraphModule:
     """Extract a forward-only graph from a joint forward+backward graph.
 
@@ -33,7 +36,13 @@ def extract_forward_graph(
     not reachable from the trimmed output (backward nodes, tangent
     placeholders, backward-only collectives, saved activations).
     """
-    gm = copy.deepcopy(joint_gm)
+    # FakeTensorMode may still be active (pushed onto the ExitStack by
+    # aot_export_joint_with_descriptors during __enter__).  deepcopy
+    # clones tensor storage, and FakeTensorMode intercepts the
+    # aten.set_.source_Storage call, which fails when the cloned
+    # (real) storage device doesn't match the original (meta) device.
+    with unset_fake_temporarily():
+        gm = copy.deepcopy(joint_gm)
     graph = gm.graph
 
     # The joint graph output is nested: ((fwd_outs...), (bwd_outs...)).
@@ -44,12 +53,21 @@ def extract_forward_graph(
     fwd_outputs = flat_outputs[:num_fwd_outputs]
     output_node.args = (tuple(fwd_outputs),)
 
+    # Identify the first num_primals placeholders — these are function
+    # inputs (params, buffers, user inputs) that must stay to match the
+    # calling convention, even when unused (e.g. unused parameters).
+    # The remaining placeholders are tangents (backward-only inputs).
+    if num_primals is not None:
+        placeholders = [n for n in graph.nodes if n.op == "placeholder"]
+        primal_nodes = set(placeholders[:num_primals])
+    else:
+        primal_nodes = set()
+
     # Compute reachability from the trimmed output and remove
-    # everything else (backward nodes, tangent placeholders,
-    # backward-only collectives, etc.).
+    # everything else, except primal placeholders.
     reachable = _reachable_from_output(graph)
     for node in reversed(list(graph.nodes)):
-        if node not in reachable:
+        if node not in reachable and node not in primal_nodes:
             node.replace_all_uses_with(None)
             graph.erase_node(node)
 

--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -298,11 +298,10 @@ class ShardingOptimizer:
                 val = node.meta.get("val")
                 if isinstance(val, torch.Tensor):
                     strats[node] = _create_all_options(self.mesh, val.shape, tensor=val)
-                else:
-                    # Non-tensor placeholders: unused parameters (e.g.
-                    # teacher-only params) or GraphModule submodules used by
-                    # HOPs. Keep them in strats with empty-shape replicate
-                    # options so the constraint system can reference them.
+                elif node.op == "placeholder":
+                    # Non-tensor placeholders (e.g. unused parameters):
+                    # keep them in strats with empty-shape replicate options
+                    # so the constraint system can reference them.
                     strats[node] = _create_all_options(self.mesh, ())
             elif node.op == "call_function":
                 if not _produces_tensor(node.meta.get("val")):
@@ -359,17 +358,14 @@ class ShardingOptimizer:
     def _all_input_nodes(self, node):
         """Variant of node.all_input_nodes that preserves duplicate nodes.
 
-        Filters out nodes not in self.strats, and non-tensor get_attr nodes
-        (HOP submodule bodies) which are in strats but should not appear as
-        numbered args for redistribute_cost indexing.
+        Filters out nodes not in self.strats:
+        - get_attr: HOP submodule nodes (GraphModules)
+        - call_function producing non-tensors: shape-computation nodes
+          (sym_size, operator.mul, etc.)
         """
         result = []
         for x in all_input_nodes(node):
             if x in self.strats:
-                if x.op == "get_attr" and not isinstance(
-                    x.meta.get("val"), torch.Tensor
-                ):
-                    continue
                 result.append(x)
             elif x.op != "get_attr":
                 val = x.meta.get("val")

--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -359,14 +359,17 @@ class ShardingOptimizer:
     def _all_input_nodes(self, node):
         """Variant of node.all_input_nodes that preserves duplicate nodes.
 
-        Filters out nodes not in self.strats:
-        - get_attr: HOP submodule nodes (GraphModules)
-        - call_function producing non-tensors: shape-computation nodes
-          (sym_size, operator.mul, etc.)
+        Filters out nodes not in self.strats, and non-tensor get_attr nodes
+        (HOP submodule bodies) which are in strats but should not appear as
+        numbered args for redistribute_cost indexing.
         """
         result = []
         for x in all_input_nodes(node):
             if x in self.strats:
+                if x.op == "get_attr" and not isinstance(
+                    x.meta.get("val"), torch.Tensor
+                ):
+                    continue
                 result.append(x)
             elif x.op != "get_attr":
                 val = x.meta.get("val")

--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -303,6 +303,16 @@ class ShardingOptimizer:
                     # keep them in strats with empty-shape replicate options
                     # so the constraint system can reference them.
                     strats[node] = _create_all_options(self.mesh, ())
+                else:
+                    # Non-tensor get_attr: GraphModule submodules used by
+                    # HOPs — not added to strats, invisible to the ILP.
+                    # _all_input_nodes filters them.
+                    assert node.op == "get_attr"
+                    assert any(
+                        isinstance(u.target, torch._ops.HigherOrderOperator)
+                        or "local_map" in u.name
+                        for u in node.users
+                    ), f"Non-tensor get_attr {node} is not used by a HOP"
             elif node.op == "call_function":
                 if not _produces_tensor(node.meta.get("val")):
                     # Shape-computation nodes (sym_size, operator.mul, etc.)

--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -299,7 +299,7 @@ class ShardingOptimizer:
                 if isinstance(val, torch.Tensor):
                     strats[node] = _create_all_options(self.mesh, val.shape, tensor=val)
                 elif node.op == "placeholder":
-                    # Non-tensor placeholders (e.g. unused parameters):
+                    # Non-tensor placeholders (e.g. baked-in booleans/strings):
                     # keep them in strats with empty-shape replicate options
                     # so the constraint system can reference them.
                     strats[node] = _create_all_options(self.mesh, ())

--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -299,14 +299,11 @@ class ShardingOptimizer:
                 if isinstance(val, torch.Tensor):
                     strats[node] = _create_all_options(self.mesh, val.shape, tensor=val)
                 else:
-                    # GraphModule submodules used by HOPs — not added to
-                    # strats, invisible to the ILP. _all_input_nodes filters
-                    # them. Guard: every skipped node must be consumed by a HOP.
-                    assert any(
-                        isinstance(u.target, torch._ops.HigherOrderOperator)
-                        or "local_map" in u.name
-                        for u in node.users
-                    ), f"Non-tensor get_attr {node} is not used by a HOP"
+                    # Non-tensor placeholders: unused parameters (e.g.
+                    # teacher-only params) or GraphModule submodules used by
+                    # HOPs. Keep them in strats with empty-shape replicate
+                    # options so the constraint system can reference them.
+                    strats[node] = _create_all_options(self.mesh, ())
             elif node.op == "call_function":
                 if not _produces_tensor(node.meta.get("val")):
                     # Shape-computation nodes (sym_size, operator.mul, etc.)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -440,6 +440,56 @@ def test_unused_parameters_captured(device_mesh_1d):
     ), f"unused_linear.bias not found in parallel model params: {param_names}"
 
 
+def test_unused_parameter_full_pipeline(device_mesh_1d):
+    """Unused parameters must not break the full pipeline including inference."""
+    dim = 128
+
+    class Model(nn.Module):
+        def __init__(self, dim):
+            super().__init__()
+            self.used_linear = nn.Linear(dim, dim)
+            self.unused_linear = nn.Linear(dim, dim)
+
+        def forward(self, x):
+            return self.used_linear(x)
+
+        def init_weights(self):
+            nn.init.ones_(self.used_linear.weight)
+            nn.init.zeros_(self.used_linear.bias)
+            nn.init.ones_(self.unused_linear.weight)
+            nn.init.zeros_(self.unused_linear.bias)
+
+    with torch.device("meta"):
+        model = Model(dim)
+
+    batch_size = 512
+    local_batch_size = batch_size // device_mesh_1d.size()
+    x = DTensor.from_local(
+        torch.rand(local_batch_size, dim, device="cuda"),
+        device_mesh_1d,
+        [Shard(0)],
+    )
+    parallel_mod = auto_parallel(
+        model,
+        device_mesh_1d,
+        sample_inputs=(x,),
+        out_shardings=(Shard(0),),
+    )
+    parallel_mod.to_empty(device="cuda")
+    parallel_mod.init_weights()
+
+    # Training forward
+    inp = torch.rand(local_batch_size, dim, device="cuda")
+    out = parallel_mod(inp)
+    assert out.shape == (local_batch_size, dim)
+
+    # Inference forward (exercises extract_forward_graph / deepcopy path)
+    with torch.no_grad():
+        out_infer = parallel_mod(inp)
+    assert out_infer.shape == out.shape
+    torch.testing.assert_close(out_infer, out)
+
+
 def test_aliased_submodule(device_mesh_1d):
     """Test that aliased submodules (two module attrs pointing to the same object) work.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -478,10 +478,18 @@ def test_unused_parameter_full_pipeline(device_mesh_1d):
     parallel_mod.to_empty(device="cuda")
     parallel_mod.init_weights()
 
-    # Training forward
+    # Training forward + backward
     inp = torch.rand(local_batch_size, dim, device="cuda")
     out = parallel_mod(inp)
     assert out.shape == (local_batch_size, dim)
+    out.sum().backward()
+
+    # Used params should have gradients
+    assert parallel_mod.used_linear.weight.grad is not None
+    assert parallel_mod.used_linear.bias.grad is not None
+    # Unused params should have no gradient (not None with zeros — actually None)
+    assert parallel_mod.unused_linear.weight.grad is None
+    assert parallel_mod.unused_linear.bias.grad is None
 
     # Inference forward (exercises extract_forward_graph / deepcopy path)
     with torch.no_grad():

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -264,3 +264,44 @@ def test_backward_numerical_equivalence():
     actual = gm(grad_out, x)
 
     torch.testing.assert_close(actual, expected)
+
+
+def test_extract_forward_deepcopy_with_tensor_constants():
+    """extract_forward_graph must deepcopy a graph module that has real (non-fake)
+    tensor constants even when FakeTensorMode is active.
+
+    Models that use lift_fresh_copy (e.g. for random ops or constant tensors)
+    produce get_attr nodes pointing to real cuda tensors on the graph module.
+    copy.deepcopy of such a graph module fails under FakeTensorMode because
+    the mode intercepts storage cloning (aten.set_.source_Storage) and rejects
+    the device mismatch between the cloned real storage and the fake wrapper.
+    """
+    from torch._subclasses import FakeTensorMode
+
+    from autoparallel.graph_passes.extract_forward import extract_forward_graph
+
+    # Build a minimal joint-like graph: one primal placeholder, one get_attr
+    # for a real tensor constant, a mul, and a nested output.
+    gm = torch.fx.GraphModule({}, torch.fx.Graph())
+    graph = gm.graph
+
+    # Register a real cuda tensor as a graph module attribute
+    gm._tensor_constant0 = torch.tensor([1.0, 2.0], device="cuda")
+
+    x = graph.placeholder("primals_1")
+    x.meta["val"] = torch.randn(4, 2, device="cuda")
+    const = graph.get_attr("_tensor_constant0")
+    const.meta["val"] = gm._tensor_constant0
+    mul = graph.call_function(torch.ops.aten.mul.Tensor, (x, const))
+    mul.meta["val"] = torch.randn(4, 2, device="cuda")
+    # Joint-style nested output: ((fwd_outs,), (bwd_outs,))
+    graph.output(((mul,), (mul,)))
+    gm.recompile()
+
+    # This should succeed even under FakeTensorMode
+    with FakeTensorMode():
+        result = extract_forward_graph(gm, num_fwd_outputs=1, num_primals=1)
+
+    # The real tensor constant should survive the deepcopy
+    assert hasattr(result, "_tensor_constant0")
+    assert result._tensor_constant0.device.type == "cuda"


### PR DESCRIPTION
Models with unused parameters (e.g. a teacher subnet only used during evaluation) would hit argument-count mismatches in the inference path. This PR fixes two places that assumed every parameter flows to the output, and hardens the pipeline against non-tensor placeholders.

- `extract_forward_graph` now accepts an optional `num_primals` to preserve primal placeholders (params, buffers, user inputs) even when unreachable from the forward output. The deepcopy is also wrapped in `unset_fake_temporarily()` to fix a device mismatch crash when the joint graph contains real CUDA tensor constants (e.g. from `lift_fresh_copy`) under an active FakeTensorMode.

- `optimize_sharding.py` gives non-tensor placeholders (baked-in booleans/strings) empty-shape replicate options instead of falling through without strats, and `apply_sharding._make_local_args` passes them through to keep the argument list aligned.

Authored with Claude.