### PR TITLE
Fix reduction sharding strategies and enable min-cost redistribute planner

### DIFF
--- a/autoparallel/apply_sharding.py
+++ b/autoparallel/apply_sharding.py
@@ -19,6 +19,7 @@ from torch._inductor.decomposition import select_decomp_table
 from torch._subclasses.fake_tensor import FakeTensor, unset_fake_temporarily
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor._dtensor_spec import DTensorSpec, ShardOrderEntry
+from torch.distributed.tensor._redistribute import use_min_cost_redistribution_plan
 from torch.distributed.tensor.placement_types import Partial, Replicate, Shard  # noqa
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.utils._pytree import tree_flatten, tree_map_only
@@ -532,7 +533,10 @@ def apply_sharding_to_model(gm, sharding_placement, params_spec, buffers_spec):
     local_args = _make_local_args(gm, sharding_placement)
     t1 = time.perf_counter()
 
-    parallel_gm = _lower_to_parallel_graph(gm, sharding_placement, local_args, dynamic)
+    with use_min_cost_redistribution_plan():
+        parallel_gm = _lower_to_parallel_graph(
+            gm, sharding_placement, local_args, dynamic
+        )
     t2 = time.perf_counter()
 
     _copy_descriptors_and_rename_placeholders(gm, parallel_gm)

--- a/autoparallel/graph_passes/debug_helpers.py
+++ b/autoparallel/graph_passes/debug_helpers.py
@@ -106,13 +106,30 @@ def build_arguments(fn):
     return args
 
 
+# _dtensor ops that are collective communications (not routed through
+# _c10d_functional but still run on the NCCL stream).
+_DTENSOR_COLLECTIVE_OPS = frozenset({"shard_dim_alltoall"})
+
+
 def _is_communication_node(node):
     if not node.op == "call_function":
         return False
     if not isinstance(node.target, torch._ops.OpOverload):
         return False
 
-    return node.target.namespace in ("_c10d_functional", "c10d_functional")
+    ns = node.target.namespace
+    if ns in ("_c10d_functional", "c10d_functional"):
+        return True
+    if ns == "_dtensor" and node.target._opname in _DTENSOR_COLLECTIVE_OPS:
+        return True
+    return False
+
+
+def _is_sync_collective(node):
+    """Return True for collectives that block (no wait_tensor follows)."""
+    if not _is_communication_node(node):
+        return False
+    return node.target.namespace == "_dtensor"
 
 
 def _is_wait_tensor(node):
@@ -208,6 +225,10 @@ def make_custom_runtime_estimation(mesh):
                 elif target == torch.ops._c10d_functional.all_reduce.default:
                     n_bytes = int(comm_bytes_gb * 1024**3)
                     return nccl_allreduce_cost(n_bytes, topo, nccl_config)
+                elif target == torch.ops._dtensor.shard_dim_alltoall.default:
+                    # alltoall moves similar data volume to allgather
+                    n_bytes = int(comm_bytes_gb * cost_mesh.shape[mesh_dim] * 1024**3)
+                    return nccl_allgather_cost(n_bytes, topo, nccl_config)
                 else:
                     return 0
 
@@ -221,6 +242,9 @@ def make_custom_runtime_estimation(mesh):
                 return reduce_scatter_cost(comm_bytes_gb, mesh_topo, mesh_dim)
             elif target == torch.ops._c10d_functional.all_reduce.default:
                 return allreduce_cost(comm_bytes_gb, mesh_topo, mesh_dim)
+            elif target == torch.ops._dtensor.shard_dim_alltoall.default:
+                comm_bytes_gb *= cost_mesh.shape[mesh_dim]
+                return allgather_cost(comm_bytes_gb, mesh_topo, mesh_dim)
             else:
                 return 0
         return estimate_strategy_runtime_cost(node, None)
@@ -283,6 +307,8 @@ def _get_collective_type(node):
         return "ReduceScatter"
     elif "all_reduce" in target_str:
         return "AllReduce"
+    elif "alltoall" in target_str:
+        return "AllToAll"
     elif "wait_tensor" in target_str:
         return "Wait"
     return "Unknown"
