### PR TITLE
Make inference path compatible with torch.compile(fullgraph=True) 

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -499,34 +499,26 @@ class AutoParallel:
         aot_config = self.joint_with_descriptors._aot_state.aot_config
         out_spec = self.joint_with_descriptors.out_spec
 
-        _inference_fn_cache = None
+        # Build inference function eagerly so that Dynamo doesn't try
+        # to trace into compiler_fn / RuntimeWrapper.post_compile (both
+        # on its skip list, causing graph breaks under fullgraph=True).
+        _fwd_example_inputs = [
+            n.meta["val"] for n in fwd_only_gm.graph.nodes if n.op == "placeholder"
+        ]
+        _compiled_fwd = compiler_fn(fwd_only_gm, _fwd_example_inputs)
 
-        def _get_inference_fn():
-            nonlocal _inference_fn_cache
-            if _inference_fn_cache is not None:
-                return _inference_fn_cache
-            example_inputs = [
-                n.meta["val"] for n in fwd_only_gm.graph.nodes if n.op == "placeholder"
-            ]
-            compiled = compiler_fn(fwd_only_gm, example_inputs)
+        from torch._functorch._aot_autograd.runtime_wrappers import RuntimeWrapper
 
-            # Wrap with RuntimeWrapper to handle mutation write-back
-            # (e.g. buffer updates like BatchNorm running stats), output
-            # alias handling, and intermediate base stripping.
-            from torch._functorch._aot_autograd.runtime_wrappers import RuntimeWrapper
+        _wrapped_fwd = RuntimeWrapper(
+            indices_of_inps_to_detach=[],
+            trace_joint=False,
+            disable_amp=False,
+        ).post_compile(_compiled_fwd, aot_config, runtime_metadata=fw_metadata)
 
-            wrapped = RuntimeWrapper(
-                indices_of_inps_to_detach=[],
-                trace_joint=False,
-                disable_amp=False,
-            ).post_compile(compiled, aot_config, runtime_metadata=fw_metadata)
-
-            def inference_fn(args):
-                flat_outs = wrapped(args)
-                return torch.utils._pytree.tree_unflatten(flat_outs, out_spec)
-
-            _inference_fn_cache = inference_fn
-            return _inference_fn_cache
+        @torch._dynamo.nonstrict_trace
+        def _inference_fn(args):
+            flat_outs = _wrapped_fwd(args)
+            return torch.utils._pytree.tree_unflatten(flat_outs, out_spec)
 
         # TODO: this probably belongs in the AOTAutograd API
         # TODO: pytree handling
@@ -571,7 +563,7 @@ class AutoParallel:
                 # NB: don't do self.parallel_model_fn work around Dynamo bug
                 out = parallel_model_fn(boxed_args)
             else:
