### PR TITLE
Force param allgather to run in param_dtype, not storage dtype

### DIFF
--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -1475,29 +1475,82 @@ class ShardingOptimizer:
             )
 
     def add_grad_reduce_dtype_constraints(self):
-        """Forbid gradient redistribution before the dtype cast.
+        """Forbid redistribution on the wrong side of dtype_cast nodes.
 
-        When MixedPrecisionPolicy specifies a reduce_dtype larger than
-        param_dtype (e.g., param_dtype=bf16, reduce_dtype=f32), the gradient
-        chain looks like:
+        When MixedPrecisionPolicy inserts dtype_cast nodes to convert between
+        storage dtype and compute dtype, we want collectives to run in the
+        smaller dtype. This method enforces two independent constraints:
+
+        **Forward** (unconditional when dtype_cast nodes exist):
+        Forces allgather to happen after the cast (in param_dtype, e.g. bf16)
+        rather than before it (in storage dtype, e.g. f32). Applies whenever
+        the model stores parameters in a higher-precision dtype than
+        param_dtype, regardless of reduce_dtype.
+
+            primals (storage_dtype) -> [unary ops] -> dtype_cast (param_dtype)
+
+        **Backward** (when reduce_dtype > param_dtype):
+        Forces reduce-scatter to happen after the cast (in reduce_dtype, e.g.
+        f32) rather than before it (in param_dtype, e.g. bf16).
 
             einsum (param_dtype) -> [unary ops] -> dtype_cast -> alias (grad_param)
 
