### PR TITLE
Unify collective cost dispatch to fix alltoall costed as allgather

### DIFF
--- a/autoparallel/cost_models/collective_runtime_estimation.py
+++ b/autoparallel/cost_models/collective_runtime_estimation.py
@@ -62,6 +62,41 @@ def _nccl_comm_cost(
         return 0.0
 
 
+def collective_comm_cost(
+    collective: str,
+    comm_bytes: int,
+    mesh_shape: tuple[int, ...],
+    mesh_dim: int,
+    mesh_topo: MeshTopoInfo | None = None,
+) -> float:
+    """Single dispatch point for collective communication cost.
+
+    Works with both the NCCL cost model (when configured via set_nccl_topo_config)
+    and the default PyTorch cost model.
+
+    Args:
+        collective: one of "allgather", "allreduce", "reduce_scatter", "all_to_all"
+        comm_bytes: total bytes communicated (post-collective size for allgather,
+            pre-collective size for reduce_scatter)
+        mesh_shape: shape of the device mesh
+        mesh_dim: which mesh dimension the collective runs on
+        mesh_topo: required when NCCL cost model is not configured
+    """
+    if _nccl_topo_config is not None:
+        return _nccl_comm_cost(mesh_shape, mesh_dim, comm_bytes, collective)
+    assert mesh_topo is not None
+    comm_bytes_gb = comm_bytes / 1024**3
+    if collective == "allgather":
+        return allgather_cost(comm_bytes_gb, mesh_topo, mesh_dim)
+    elif collective == "allreduce":
+        return allreduce_cost(comm_bytes_gb, mesh_topo, mesh_dim)
+    elif collective == "reduce_scatter":
+        return reduce_scatter_cost(comm_bytes_gb, mesh_topo, mesh_dim)
+    elif collective == "all_to_all":
+        return all_to_all_cost(comm_bytes_gb, mesh_topo, mesh_dim)
+    return 0.0
+
+
 def all_to_all_cost(bytes_gb: float, mesh_topo: MeshTopoInfo, mesh_dim: int) -> float:
     num_devices_on_mesh_dim = mesh_topo.mesh_dim_devices[mesh_dim]
     mesh_dim_bandwidth = mesh_topo.mesh_dim_bandwidth[mesh_dim]
@@ -109,8 +144,7 @@ def redistribute_cost(
     comm_bytes_gb = (
         spec_to_bytes(current_spec) / current_spec.num_shards / 1024 / 1024 / 1024
     )
-    use_nccl = _nccl_topo_config is not None
-    mesh_shape = tuple(current_spec.mesh.shape) if use_nccl else ()
+    mesh_shape = tuple(current_spec.mesh.shape)
     # Transformation that considered for redistribute cost:
     # 1. allgather 2. alltoall
     # 3. allreduce 4. reduce_scatter
@@ -129,13 +163,9 @@ def redistribute_cost(
             current = cast(Shard, current)
             # allgather gives larger comm bytes
             comm_bytes_gb *= num_devices_on_mesh_dim
-            # add up allgather comm cost
-            if use_nccl:
-                cost += _nccl_comm_cost(
-                    mesh_shape, i, int(comm_bytes_gb * 1024**3), "allgather"
-                )
-            else:
-                cost += allgather_cost(comm_bytes_gb, mesh_topo, i)
+            cost += collective_comm_cost(
+                "allgather", int(comm_bytes_gb * 1024**3), mesh_shape, i, mesh_topo
+            )
             if current.dim != 0:
                 # penalize cases like  S(1) -> R as there are additional compute cost
                 # which corresponds to reshuffling the whole output tensor
@@ -146,14 +176,9 @@ def redistribute_cost(
         elif current.is_shard() and target.is_shard():
             current = cast(Shard, current)
             target = cast(Shard, target)
-            # should be alltoall comm, since we haven't implement it yet, add penalty
-            # to favor allgather instead
-            if use_nccl:
-                cost += _nccl_comm_cost(
-                    mesh_shape, i, int(comm_bytes_gb * 1024**3), "all_to_all"
-                )
-            else:
-                cost += all_to_all_cost(comm_bytes_gb, mesh_topo, i)  # us
+            cost += collective_comm_cost(
+                "all_to_all", int(comm_bytes_gb * 1024**3), mesh_shape, i, mesh_topo
+            )
 
             num_copies = 0
             if current.dim != 0:
@@ -166,22 +191,18 @@ def redistribute_cost(
             cost += num_copies * compute_cost
 
         elif current.is_partial() and target.is_replicate():
-            # add up allreduce comm cost
-            if use_nccl:
-                cost += _nccl_comm_cost(
-                    mesh_shape, i, int(comm_bytes_gb * 1024**3), "allreduce"
-                )
-            else:
-                cost += allreduce_cost(comm_bytes_gb, mesh_topo, i)
+            cost += collective_comm_cost(
+                "allreduce", int(comm_bytes_gb * 1024**3), mesh_shape, i, mesh_topo
+            )
         elif current.is_partial() and target.is_shard():
             target = cast(Shard, target)
-            # add up reduce_scatter comm cost
-            if use_nccl:
-                cost += _nccl_comm_cost(
-                    mesh_shape, i, int(comm_bytes_gb * 1024**3), "reduce_scatter"
-                )
-            else:
-                cost += reduce_scatter_cost(comm_bytes_gb, mesh_topo, i)
+            cost += collective_comm_cost(
+                "reduce_scatter",
+                int(comm_bytes_gb * 1024**3),
+                mesh_shape,
+                i,
+                mesh_topo,
+            )
             if target.dim != 0:
                 # penalize cases like  P -> S(1) as there are additional compute cost
                 # which corresponds to reshuffling the whole input tensor

--- a/autoparallel/graph_passes/debug_helpers.py
+++ b/autoparallel/graph_passes/debug_helpers.py
@@ -177,7 +177,7 @@ def make_custom_runtime_estimation(mesh):
     }
     # Collectives where the input tensor is shard-sized and the actual
     # communicated volume is input_bytes * num_devices_on_mesh_dim.
-    _SCALES_BY_MESH_DIM = {"allgather", "all_to_all"}
+    _SCALES_BY_MESH_DIM = {"allgather"}
 
     def custom_runtime_estimation(node: torch.fx.Node, override_size=None):
         if not node.op == "call_function":

--- a/autoparallel/graph_passes/debug_helpers.py
+++ b/autoparallel/graph_passes/debug_helpers.py
@@ -19,13 +19,9 @@ from torch.utils._dtype_abbrs import dtype_abbrs
 
 from autoparallel.cost_models.collective_runtime_estimation import (
     MeshTopoInfo,
-    allgather_cost,
-    allreduce_cost,
-    get_nccl_topo_config,
-    reduce_scatter_cost,
+    collective_comm_cost,
 )
 from autoparallel.cost_models.compute_estimation import estimate_strategy_runtime_cost
-from autoparallel.cost_models.nccl_cost_model import derive_mesh_dim_topo
 
 
 def parse_tensor_annotation(annotation: str) -> torch.Tensor:
@@ -172,7 +168,16 @@ def _resolve_comm_node(node, global_time):
 
 
 def make_custom_runtime_estimation(mesh):
-    nccl_config = get_nccl_topo_config()
+    _TARGET_TO_COLLECTIVE = {
+        torch.ops._c10d_functional.all_gather_into_tensor.default: "allgather",
+        torch.ops._c10d_functional.all_gather_into_tensor_out.default: "allgather",
+        torch.ops._c10d_functional.reduce_scatter_tensor.default: "reduce_scatter",
+        torch.ops._c10d_functional.all_reduce.default: "allreduce",
+        torch.ops._dtensor.shard_dim_alltoall.default: "all_to_all",
+    }
+    # Collectives where the input tensor is shard-sized and the actual
+    # communicated volume is input_bytes * num_devices_on_mesh_dim.
+    _SCALES_BY_MESH_DIM = {"allgather", "all_to_all"}
 
     def custom_runtime_estimation(node: torch.fx.Node, override_size=None):
         if not node.op == "call_function":
@@ -183,6 +188,9 @@ def make_custom_runtime_estimation(mesh):
         if _is_communication_node(node):
             target = node.target
             if target == torch.ops._c10d_functional.wait_tensor.default:
+                return 0
+            collective = _TARGET_TO_COLLECTIVE.get(target)
+            if collective is None:
                 return 0
             # Resolve group_name to a mesh and dimension. Collectives may
             # use per-dimension groups or the flattened mesh group created
@@ -199,54 +207,18 @@ def make_custom_runtime_estimation(mesh):
                 return 0
             mesh_topo = MeshTopoInfo.build_from_mesh(cost_mesh)
             t = node.args[0].meta["val"]  # type: ignore[union-attr]
-            comm_bytes_gb = t.numel() * t.itemsize / 2**30
+            comm_bytes = t.numel() * t.itemsize
             if override_size is not None:
-                comm_bytes_gb = override_size
-
-            if nccl_config is not None:
-                from autoparallel.cost_models.nccl_cost_model import (
-                    nccl_allgather_cost,
-                    nccl_allreduce_cost,
-                    nccl_reduce_scatter_cost,
-                )
-
-                mesh_shape = tuple(cost_mesh.shape)
-                topo = derive_mesh_dim_topo(nccl_config, mesh_shape, mesh_dim)
-
-                if target in {
-                    torch.ops._c10d_functional.all_gather_into_tensor.default,
-                    torch.ops._c10d_functional.all_gather_into_tensor_out.default,
-                }:
-                    n_bytes = int(comm_bytes_gb * cost_mesh.shape[mesh_dim] * 1024**3)
-                    return nccl_allgather_cost(n_bytes, topo, nccl_config)
-                elif target == torch.ops._c10d_functional.reduce_scatter_tensor.default:
-                    n_bytes = int(comm_bytes_gb * 1024**3)
-                    return nccl_reduce_scatter_cost(n_bytes, topo, nccl_config)
-                elif target == torch.ops._c10d_functional.all_reduce.default:
-                    n_bytes = int(comm_bytes_gb * 1024**3)
-                    return nccl_allreduce_cost(n_bytes, topo, nccl_config)
-                elif target == torch.ops._dtensor.shard_dim_alltoall.default:
-                    # alltoall moves similar data volume to allgather
-                    n_bytes = int(comm_bytes_gb * cost_mesh.shape[mesh_dim] * 1024**3)
-                    return nccl_allgather_cost(n_bytes, topo, nccl_config)
-                else:
-                    return 0
-
-            if target in {
-                torch.ops._c10d_functional.all_gather_into_tensor.default,
-                torch.ops._c10d_functional.all_gather_into_tensor_out.default,
-            }:
-                comm_bytes_gb *= cost_mesh.shape[mesh_dim]
-                return allgather_cost(comm_bytes_gb, mesh_topo, mesh_dim)
-            elif target == torch.ops._c10d_functional.reduce_scatter_tensor.default:
-                return reduce_scatter_cost(comm_bytes_gb, mesh_topo, mesh_dim)
-            elif target == torch.ops._c10d_functional.all_reduce.default:
-                return allreduce_cost(comm_bytes_gb, mesh_topo, mesh_dim)
-            elif target == torch.ops._dtensor.shard_dim_alltoall.default:
-                comm_bytes_gb *= cost_mesh.shape[mesh_dim]
-                return allgather_cost(comm_bytes_gb, mesh_topo, mesh_dim)
-            else:
-                return 0
+                comm_bytes = int(override_size * 2**30)
+            if collective in _SCALES_BY_MESH_DIM:
+                comm_bytes *= cost_mesh.shape[mesh_dim]
+            return collective_comm_cost(
+                collective,
+                comm_bytes,
+                tuple(cost_mesh.shape),
+                mesh_dim,
+                mesh_topo,
+            )
         return estimate_strategy_runtime_cost(node, None)
 
     return custom_runtime_estimation


### PR DESCRIPTION
`make_custom_runtime_estimation` had its own if/elif chain mapping FX op targets to cost functions, duplicating the dispatch logic already in `collective_runtime_estimation.py`. The duplication caused `shard_dim_alltoall` to be costed using `nccl_allgather_cost` instead of `nccl_all_to_all_cost`.

This extracts a single `collective_comm_cost()` dispatcher that handles both NCCL and default PyTorch cost models, and uses it in both `redistribute_cost` and `make_custom_runtime_estimation`. The latter collapses from an 80-line if/elif chain into a table lookup + one call, so the mapping from collective type to cost function can't diverge again.

Authored with Claude.