### PR TITLE
Fix `_check_forward_args` dynamic dim detection under `torch.compile`

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -544,7 +544,7 @@ class AutoParallel:
             strategy = sharding_placement[node]
             solved_input_placements.append(tuple(strategy.output_specs.placements))
 
-        expected_inputs = _compute_expected_inputs(
+        expected_inputs, dynamic_dims = _compute_expected_inputs(
             self._traced_inputs, solved_input_placements, self.mesh
         )
 
@@ -554,7 +554,7 @@ class AutoParallel:
             flat_args, _ = torch.utils._pytree.tree_flatten(args)
             if len(flat_args) != len(expected_inputs):
                 flat_args, _ = torch.utils._pytree.tree_flatten((args, kwargs))
-            _check_forward_args(flat_args, expected_inputs)
+            _check_forward_args(flat_args, expected_inputs, dynamic_dims)
             # NB: don't close over the parameters/buffers, as the user may
             # reassign the module!
             # Use the exact param/buffer FQNs that the compiled graph

--- a/autoparallel/input_validation.py
+++ b/autoparallel/input_validation.py
@@ -9,16 +9,6 @@ import torch
 from torch.distributed.tensor import DeviceMesh
 
 
-def _get_expected_dim_value(exp):
-    """Return a concrete expected dim value when a symbolic dim collapsed to one."""
-    if not isinstance(exp, torch.SymInt):
-        return exp
-    expr = exp.node.expr
-    if expr.is_number:
-        return int(expr)
-    return None
-
-
 def _compute_expected_inputs(traced_inputs, input_placements, mesh):
     """Compute expected runtime inputs by applying sharding to traced global shapes.
 
@@ -32,8 +22,11 @@ def _compute_expected_inputs(traced_inputs, input_placements, mesh):
             by the solver's solution.
         mesh: The device mesh.
 
-    Returns a flat list of meta tensors (for tensor inputs) or raw values
-    (for non-tensor inputs).
+    Returns:
+        A tuple of (expected_inputs, dynamic_dims) where expected_inputs is a
+        flat list of meta tensors (for tensor inputs) or raw values (for
+        non-tensor inputs), and dynamic_dims is a set of (arg_index, dim) pairs
+        indicating which dimensions are dynamic and should not be checked.
     """
     import torch.utils._pytree as pytree
     from torch.distributed.tensor.placement_types import Shard
@@ -41,11 +34,16 @@ def _compute_expected_inputs(traced_inputs, input_placements, mesh):
     flat_inputs, _ = pytree.tree_flatten(traced_inputs)
 
     result = []
+    dynamic_dims: set[tuple[int, int]] = set()
+    result_idx = 0
     tensor_idx = 0
     for inp in flat_inputs:
         if isinstance(inp, torch.Tensor):
             placements = input_placements[tensor_idx]
             local_shape = list(inp.shape)
+            for d, s in enumerate(inp.shape):
+                if isinstance(s, torch.SymInt) and not s.node.expr.is_number:
+                    dynamic_dims.add((result_idx, d))
             for mesh_dim, placement in enumerate(placements):
                 if isinstance(placement, Shard):
                     dim = placement.dim
@@ -57,15 +55,21 @@ def _compute_expected_inputs(traced_inputs, input_placements, mesh):
             tensor_idx += 1
         else:
             result.append(inp)
+        result_idx += 1
 
-    return result
+    return result, dynamic_dims
 
 
-def _check_forward_args(args, expected_inputs):
+def _check_forward_args(args, expected_inputs, dynamic_dims=frozenset()):
     """Validate that forward() args match the shapes/dtypes used during tracing.
 
-    When dynamic shapes are enabled, dimensions that are SymInt in the expected
-    shape accept any size. Concrete dimensions are checked exactly.
+    Dynamic dimensions (identified by dynamic_dims) accept any size.
+    Concrete dimensions are checked exactly.
+
+    Args:
+        args: The actual forward arguments (flat list).
+        expected_inputs: Expected shapes from _compute_expected_inputs.
+        dynamic_dims: Set of (arg_index, dim) pairs for dynamic dimensions.
     """
     if len(args) != len(expected_inputs):
         raise ValueError(
@@ -85,10 +89,11 @@ def _check_forward_args(args, expected_inputs):
                     f"but expected {len(expected.shape)} dims"
                 )
             for dim, (actual, exp) in enumerate(zip(arg.shape, expected.shape)):
-                expected_dim = _get_expected_dim_value(exp)
-                if expected_dim is None:
+                if (i, dim) in dynamic_dims:
                     continue
-                if actual != expected_dim:
+                if isinstance(exp, torch.SymInt) and not exp.node.expr.is_number:
+                    continue
+                if actual != exp:
                     raise ValueError(
                         f"AutoParallel: argument {i} has shape {tuple(arg.shape)} "
                         f"but expected {tuple(expected.shape)}"

--- a/tests/test_dynamic_shapes.py
+++ b/tests/test_dynamic_shapes.py
@@ -917,6 +917,280 @@ class TestCheckForwardArgsMultiInput:
             _check_forward_args([torch.randn(4, 8), torch.randn(4, 8)], expected)
 
 
+class TestDynamicDimsParameter:
+    """Tests for _check_forward_args with explicit dynamic_dims.
+
+    These exercise the code path used when torch.compile concretizes SymInts
+    from a foreign ShapeEnv, making isinstance(exp, torch.SymInt) unreliable.
+    The dynamic_dims set provides a compile-resistant way to mark dims as dynamic.
+    """
+
+    def test_dynamic_dim_accepts_any_size(self):
+        """dynamic_dims skips validation even when expected shape is concrete."""
+        from autoparallel.input_validation import _check_forward_args
+
+        # Concrete meta tensor (no SymInts) — simulates what torch.compile sees
+        expected = [torch.empty(4, 200, device="meta")]
+        dynamic_dims = {(0, 1)}
+
+        # dim 1 differs but is marked dynamic → should pass
+        _check_forward_args([torch.randn(4, 150)], expected, dynamic_dims)
+        _check_forward_args([torch.randn(4, 1)], expected, dynamic_dims)
+        _check_forward_args([torch.randn(4, 999)], expected, dynamic_dims)
+
+    def test_static_dim_still_enforced(self):
+        """Dims not in dynamic_dims are still checked exactly."""
+        from autoparallel.input_validation import _check_forward_args
+
+        expected = [torch.empty(4, 200, device="meta")]
+        dynamic_dims = {(0, 1)}
+
+        with pytest.raises(ValueError, match="has shape"):
+            _check_forward_args([torch.randn(5, 200)], expected, dynamic_dims)
+
+    def test_multiple_dynamic_dims_same_tensor(self):
+        """Multiple dims on the same tensor can be dynamic."""
+        from autoparallel.input_validation import _check_forward_args
+
+        expected = [torch.empty(4, 8, 200, device="meta")]
+        dynamic_dims = {(0, 0), (0, 2)}
+
+        _check_forward_args([torch.randn(7, 8, 150)], expected, dynamic_dims)
+
+        # dim 1 is static
+        with pytest.raises(ValueError, match="has shape"):
+            _check_forward_args([torch.randn(7, 16, 150)], expected, dynamic_dims)
+
+    def test_dynamic_dims_across_multiple_args(self):
+        """dynamic_dims correctly indexes across multiple arguments."""
+        from autoparallel.input_validation import _check_forward_args
+
+        expected = [
+            torch.empty(4, 128, device="meta"),
+            torch.empty(4, 64, device="meta"),
+        ]
+        # arg 0 dim 0 and arg 1 dim 0 are dynamic
+        dynamic_dims = {(0, 0), (1, 0)}
+
+        _check_forward_args(
+            [torch.randn(32, 128), torch.randn(16, 64)], expected, dynamic_dims
+        )
+
+        # arg 1 dim 1 is static
+        with pytest.raises(ValueError, match="has shape"):
+            _check_forward_args(
+                [torch.randn(32, 128), torch.randn(16, 999)], expected, dynamic_dims
+            )
+
+    def test_empty_dynamic_dims_enforces_all(self):
+        """Empty dynamic_dims means all dims are checked (backward compat)."""
+        from autoparallel.input_validation import _check_forward_args
+
+        expected = [torch.empty(4, 8, device="meta")]
+
+        _check_forward_args([torch.randn(4, 8)], expected)
+        _check_forward_args([torch.randn(4, 8)], expected, frozenset())
+
+        with pytest.raises(ValueError, match="has shape"):
+            _check_forward_args([torch.randn(4, 9)], expected)
+
+    def test_compute_expected_inputs_detects_dynamic_dims(self):
+        """_compute_expected_inputs correctly identifies SymInt dims."""
+        from torch._subclasses import FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import (
+            DimDynamic,
+            ShapeEnv,
+            StatelessSymbolicContext,
+        )
+
+        from autoparallel.input_validation import _compute_expected_inputs
+
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(shape_env=shape_env, static_shapes=False)
+
+        t1 = fake_mode.from_tensor(
+            torch.empty(16, 128),
+            symbolic_context=StatelessSymbolicContext(
+                dynamic_sizes=[DimDynamic.DYNAMIC, DimDynamic.STATIC]
+            ),
+        )
+        t2 = fake_mode.from_tensor(
+            torch.empty(16, 64, 32),
+            symbolic_context=StatelessSymbolicContext(
+                dynamic_sizes=[
+                    DimDynamic.DYNAMIC,
+                    DimDynamic.STATIC,
+                    DimDynamic.DYNAMIC,
+                ]
+            ),
+        )
+
+        # Use a mock mesh that just returns identity for size
+        class FakeMesh:
+            def size(self, dim=0):
+                return 1
+
+        _, dynamic_dims = _compute_expected_inputs([t1, t2], [(), ()], FakeMesh())
+        assert (0, 0) in dynamic_dims, "t1 dim 0 should be dynamic"
+        assert (0, 1) not in dynamic_dims, "t1 dim 1 should be static"
+        assert (1, 0) in dynamic_dims, "t2 dim 0 should be dynamic"
+        assert (1, 1) not in dynamic_dims, "t2 dim 1 should be static"
+        assert (1, 2) in dynamic_dims, "t2 dim 2 should be dynamic"
+
+    def test_compute_expected_inputs_non_tensor_indexing(self):
+        """Non-tensor inputs don't shift the dynamic_dims arg indices."""
+        from torch._subclasses import FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import (
+            DimDynamic,
+            ShapeEnv,
+            StatelessSymbolicContext,
+        )
+
+        from autoparallel.input_validation import _compute_expected_inputs
+
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(shape_env=shape_env, static_shapes=False)
+
+        t1 = fake_mode.from_tensor(
+            torch.empty(16, 128),
+            symbolic_context=StatelessSymbolicContext(
+                dynamic_sizes=[DimDynamic.DYNAMIC, DimDynamic.STATIC]
+            ),
+        )
+
+        class FakeMesh:
+            def size(self, dim=0):
+                return 1
+
+        # Non-tensor followed by tensor: the tensor is result_idx=1
+        _, dynamic_dims = _compute_expected_inputs([42, t1], [()], FakeMesh())
+        assert (1, 0) in dynamic_dims, "tensor at result_idx=1, dim 0 should be dynamic"
+        assert (0, 0) not in dynamic_dims, "result_idx=0 is a non-tensor"
+
+
+class TestDynamicDimsUnderCompile:
+    """Tests that dynamic_dims works correctly inside torch.compile."""
+
+    def test_dynamic_dim_survives_compile(self):
+        """The key bug: inside torch.compile, SymInts become concrete ints.
+        dynamic_dims must still allow different sizes."""
+        from torch._subclasses import FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import (
+            DimDynamic,
+            ShapeEnv,
+            StatelessSymbolicContext,
+        )
+
+        from autoparallel.input_validation import _check_forward_args
+
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(shape_env=shape_env, static_shapes=False)
+
+        expected_tensor = fake_mode.from_tensor(
+            torch.empty(1, 1, 256, 200),
+            symbolic_context=StatelessSymbolicContext(
+                dynamic_sizes=[
+                    DimDynamic.STATIC,
+                    DimDynamic.STATIC,
+                    DimDynamic.STATIC,
+                    DimDynamic.DYNAMIC,
+                ]
+            ),
+        )
+
+        # Record dynamic dims while SymInts are still symbolic
+        dynamic_dims = set()
+        for d, s in enumerate(expected_tensor.shape):
+            if isinstance(s, torch.SymInt) and not s.node.expr.is_number:
+                dynamic_dims.add((0, d))
+        assert dynamic_dims == {(0, 3)}
+
+        # Inside torch.compile, SymInt becomes concrete — dynamic_dims saves us
+        torch._dynamo.reset()
+
+        @torch.compile(dynamic=False)
+        def forward(x):
+            _check_forward_args([x], [expected_tensor], dynamic_dims)
+            return x
+
+        forward(torch.randn(1, 1, 256, 200))
+        forward(torch.randn(1, 1, 256, 150))
+
+    def test_static_dim_mismatch_still_caught_under_compile(self):
+        """Static dim mismatches are still caught inside torch.compile."""
+        from torch._subclasses import FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import (
+            DimDynamic,
+            ShapeEnv,
+            StatelessSymbolicContext,
+        )
+
+        from autoparallel.input_validation import _check_forward_args
+
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(shape_env=shape_env, static_shapes=False)
+
+        expected_tensor = fake_mode.from_tensor(
+            torch.empty(1, 256, 200),
+            symbolic_context=StatelessSymbolicContext(
+                dynamic_sizes=[
+                    DimDynamic.STATIC,
+                    DimDynamic.STATIC,
+                    DimDynamic.DYNAMIC,
+                ]
+            ),
+        )
+
+        dynamic_dims = {(0, 2)}
+
+        torch._dynamo.reset()
+
+        @torch.compile(dynamic=False)
+        def forward(x):
+            _check_forward_args([x], [expected_tensor], dynamic_dims)
+            return x
+
+        with pytest.raises((ValueError, torch._dynamo.exc.Unsupported)):
+            forward(torch.randn(1, 128, 200))
+
+    def test_without_dynamic_dims_compile_breaks(self):
+        """Without dynamic_dims, torch.compile enforces the tracing-time value
+        for dynamic dims — confirming the original bug."""
+        from torch._subclasses import FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import (
+            DimDynamic,
+            ShapeEnv,
+            StatelessSymbolicContext,
+        )
+
+        from autoparallel.input_validation import _check_forward_args
+
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(shape_env=shape_env, static_shapes=False)
+
+        expected_tensor = fake_mode.from_tensor(
+            torch.empty(4, 200),
+            symbolic_context=StatelessSymbolicContext(
+                dynamic_sizes=[DimDynamic.STATIC, DimDynamic.DYNAMIC]
+            ),
+        )
+
+        torch._dynamo.reset()
+
+        @torch.compile(dynamic=False)
+        def forward(x):
+            # No dynamic_dims passed — original buggy path
+            _check_forward_args([x], [expected_tensor])
+            return x
+
+        # Same size works
+        forward(torch.randn(4, 200))
+
+        # Different size on the dynamic dim fails (the original bug)
+        with pytest.raises((ValueError, torch._dynamo.exc.Unsupported)):
+            forward(torch.randn(4, 150))
+
+
 # ============================================================================
 # Integration tests — require fake process group and mesh fixtures
 # ============================================================================
@@ -1103,7 +1377,7 @@ def test_dynamic_check_forward_args_accepts_different_batch(device_mesh_1d):
         autop.add_output_constraints([placement])
         autop.optimize_placement(verbose=False)
 
-        expected = _compute_expected_inputs(
+        expected, dynamic_dims = _compute_expected_inputs(
             autop._traced_inputs, autop.input_constraints, device_mesh_1d
         )
 
@@ -1116,6 +1390,7 @@ def test_dynamic_check_forward_args_accepts_different_batch(device_mesh_1d):
         _check_forward_args(
             [torch.randn(test_bs, dim1)],
             expected,
+            dynamic_dims,
         )
 
     # Wrong non-batch dim should be rejected
@@ -1123,6 +1398,7 @@ def test_dynamic_check_forward_args_accepts_different_batch(device_mesh_1d):
         _check_forward_args(
             [torch.randn(local_bs, dim1 + 1)],
             expected,
+            dynamic_dims,
         )
 
 

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -60,7 +60,7 @@ def test_compute_expected_inputs(device_mesh_1d):
     traced = [torch.empty(512, 128, device="meta")]
     placements = [(Shard(0),)]
 
-    result = _compute_expected_inputs(traced, placements, mesh)
+    result, _dynamic_dims = _compute_expected_inputs(traced, placements, mesh)
     assert len(result) == 1
     assert result[0].shape == (512 // world_size, 128)
     assert result[0].dtype == torch.float32
@@ -73,7 +73,7 @@ def test_compute_expected_inputs_replicated(device_mesh_1d):
     traced = [torch.empty(512, 128, device="meta")]
     placements = [(Replicate(),)]
 
-    result = _compute_expected_inputs(traced, placements, mesh)
+    result, _dynamic_dims = _compute_expected_inputs(traced, placements, mesh)
     assert len(result) == 1
     assert result[0].shape == (512, 128)
 
@@ -86,7 +86,7 @@ def test_compute_expected_inputs_uneven(device_mesh_2d):
     traced = [torch.empty(10, 128, device="meta")]
     placements = [(Replicate(), Shard(0))]
 
-    result = _compute_expected_inputs(traced, placements, mesh)
+    result, _dynamic_dims = _compute_expected_inputs(traced, placements, mesh)
     assert len(result) == 1
     expected_dim0 = (10 + tp_size - 1) // tp_size  # ceil(10/8) = 2
     assert result[0].shape == (expected_dim0, 128)
@@ -154,7 +154,7 @@ def test_compute_expected_inputs_dict_pytree(device_mesh_1d):
     ]
     constraints = [(Shard(0),), (Shard(0),)]
 
-    result = _compute_expected_inputs(traced, constraints, mesh)
+    result, _dynamic_dims = _compute_expected_inputs(traced, constraints, mesh)
     assert len(result) == 2
     assert result[0].shape == (512 // world_size, 128)
     assert result[1].shape == (512 // world_size, 64)


### PR DESCRIPTION
When `AutoParallel` traces with `dynamic=True`, `_check_forward_args` relied on `isinstance(exp, torch.SymInt)` to detect dynamic dimensions and skip validation for them. This breaks under an outer `torch.compile`: dynamo resolves foreign-ShapeEnv SymInts to their concrete backing values, so the isinstance check never triggers and the tracing-time concrete value is enforced at runtime. This causes `ValueError` → graph break → eager fallback for the entire forward.

The fix records which dimensions are dynamic at `_compute_expected_inputs` time (when SymInts are still symbolic), returning a `set[tuple[int, int]]` of `(arg_index, dim)` pairs alongside the expected inputs. `_check_forward_args` uses this set to skip dynamic dims, with the old SymInt isinstance check kept as a fallback for direct callers outside compile.

Authored with Claude.