### PR TITLE
Fix fake trace not being saved in autobucketing pass

### DIFF
--- a/autoparallel/graph_passes/auto_bucketing.py
+++ b/autoparallel/graph_passes/auto_bucketing.py
@@ -136,7 +136,7 @@ def aten_autobucketing_reordering_pass(
         create_execution_trace(
             new_gm,
             configs.custom_runtime_estimation,
-            f"fake_trace_{configs._counter}.json",
+            file_path=f"fake_trace_{configs._counter}.json",
         )
         configs._counter += 1
     return new_gm


### PR DESCRIPTION
The `create_execution_trace` call in `aten_autobucketing_reordering_pass` was passing the output filename as the `name` parameter (3rd positional arg) instead of `file_path` (4th parameter). Since `file_path` defaulted to `None`, the trace was computed but never written to disk.

Authored with Claude.