-                out = _get_inference_fn()(boxed_args)
+                out = _inference_fn(boxed_args)
             return out
 
         self.parallel_model = make_parallel_module(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -757,3 +757,75 @@ def test_inherited_user_model(device_mesh_1d):
     assert isinstance(parallel_mod, Model)
     assert isinstance(parallel_mod, BaseModel)
     assert parallel_mod.get_num_params() > 0
+
+
+def _make_simple_parallel_mod(device_mesh_1d):
+    dim = 128
+    batch_size = 512
+    local_batch_size = batch_size // device_mesh_1d.size()
+
+    class SimpleLinear(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(dim, dim)
+
+        def forward(self, x):
+            return self.linear(x)
+
+    with torch.device("meta"):
+        model = SimpleLinear()
+
+    x = DTensor.from_local(
+        torch.randn(local_batch_size, dim, device="cuda"),
+        device_mesh_1d,
+        [Shard(0)],
+    )
+
+    parallel_mod = auto_parallel(
+        model, device_mesh_1d, sample_inputs=(x,), out_shardings=(Shard(0),)
+    )
+    parallel_mod.to_empty(device="cuda")
+    return parallel_mod, local_batch_size, dim
+
+
+def test_compile_fullgraph_training(device_mesh_1d):
+    """torch.compile(fullgraph=True) works in training mode (grad enabled)."""
+    parallel_mod, bs, dim = _make_simple_parallel_mod(device_mesh_1d)
+    torch._dynamo.reset()
+    compiled = torch.compile(parallel_mod, fullgraph=True)
+    x = torch.randn(bs, dim, device="cuda")
+    out = compiled(x)
+    assert out.shape == (bs, dim)
+
+
+def test_compile_fullgraph_inference(device_mesh_1d):
+    """torch.compile(fullgraph=True) works in inference mode (no_grad)."""
+    parallel_mod, bs, dim = _make_simple_parallel_mod(device_mesh_1d)
+    torch._dynamo.reset()
+    compiled = torch.compile(parallel_mod, fullgraph=True)
+    with torch.no_grad():
+        x = torch.randn(bs, dim, device="cuda")
+        out = compiled(x)
+    assert out.shape == (bs, dim)
+
+
+def test_compile_no_recompilation(device_mesh_1d):
+    """Repeated forward calls don't trigger recompilation in either mode."""
+    parallel_mod, bs, dim = _make_simple_parallel_mod(device_mesh_1d)
+    torch._dynamo.reset()
+    compiled = torch.compile(parallel_mod)
+
+    # Warm up both paths (each triggers one compilation)
+    compiled(torch.randn(bs, dim, device="cuda"))
+    with torch.no_grad():
+        compiled(torch.randn(bs, dim, device="cuda"))
+
+    # Subsequent calls in either mode must not recompile
+    torch._dynamo.config.error_on_recompile = True
+    try:
+        for _ in range(3):
+            compiled(torch.randn(bs, dim, device="cuda"))
+            with torch.no_grad():
+                compiled(torch.randn(bs, dim, device="cuda"))
+    finally:
+        torch._dynamo.config.error_on_recompile = False

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -809,11 +809,11 @@ def test_compile_fullgraph_inference(device_mesh_1d):
     assert out.shape == (bs, dim)
 
 
-def test_compile_no_recompilation(device_mesh_1d):
-    """Repeated forward calls don't trigger recompilation in either mode."""
+def test_compile_fullgraph_no_recompilation(device_mesh_1d):
+    """Repeated fullgraph calls in both grad modes don't recompile."""
     parallel_mod, bs, dim = _make_simple_parallel_mod(device_mesh_1d)
     torch._dynamo.reset()
-    compiled = torch.compile(parallel_mod)
+    compiled = torch.compile(parallel_mod, fullgraph=True)
 
     # Warm up both paths (each triggers one compilation)
     compiled(torch.randn(bs, dim, device="cuda"))

--- a/tests/test_flex_attention.py
+++ b/tests/test_flex_attention.py
@@ -531,3 +531,29 @@ def test_flex_attention_gqa_compile(device_mesh_1d):
     with torch.device("meta"):
         model = FlexAttnGQAModel(DIM, N_HEADS, n_kv_heads)
     _run_auto_parallel(model, device_mesh_1d, compile=True)
+
+
+def test_flex_attention_compile_no_recompilation(device_mesh_1d):
+    """flex_attention parallel module doesn't recompile on repeated calls."""
+    with torch.device("meta"):
+        model = FlexAttnModel(DIM, N_HEADS)
+    parallel_mod = _run_auto_parallel(model, device_mesh_1d)
+    parallel_mod.to_empty(device="cuda")
+
+    torch._dynamo.reset()
+    compiled = torch.compile(parallel_mod)
+
+    x = torch.randn(LOCAL_BS, SEQLEN, DIM, device="cuda")
+
+    # Warm up both grad modes
+    compiled(x)
+    with torch.no_grad():
+        compiled(x)
+
+    torch._dynamo.config.error_on_recompile = True
+    try:
+        compiled(x)
+        with torch.no_grad():
+            compiled(x)
+    finally:
+        torch._dynamo.config.error_on_recompile = False

--- a/tests/test_flex_attention.py
+++ b/tests/test_flex_attention.py
@@ -557,3 +557,39 @@ def test_flex_attention_compile_no_recompilation(device_mesh_1d):
             compiled(x)
     finally:
         torch._dynamo.config.error_on_recompile = False
+
+
+def test_flex_attention_block_mask_compile_no_recompilation(device_mesh_1d):
+    """flex_attention with block_mask doesn't recompile on repeated calls."""
+    model = FlexAttnBlockMaskModel(DIM, N_HEADS, SEQLEN)
+    model = model.to("meta")
+    parallel_mod = _run_auto_parallel(model, device_mesh_1d)
+    parallel_mod.to_empty(device="cuda")
+
+    # Reinitialize block_mask buffers: to_empty zeroes them out, which
+    # gives the Triton kernel invalid indices (0 blocks to attend to).
+    fresh_mask = FlexAttnBlockMaskModel(DIM, N_HEADS, SEQLEN).block_mask
+    for name, buf in parallel_mod.named_buffers():
+        if "block_mask" not in name:
+            continue
+        field = name.split("block_mask_")[-1]
+        src = getattr(fresh_mask, field)
+        buf.copy_(src)
+
+    torch._dynamo.reset()
+    compiled = torch.compile(parallel_mod, fullgraph=True)
+
+    x = torch.randn(LOCAL_BS, SEQLEN, DIM, device="cuda")
+
+    # Warm up both grad modes
+    compiled(x)
+    with torch.no_grad():
+        compiled(x)
+
+    torch._dynamo.config.error_on_recompile = True
+    try:
+        compiled(x)
+        with torch.no_grad():
+            compiled(x)
+    finally:
+        torch._dynamo.config.error_on_recompile = False

--- a/tests/test_flex_attention.py
+++ b/tests/test_flex_attention.py
@@ -541,7 +541,7 @@ def test_flex_attention_compile_no_recompilation(device_mesh_1d):
     parallel_mod.to_empty(device="cuda")
 
     torch._dynamo.reset()
-    compiled = torch.compile(parallel_mod)
+    compiled = torch.compile(parallel_mod, fullgraph=True)
 
     x = torch.randn(LOCAL_BS, SEQLEN, DIM, device="cuda")
 


### PR DESCRIPTION
The inference path (`torch.no_grad()`) used a lazy `_get_inference_fn()` that built the compiled function on first call. When Dynamo traced through this, it hit several items on its skip list (`GraphModule.graph`, `RuntimeWrapper.post_compile`, `runtime_wrapper`), causing graph breaks that prevented `fullgraph=True`.

The fix eagerly builds the inference function at `apply_placement()` time (matching how the training path already works) and decorates it with `@torch._dynamo.nonstrict_trace` (the same decorator used by the training path's `parallel_model_fn`). Since the `compile` option was removed from AutoParallel, the eager build just runs the nop compiler and RuntimeWrapper bookkeeping, so there's no meaningful cost increase.

Authored with Claude.