### PR TITLE
Fix double recomputation of FSDP all-gather in activation checkpointing

### DIFF
--- a/autoparallel/graph_passes/activation_checkpointing.py
+++ b/autoparallel/graph_passes/activation_checkpointing.py
@@ -250,13 +250,18 @@ def force_recompute_fsdp_all_gather(graph: torch.fx.Graph) -> None:
             ag_node = node.args[0]
             force_recompute_node(ag_node)  # all_gather
             force_recompute_node(node)  # wait_tensor
-            # Force-recompute slice that comes after wait
-            for user in node.users:
-                if (
-                    user.op == "call_function"
-                    and user.target == torch.ops.aten.slice.Tensor
-                ):
-                    force_recompute_node(user)
+            # Force-recompute the downstream single-input chain from
+            # wait_tensor (permute, slice, reshape, etc.). Without this,
+            # the partitioner saves the first untagged downstream node,
+            # which holds the same allgathered data and defeats the
+            # MUST_RECOMPUTE on the allgather itself.
+            w = node
+            while len(w.users) == 1:
+                user = next(iter(w.users))
+                if len(user.all_input_nodes) > 1:
+                    break
+                force_recompute_node(user)
+                w = user
             # Force-recompute potential dtype casts from all_gather
             if (
                 ag_node.all_input_nodes[0].op == "call_function"

--- a/tests/test_activation_checkpointing.py
+++ b/tests/test_activation_checkpointing.py
@@ -908,13 +908,10 @@ def test_local_map_custom_metadata_propagation(device_mesh_3d):
         f"{[n.name for n in sdpa_nodes]}"
     )
     fwd_sdpa, bwd_sdpa = sdpa_nodes
-    assert fwd_sdpa.meta["custom"] == {
+    expected_custom = {
         "inside_checkpoint": 0,
         "inside_local_map": 2,
         "outside_checkpoint": 0,
     }
-    assert bwd_sdpa.meta["custom"] == {
-        "inside_checkpoint": 0,
-        "inside_local_map": 2,
-        "outside_checkpoint": 0,
-    }
+    assert expected_custom.items() <= fwd_sdpa.meta["custom"].items()
+    assert expected_custom.items() <= bwd_sdpa.meta["custom"].items()


### PR DESCRIPTION
The previous code only force-recomputed `aten.slice` nodes after `wait_tensor`, but other single-input ops (permute, reshape, etc.) can also appear in between. When those intermediate nodes aren't tagged as `MUST_RECOMPUTE`, the partitioner saves them in the forward pass, defeating the recomputation of the all-gather itself.

This generalizes the tagging to walk the entire single-input chain downstream from `wait_tensor`, stopping when a node has multiple users or multiple inputs. Also relaxes a test assertion to use subset checking so it's resilient to additional metadata keys.

Authored with Claude.