@@ -374,6 +400,9 @@ def create_execution_trace(
             curr_time[0] += launch_overhead
             # keep track of when a given collective will finish
             global_time[node] = curr_time[tid]
+            if _is_sync_collective(node):
+                # Synchronous collective: compute stream must wait for it
+                curr_time[0] = max(curr_time[0], curr_time[tid])
 
         event["args"] = {
             "name": node.name,

--- a/autoparallel/graph_passes/estimate_graph_metrics.py
+++ b/autoparallel/graph_passes/estimate_graph_metrics.py
@@ -12,6 +12,7 @@ from torch._inductor.fx_passes.memory_estimator import MemoryTracker
 from autoparallel.graph_passes.debug_helpers import (
     _get_tid,
     _is_communication_node,
+    _is_sync_collective,
     _is_wait_tensor,
     _resolve_comm_node,
 )
@@ -74,6 +75,10 @@ def estimate_graph_metrics(
         if tid != 0:
             curr_time[0] += launch_overhead
             global_time[node] = curr_time[tid]
+            if _is_sync_collective(node):
+                stall = max(0.0, curr_time[tid] - curr_time[0])
+                exposed_comm_time += stall
+                curr_time[0] = max(curr_time[0], curr_time[tid])
 
     return GraphMetrics(
         total_time=max(curr_time.values()),

--- a/autoparallel/graph_passes/graph_utils.py
+++ b/autoparallel/graph_passes/graph_utils.py
@@ -187,7 +187,13 @@ def is_collective(node: torch.fx.Node) -> bool:
     return (
         node.op == "call_function"
         and isinstance(node.target, torch._ops.OpOverload)
-        and node.target.namespace == "_c10d_functional"
+        and (
+            node.target.namespace == "_c10d_functional"
+            or (
+                node.target.namespace == "_dtensor"
+                and node.target._opname == "shard_dim_alltoall"
+            )
+        )
     )
 
 

--- a/autoparallel/shardings/propagation_rules.py
+++ b/autoparallel/shardings/propagation_rules.py
@@ -1213,3 +1213,121 @@ def index_strategy(mesh, op_schema: OpSchema):
     return expand_to_full_mesh_op_strategy(
         mesh, op_schema, single_mesh_dim_strategies, input_index=1
     )
+
+
+# ---------------------------------------------------------------------------
+# Workaround for upstream DTensor bug in common_reduction_strategy:
+# the `reduction_linear` flag is cumulative across strategies — once a
+# Partial(avg) strategy flips it to False, all subsequent strategies
+# (including valid ones like S(0)S(1)) are forced through
+# replicate_reduction_dims and collapse to RR.  This prevents the
+# optimizer from discovering the cheap reduce-scatter path for weight
+# gradient reductions.
+#
+# We re-register the linear-reduction ops with a fixed version that
+# resets reduction_linear per strategy.
+# ---------------------------------------------------------------------------
+
+
+def _fixed_common_reduction_strategy(
+    input_strategy,
+    reduce_dims,
+    keep_dim=False,
+    reduction_linear=True,
+    reduction_op="sum",
+):
+    from torch.distributed.tensor._ops._math_ops import (
+        _infer_reduce_dims_map,
+        map_placements_after_reduction,
+        replicate_reduction_dims,
+    )
+
+    reduction_strategy = OpStrategy([])
+
+    for op_spec in input_strategy.strategies:
+        # Per-strategy reset: the flag should not leak across strategies.
+        spec_reduction_linear = reduction_linear
+
+        if reduction_op == "avg":
+            from torch.distributed.tensor._ops.utils import (
+                is_tensor_evenly_shardable_on_dim,
+            )
+
+            output_spec = op_spec.output_spec
+            local_shape = list(output_spec.tensor_meta.shape)
+            for dim in reduce_dims:
+                if not is_tensor_evenly_shardable_on_dim(local_shape, output_spec, dim):
+                    spec_reduction_linear = False
+                    break
+
+        for p in op_spec.output_spec.placements:
+            if isinstance(p, Partial) and p.reduce_op != reduction_op:
+                spec_reduction_linear = False
+                break
+
+        if not spec_reduction_linear:
+            input_placements = replicate_reduction_dims(
+                op_spec.output_spec.placements, reduce_dims
+            )
+        else:
+            input_placements = op_spec.output_spec.placements
+
+        input_spec = DTensorSpec(
+            mesh=input_strategy.mesh,
+            placements=input_placements,
+            tensor_meta=op_spec.output_spec.tensor_meta,
+        )
+
+        reduce_dims_map = _infer_reduce_dims_map(reduce_dims, input_spec.ndim, keep_dim)
+        out_placements = map_placements_after_reduction(
+            input_spec.placements, reduce_dims, reduce_dims_map, reduction_op
+        )
+        redistribute_cost = [generate_redistribute_costs(input_strategy, input_spec)]
+        reduction_strategy.strategies.append(
+            OpSpec(
+                output_specs=DTensorSpec(
+                    mesh=input_strategy.mesh,
+                    placements=out_placements,
+                ),
+                input_specs=(input_spec,),
+                redistribute_cost=redistribute_cost,
+            )
+        )
+
+    return reduction_strategy
+
+
+def _fixed_linear_reduction_rule(mesh, op_schema):
+    from torch.distributed.tensor._ops._math_ops import (
+        LINEAR_REDUCTION_OP_MAP,
+        _infer_reduction_dims,
+    )
+
+    args_schema = op_schema.args_schema
+    input_strategy = args_schema[0]
+
+    dims = None
+    if len(args_schema) > 1:
+        dims = _infer_reduction_dims(args_schema[1], input_strategy.ndim)
+
+    reduce_dims = list(range(input_strategy.ndim)) if dims is None else dims
+    keep_dim = len(args_schema) > 2 and bool(args_schema[2])
+    reduction_op = LINEAR_REDUCTION_OP_MAP[op_schema.op]
+
+    return _fixed_common_reduction_strategy(
+        input_strategy,
+        reduce_dims,
+        keep_dim=keep_dim,
+        reduction_linear=True,
+        reduction_op=reduction_op,
+    )
+
+
+def _register_fixed_reduction_rules():
+    from torch.distributed.tensor._ops._math_ops import LINEAR_REDUCTION_OP_MAP
+
+    for op in LINEAR_REDUCTION_OP_MAP:
+        _op_rules[op] = _fixed_linear_reduction_rule
+
+
+_register_fixed_reduction_rules()

--- a/tests/test_reduction_strategies.py
+++ b/tests/test_reduction_strategies.py
@@ -1,0 +1,135 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from torch.distributed._tensor.placement_types import DTensorSpec, TensorMeta
+from torch.distributed.tensor._op_schema import OpSpec, OpStrategy
+from torch.distributed.tensor.placement_types import Partial, Replicate, Shard
+
+from autoparallel.shardings.propagation_rules import _fixed_common_reduction_strategy
+
+
+def _make_tensor_meta(shape, dtype=torch.float32):
+    t = torch.empty(shape, dtype=dtype, device="meta")
+    return TensorMeta(t.shape, t.stride(), t.dtype)
+
+
+def _make_input_strategy(mesh, placements_list, shape):
+    """Build an OpStrategy with one strategy per placement tuple."""
+    tm = _make_tensor_meta(shape)
+    strategies = []
+    for placements in placements_list:
+        spec = DTensorSpec(mesh, tuple(placements), tensor_meta=tm)
+        strategies.append(OpSpec(spec, input_specs=(), redistribute_cost=[]))
+    return OpStrategy(strategies)
+
+
+def _output_placements(strategy):
+    """Extract the set of output placement tuples from an OpStrategy."""
+    return {s.output_specs.placements for s in strategy.strategies}
+
+
+class TestReductionStrategyCompleteness:
+    """Verify that the fixed reduction strategy generates Partial outputs
+    for all input strategies where the reduced dims are sharded, not just
+    the ones that appear before the first Partial(avg) strategy."""
+
+    def test_sum_with_shard_on_reduced_dims_produces_partial(self, device_mesh_2d):
+        mesh = device_mesh_2d
+        shape = (32, 8192, 4096)
+        # S(0)S(1): both sharded dims are in the reduction dims [0, 1].
+        # The sum should produce P(sum)P(sum).
+        input_strategy = _make_input_strategy(mesh, [(Shard(0), Shard(1))], shape)
+        result = _fixed_common_reduction_strategy(
+            input_strategy, reduce_dims=[0, 1], reduction_op="sum"
+        )
+        out = _output_placements(result)
+        assert (Partial("sum"), Partial("sum")) in out
+
+    def test_sum_preserves_shard_on_non_reduced_dim(self, device_mesh_2d):
+        mesh = device_mesh_2d
+        shape = (32, 8192, 4096)
+        # S(2)S(2): hidden sharded on both mesh dims, reducing [0, 1].
+        # Neither shard dim is in reduce_dims, so output should be S(0)S(0)
+        # (dims shift after collapsing dims 0 and 1).
+        input_strategy = _make_input_strategy(mesh, [(Shard(2), Shard(2))], shape)
+        result = _fixed_common_reduction_strategy(
+            input_strategy, reduce_dims=[0, 1], reduction_op="sum"
+        )
+        out = _output_placements(result)
+        assert (Shard(0), Shard(0)) in out
+
+    def test_partial_avg_does_not_suppress_subsequent_shard_strategies(
+        self, device_mesh_2d
+    ):
+        """The upstream bug: a Partial(avg) strategy early in the list
+        permanently flips reduction_linear to False, causing later
+        Shard-on-reduced-dim strategies to collapse to Replicate."""
+        mesh = device_mesh_2d
+        shape = (32, 8192, 4096)
+        input_strategy = _make_input_strategy(
+            mesh,
+            [
+                (Replicate(), Replicate()),  # RR
+                (Replicate(), Partial("avg")),  # RP(avg) — triggers the bug
+                (Shard(0), Shard(1)),  # S(0)S(1) — must not be lost
+                (Shard(0), Shard(2)),  # S(0)S(2)
+            ],
+            shape,
+        )
+        result = _fixed_common_reduction_strategy(
+            input_strategy, reduce_dims=[0, 1], reduction_op="sum"
+        )
+        out = _output_placements(result)
+        # S(0)S(1) reducing [0,1] → P(sum)P(sum): both sharded dims are reduced
+        assert (
+            Partial("sum"),
+            Partial("sum"),
+        ) in out, "S(0)S(1) strategy was suppressed — reduction_linear leaked across strategies"
+        # S(0)S(2) reducing [0,1] → P(sum)S(0): dim 0 reduced, dim 2 shifts to 0
+        assert (Partial("sum"), Shard(0)) in out
+
+    def test_upstream_bug_reproducer(self, device_mesh_2d):
+        """Minimal reproducer: if reduction_linear leaks, the second strategy
+        (S(0)S(1)) gets forced through replicate_reduction_dims and its output
+        becomes (RR) → RR, identical to the first strategy."""
+        mesh = device_mesh_2d
+        shape = (32, 8192, 4096)
+        input_strategy = _make_input_strategy(
+            mesh,
+            [
+                (Replicate(), Partial("avg")),  # flips reduction_linear in buggy code
+                (Shard(0), Shard(1)),  # should produce P(sum)P(sum)
+            ],
+            shape,
+        )
+        result = _fixed_common_reduction_strategy(
+            input_strategy, reduce_dims=[0, 1], reduction_op="sum"
+        )
+        # With the bug, both strategies collapse to the same output (RR),
+        # so we'd only get 1 unique output. With the fix, we get 2.
+        out = _output_placements(result)
+        assert (
+            len(out) == 2
+        ), f"Expected 2 distinct output placements, got {len(out)}: {out}"
+        assert (Replicate(), Replicate()) in out  # from RP(avg) input, non-linear
+        assert (Partial("sum"), Partial("sum")) in out  # from S(0)S(1) input
+
+    def test_mean_reduction_with_mixed_strategies(self, device_mesh_2d):
+        mesh = device_mesh_2d
+        shape = (32, 8192, 4096)
+        input_strategy = _make_input_strategy(
+            mesh,
+            [
+                (Replicate(), Replicate()),
+                (Shard(0), Shard(1)),
+            ],
+            shape,
+        )
+        result = _fixed_common_reduction_strategy(
+            input_strategy, reduce_dims=[0, 1], reduction_op="avg"
+        )
+        out = _output_placements(result)
+        assert (Partial("avg"), Partial("avg")) in out


### PR DESCRIPTION
Two fixes for suboptimal sharding on multi-dimensional meshes, investigated on LLaMA-3 8B at 128 GPUs (dp=16, tp=8).

The first change works around an upstream DTensor bug in `common_reduction_strategy` where the `reduction_linear` flag leaks across strategy iterations — once a `Partial(avg)` strategy sets it to `False`, all subsequent strategies (including `S(0)S(1)`) are forced through `replicate_reduction_dims` and collapse into duplicates. This prevented the optimizer from discovering the `S(0)S(1) → P(sum)P(sum) → reduce-scatter` path for RMSNorm weight gradient reductions, forcing it into expensive cross-node all-to-alls instead. The workaround re-registers the linear reduction ops with a fixed version that resets the flag per strategy.

The second change enables DTensor's Dijkstra-based redistribute planner (`use_min_cost_redistribution_plan`) during `apply_sharding_to_model`. The default greedy planner decomposes multi-dim `Shard→Shard` transitions through an intermediate replicated state (all-gather + all-to-all), amplifying data volume. The Dijkstra planner finds the optimal two-all-to-all decomposition that keeps data at per-shard size throughout.

The remaining changes teach the graph-analysis utilities (`debug_helpers`, `estimate_graph_metrics`, `graph_utils`) about `_dtensor.shard_dim_alltoall` as a collective operation, so that execution traces and metric estimation account for all-to-all ops correctly.

Authored with Claude.