-        We want redistribution to happen after the dtype_cast so that the
-        reduce-scatter runs in reduce_dtype. This is enforced by disabling
-        (forcing to zero) any decision variables on pre-cast edges that
-        would imply a placement change, making redistribution before the
-        cast impossible. Redistribution may still happen after the cast
-        (e.g., at the edge from dtype_cast to the grad_param alias), which
-        is correct since that communication occurs in reduce_dtype.
-
-        The multi-input producer (e.g., einsum) is excluded — only edges
-        between unary nodes in the pre-cast chain are affected.
+        Both are enforced by disabling decision variables on pre-cast edges
+        that would imply a placement change.
         """
+        # --- Forward: forbid redistribution before param dtype_cast ---
+        # Only when the cast reduces precision (storage_dtype > param_dtype),
+        # so that allgather runs in the smaller param_dtype. When the cast
+        # increases precision (e.g. bf16 storage → f32 compute), we want the
+        # allgather in the smaller storage dtype, which is already the default.
+        fwd_pre_cast_node_idxs: set[int] = set()
+        for param, _grad in get_param_and_grad_nodes(self.graph).values():
+            # Walk forward from param through single-user unary nodes
+            n = param
+            while True:
+                if n.target == torch.ops.autoparallel.dtype_cast.default:
+                    break
+                users = list(n.users.keys())
+                if len(users) != 1:
+                    break
+                child = users[0]
+                if len(child.all_input_nodes) != 1:
+                    break
+                n = child
+
+            if n.target != torch.ops.autoparallel.dtype_cast.default:
+                continue
+
+            # Only constrain if it downcasts
+            storage_dtype = param.meta["val"].dtype
+            cast_dtype = n.meta["val"].dtype
+            if cast_dtype.itemsize >= storage_dtype.itemsize:
+                continue
+
+            # Mark dtype_cast and all nodes between param and dtype_cast
+            # (exclusive of param itself since placeholders don't have
+            # input edges)
+            node = n
+            while node != param:
+                if node in self.node_map:
+                    fwd_pre_cast_node_idxs.add(self.node_map[node])
+                parent = node.all_input_nodes[0]
+                node = parent
+
+        for key, dv in self.decision_vars.items():
+            node_idx, argi, out_idx, inp_idx = key
+            if node_idx not in fwd_pre_cast_node_idxs:
+                continue
+            if dv.comm_cost > 0:
+                self.prob += (
+                    dv.var == 0,
+                    self._get_next_name("fwd_param_dtype"),
+                )
+
+        # --- Backward: forbid redistribution before grad dtype_cast ---
         if not self.force_grad_reduce_in_higher_precision:
             return
 
-        # Collect pre-cast node indices
         pre_cast_node_idxs: set[int] = set()
         for param, grad in get_param_and_grad_nodes(self.graph).values():
             if grad is None:

--- a/tests/test_grad_reduce_dtype.py
+++ b/tests/test_grad_reduce_dtype.py
@@ -208,3 +208,169 @@ def test_grad_reduce_dtype_same_dtype_no_constraint(device_mesh_1d):
     )
     sharding_placement, _ = _run_autop(mesh, model_fn, input_fn, mp_policy)
     assert sharding_placement is not None, "Optimizer should find a feasible solution"
+
+
+# ---- Forward dtype_cast constraint tests ----
+
+
+def _assert_no_fwd_pre_cast_redistribution(
+    sharding_placement, autop, require_linked_validation=False
+):
+    """Assert that no forward dtype_cast has redistribution on its input edge.
+
+    Validates that every forward dtype_cast node matches its producer's
+    placement, so allgather happens on the cast output (smaller dtype)
+    rather than on the raw parameter (larger storage dtype).
+    """
+    from torch._functorch._aot_autograd.fx_utils import get_param_and_grad_nodes
+
+    opt = autop.sharding_optimizer
+    validated_keys = 0
+    validated_linked_keys = 0
+
+    for param, _grad in get_param_and_grad_nodes(opt.graph).values():
+        # Walk forward from param through single-user unary nodes
+        n = param
+        while True:
+            if n.target == torch.ops.autoparallel.dtype_cast.default:
+                break
+            users = list(n.users.keys())
+            if len(users) != 1:
+                break
+            child = users[0]
+            if len(child.all_input_nodes) != 1:
+                break
+            n = child
+
+        if n.target != torch.ops.autoparallel.dtype_cast.default:
+            continue
+
+        # Only check downcasts (storage > param_dtype)
+        storage_dtype = param.meta["val"].dtype
+        cast_dtype = n.meta["val"].dtype
+        if cast_dtype.itemsize >= storage_dtype.itemsize:
+            continue
+
+        # Collect pre-cast node indices
+        fwd_pre_cast_node_idxs = set()
+        node = n
+        while node != param:
+            if node in opt.node_map:
+                fwd_pre_cast_node_idxs.add(opt.node_map[node])
+            node = node.all_input_nodes[0]
+
+        for key in opt.selected_keys:
+            node_idx, argi, out_idx, inp_idx = key
+            if node_idx not in fwd_pre_cast_node_idxs:
+                continue
+            dv = opt._resolve_decision_var(key)
+            validated_keys += 1
+            if key in opt.cluster_links:
+                validated_linked_keys += 1
+            assert dv.comm_cost == 0, (
+                f"Forward pre-cast node {opt.nodes[node_idx].name} has chosen "
+                f"decision var with comm_cost={dv.comm_cost} > 0. "
+                f"Redistribution should not happen before the dtype_cast."
+            )
+
+    assert validated_keys > 0, "Expected to validate at least one forward pre-cast key"
+    if require_linked_validation:
+        assert (
+            validated_linked_keys > 0
+        ), "Expected to validate at least one cluster-linked forward pre-cast key"
+
+
+@apply_cuda_patches
+def test_fwd_allgather_in_param_dtype(device_mesh_1d):
+    """With param_dtype=bf16 and f32 storage, forward allgather should happen
+    after the dtype_cast (in bf16), not before it (in f32)."""
+    dim = 1024
+    mesh = device_mesh_1d
+
+    def model_fn():
+        return SimpleLinear(dim)
+
+    def input_fn():
+        return torch.randn(2048 * mesh.shape[0], dim, device="cuda")
+
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=torch.bfloat16, reduce_dtype=torch.float32
+    )
+    sharding_placement, autop = _run_autop(mesh, model_fn, input_fn, mp_policy)
+    _assert_no_fwd_pre_cast_redistribution(sharding_placement, autop)
+
+
+@apply_cuda_patches
+def test_fwd_allgather_in_param_dtype_reduce_bf16(device_mesh_1d):
+    """With param_dtype=bf16, reduce_dtype=bf16, and f32 storage, the forward
+    constraint should still fire (it depends on storage > param_dtype, not on
+    reduce_dtype)."""
+    dim = 1024
+    mesh = device_mesh_1d
+
+    def model_fn():
+        return SimpleLinear(dim)
+
+    def input_fn():
+        return torch.randn(2048 * mesh.shape[0], dim, device="cuda")
+
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=torch.bfloat16, reduce_dtype=torch.bfloat16
+    )
+    sharding_placement, autop = _run_autop(mesh, model_fn, input_fn, mp_policy)
+    _assert_no_fwd_pre_cast_redistribution(sharding_placement, autop)
+
+
+@apply_cuda_patches
+def test_fwd_allgather_with_repeated_subgraphs(device_mesh_1d):
+    """Forward constraint with repeated_subgraphs=True (cluster-linked nodes)."""
+    dim = 1024
+    mesh = device_mesh_1d
+
+    def model_fn():
+        return StackedLinear(dim, n_layers=4)
+
+    def input_fn():
+        return torch.randn(2048 * mesh.shape[0], dim, device="cuda")
+
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=torch.bfloat16, reduce_dtype=torch.float32
+    )
+    sharding_placement, autop = _run_autop(
+        mesh, model_fn, input_fn, mp_policy, repeated_subgraphs=True
+    )
+    _assert_no_fwd_pre_cast_redistribution(
+        sharding_placement, autop, require_linked_validation=True
+    )
+
+
+@apply_cuda_patches
+def test_fwd_no_constraint_when_upcasting(device_mesh_1d):
+    """With param_dtype=f32 and bf16 storage (upcast), the forward constraint
+    should NOT fire since the storage dtype is already smaller."""
+    dim = 1024
+    mesh = device_mesh_1d
+
+    def model_fn():
+        m = SimpleLinear(dim)
+        # Force bf16 storage so dtype_cast goes bf16 -> f32
+        m.linear.weight = nn.Parameter(m.linear.weight.to(torch.bfloat16))
+        return m
+
+    def input_fn():
+        return torch.randn(2048 * mesh.shape[0], dim, device="cuda")
+
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=torch.float32, reduce_dtype=torch.bfloat16
+    )
+    sharding_placement, autop = _run_autop(mesh, model_fn, input_fn, mp_policy)
+
+    # Verify no fwd_param_dtype constraints were added to the ILP
+    opt = autop.sharding_optimizer
+    fwd_constraint_names = [
+        name for name in opt.prob.constraints if name.startswith("fwd_param_dtype")
+    ]
+    assert len(fwd_constraint_names) == 0, (
+        f"Forward dtype constraint should not fire for upcasting, "
+        f"but found {len(fwd_constraint_names)} constraints: {fwd_constraint_names}"
+    )


### PR DESCRIPTION
When `MixedPrecisionPolicy` sets `param_dtype` smaller than the storage dtype (e.g., bf16 params with f32 stored weights), the optimizer was free to place the `dtype_cast` node at a different sharding than its input parameter. This caused the allgather to land on the f32 input edge rather than the bf16 output edge, doubling communication volume.

The root cause is a flat spot in the NCCL allgather cost model where different message sizes (4MB vs 8MB) return identical costs, making the optimizer indifferent between f32 and bf16 allgathers. Rather than fixing the cost model (which would be fragile), this PR adds a structural constraint that makes the behavior correct regardless of cost model accuracy.

The existing `add_grad_reduce_dtype_constraints` already handled the backward direction (forcing reduce-scatter after the grad dtype\_cast). This PR adds the symmetric forward constraint: forbid redistribution between a parameter placeholder and its `dtype_cast` node, so any allgather happens on the cast output in `param_dtype`. The forward constraint runs unconditionally whenever a downcasting `dtype_cast` exists, independent of `reduce_dtype` — this handles the case where `param_dtype=bf16, reduce_dtype=bf16` with f32 storage, which the old `reduce_dtype > param_dtype` guard missed.

Authored with Claude.