### PR TITLE
Physically shard reversed-order parameters with `_StridedShard` for DCP compatibility

### DIFF
--- a/autoparallel/apply_sharding.py
+++ b/autoparallel/apply_sharding.py
@@ -290,27 +290,37 @@ class ApplyShardingInterpreter(torch.fx.Interpreter):
         return out
 
 
-def _get_effective_placements(node, sharding_placement, param_placement_order):
-    """Return the (mesh, placements) to use when sharding a node.
+def _build_physical_placements(sharding_placement, param_placement_order):
+    """Build a dict mapping each node to its physical DTensorSpec.
 
-    For reversed-order params, converts to _StridedShard placements so the
-    physical layout matches the intended shard order. For everything else,
-    returns the solver-assigned placements unchanged.
+    For reversed-order nodes in param_placement_order, converts to
+    _StridedShard placements so the physical layout matches the intended
+    shard order. For everything else, returns the solver-assigned spec.
     """
-    tgt_spec = sharding_placement[node].input_specs[0]
-    placements = tgt_spec.placements
-    if (
-        node in param_placement_order
-        and param_placement_order[node].is_target_reversed_order
-    ):
-        reversed_shard_order = _compute_shard_order(tgt_spec.shard_order, reverse=True)
-        placements = DTensorSpec._convert_shard_order_to_StridedShard(
-            reversed_shard_order, tgt_spec.placements, tgt_spec.mesh
-        )
-    return tgt_spec.mesh, placements
+    physical = {}
+    for node, op_spec in sharding_placement.items():
+        if op_spec.input_specs is None:
+            continue
+        tgt_spec = op_spec.input_specs[0]
+        if (
+            node in param_placement_order
+            and param_placement_order[node].is_target_reversed_order
+        ):
+            reversed_shard_order = _compute_shard_order(
+                tgt_spec.shard_order, reverse=True
+            )
+            placements = DTensorSpec._convert_shard_order_to_StridedShard(
+                reversed_shard_order, tgt_spec.placements, tgt_spec.mesh
+            )
+            tgt_spec = DTensorSpec(
+                tgt_spec.mesh, placements, tensor_meta=tgt_spec.tensor_meta
+            )
+        physical[node] = tgt_spec
+    return physical
 
 
-def shard_node_given_placements(node, mesh, placements):
+def shard_node_given_placements(node, spec):
+    mesh = spec.mesh
     curr_placement = (Replicate(),) * mesh.ndim
     tensor = node.meta["val"]
 
@@ -320,7 +330,7 @@ def shard_node_given_placements(node, mesh, placements):
     with unset_fake_temporarily():
         tensor = torch.empty(tensor.shape, dtype=tensor.dtype, device="meta")
         sharded_tensor = DTensor.from_local(tensor, mesh, curr_placement).redistribute(
-            mesh, placements
+            mesh, spec.placements
         )
 
     return sharded_tensor
@@ -373,7 +383,7 @@ def _has_rank_varying_size(dim_idx, global_shape, spec):
     return False
 
 
-def _make_local_args(gm, sharding_placement, param_placement_order):
+def _make_local_args(gm, physical_placements):
     """Create local tensors for each placeholder via DTensor redistribute.
 
     Uses DTensor's redistribute to compute correct local shapes and strides.
@@ -395,9 +405,8 @@ def _make_local_args(gm, sharding_placement, param_placement_order):
             local_args.append(val)
             continue
         tensor = val
-        mesh, redistribute_placements = _get_effective_placements(
-            node, sharding_placement, param_placement_order
-        )
+        spec = physical_placements[node]
+        mesh = spec.mesh
         curr_placement = (Replicate(),) * mesh.ndim
 
         # Use DTensor to compute the correct local shape and strides.
@@ -416,7 +425,7 @@ def _make_local_args(gm, sharding_placement, param_placement_order):
 
         sharded = DTensor.from_local(
             concrete_tensor, mesh, curr_placement
-        ).redistribute(mesh, redistribute_placements)
+        ).redistribute(mesh, spec.placements)
         local = sharded.to_local()
 
         # For dynamic shapes, re-create with fresh SymInts.
@@ -428,9 +437,7 @@ def _make_local_args(gm, sharding_placement, param_placement_order):
             dynamic_sizes = [
                 DimDynamic.DYNAMIC
                 if (isinstance(s, torch.SymInt) and not s.node.expr.is_number)
-                or _has_rank_varying_size(
-                    i, tensor.shape, DTensorSpec(mesh, redistribute_placements)
-                )
+                or _has_rank_varying_size(i, tensor.shape, spec)
                 else DimDynamic.STATIC
                 for i, s in enumerate(tensor.shape)
             ]
@@ -500,9 +507,7 @@ def _copy_descriptors_and_rename_placeholders(source_gm, target_gm):
     target_gm.recompile()
 
 
-def _shard_params_and_buffers(
-    gm, sharding_placement, params_spec, buffers_spec, param_placement_order
-):
+def _shard_params_and_buffers(gm, physical_placements, params_spec, buffers_spec):
     """Shard parameters and buffers according to the sharding placement."""
     # NB: ok to NOT use the parallel_gm here because we will just reapply the
     # correct sharding placement via sharding_placement
@@ -512,21 +517,17 @@ def _shard_params_and_buffers(
     sharded_param_dict = {}
     for fqn in params_spec:
         n = fqn_to_param[fqn]
-        mesh, placements = _get_effective_placements(
-            n, sharding_placement, param_placement_order
-        )
         with unset_fake_temporarily():
             sharded_param_dict[fqn] = nn.Parameter(
-                shard_node_given_placements(n, mesh, placements)
+                shard_node_given_placements(n, physical_placements[n])
             )
 
     sharded_buffer_dict = {}
     for fqn in buffers_spec:
         n = fqn_to_buffer[fqn]
-        mesh, placements = _get_effective_placements(
-            n, sharding_placement, param_placement_order
+        sharded_buffer_dict[fqn] = shard_node_given_placements(
+            n, physical_placements[n]
         )
-        sharded_buffer_dict[fqn] = shard_node_given_placements(n, mesh, placements)
 
     return sharded_param_dict, sharded_buffer_dict
 
@@ -564,8 +565,11 @@ def apply_sharding_to_model(gm, sharding_placement, params_spec, buffers_spec):
     param_placement_order = compute_optimal_placement_order_for_parameters(
         gm, sharding_placement
     )
+    physical_placements = _build_physical_placements(
+        sharding_placement, param_placement_order
+    )
 
-    local_args = _make_local_args(gm, sharding_placement, param_placement_order)
+    local_args = _make_local_args(gm, physical_placements)
     t1 = time.perf_counter()
 
     with use_min_cost_redistribution_plan():
@@ -582,7 +586,7 @@ def apply_sharding_to_model(gm, sharding_placement, params_spec, buffers_spec):
     t3 = time.perf_counter()
 
     sharded_param_dict, sharded_buffer_dict = _shard_params_and_buffers(
-        gm, sharding_placement, params_spec, buffers_spec, param_placement_order
+        gm, physical_placements, params_spec, buffers_spec
     )
     t4 = time.perf_counter()
 

--- a/autoparallel/apply_sharding.py
+++ b/autoparallel/apply_sharding.py
@@ -355,7 +355,7 @@ def _has_rank_varying_size(dim_idx, global_shape, spec):
     return False
 
 
-def _make_local_args(gm, sharding_placement):
+def _make_local_args(gm, sharding_placement, param_placement_order):
     """Create local tensors for each placeholder via DTensor redistribute.
 
     Uses DTensor's redistribute to compute correct local shapes and strides.
@@ -395,9 +395,23 @@ def _make_local_args(gm, sharding_placement):
                     device=tensor.device,
                 )
 
+        # For reversed-order params, use _StridedShard placements so the
+        # local shape matches the actual runtime parameter shard layout.
+        redistribute_placements = tgt_spec.placements
+        if (
+            node in param_placement_order
+            and param_placement_order[node].is_target_reversed_order
+        ):
+            reversed_shard_order = _compute_shard_order(
+                tgt_spec.shard_order, reverse=True
+            )
+            redistribute_placements = DTensorSpec._convert_shard_order_to_StridedShard(
+                reversed_shard_order, tgt_spec.placements, mesh
+            )
+
         sharded = DTensor.from_local(
             concrete_tensor, mesh, curr_placement
-        ).redistribute(mesh, tgt_spec.placements)
+        ).redistribute(mesh, redistribute_placements)
         local = sharded.to_local()
 
         # For dynamic shapes, re-create with fresh SymInts.
@@ -561,7 +575,7 @@ def apply_sharding_to_model(gm, sharding_placement, params_spec, buffers_spec):
         gm, sharding_placement
     )
 
-    local_args = _make_local_args(gm, sharding_placement)
+    local_args = _make_local_args(gm, sharding_placement, param_placement_order)
     t1 = time.perf_counter()
 
     with use_min_cost_redistribution_plan():

--- a/autoparallel/apply_sharding.py
+++ b/autoparallel/apply_sharding.py
@@ -92,7 +92,9 @@ class ApplyShardingInterpreter(torch.fx.Interpreter):
         self.sharding_placement = sharding_placement
         self.dynamic = dynamic
         if param_placement_order is None:
-            param_placement_order = {}
+            param_placement_order = compute_optimal_placement_order_for_parameters(
+                module, sharding_placement
+            )
         self.param_placement_order = param_placement_order
 
     def run_node(self, n):

--- a/autoparallel/apply_sharding.py
+++ b/autoparallel/apply_sharding.py
@@ -85,17 +85,14 @@ class ApplyShardingInterpreter(torch.fx.Interpreter):
         self,
         module,
         sharding_placement,
-        enable_ordered_sharding_optimization: bool = True,
+        param_placement_order: dict | None = None,
         dynamic: bool = False,
     ):
         super().__init__(module, garbage_collect_values=True, graph=None)
         self.sharding_placement = sharding_placement
         self.dynamic = dynamic
-        param_placement_order = {}
-        if enable_ordered_sharding_optimization:
-            param_placement_order = compute_optimal_placement_order_for_parameters(
-                module, sharding_placement
-            )
+        if param_placement_order is None:
+            param_placement_order = {}
         self.param_placement_order = param_placement_order
 
     def run_node(self, n):
@@ -436,11 +433,18 @@ def _make_local_args(gm, sharding_placement):
     return local_args
 
 
-def _lower_to_parallel_graph(gm, sharding_placement, local_args, dynamic=False):
+def _lower_to_parallel_graph(
+    gm, sharding_placement, local_args, dynamic=False, param_placement_order=None
+):
     """Two-pass lowering: interpret with sharding collectives, then decompose."""
     decomp_table = _get_inductor_decomp_table()
 
-    interp = ApplyShardingInterpreter(gm, sharding_placement, dynamic=dynamic)
+    interp = ApplyShardingInterpreter(
+        gm,
+        sharding_placement,
+        param_placement_order=param_placement_order,
+        dynamic=dynamic,
+    )
 
     tracing_mode = "symbolic" if dynamic else "real"
 
@@ -475,7 +479,9 @@ def _copy_descriptors_and_rename_placeholders(source_gm, target_gm):
     target_gm.recompile()
 
 
-def _shard_params_and_buffers(gm, sharding_placement, params_spec, buffers_spec):
+def _shard_params_and_buffers(
+    gm, sharding_placement, params_spec, buffers_spec, param_placement_order
+):
     """Shard parameters and buffers according to the sharding placement."""
     # NB: ok to NOT use the parallel_gm here because we will just reapply the
     # correct sharding placement via sharding_placement
@@ -485,12 +491,33 @@ def _shard_params_and_buffers(gm, sharding_placement, params_spec, buffers_spec)
     sharded_param_dict = {}
     for fqn in params_spec:
         n = fqn_to_param[fqn]
+        tgt_spec = sharding_placement[n].input_specs[0]
+        mesh = tgt_spec.mesh
+        needs_reversed = (
+            n in param_placement_order
+            and param_placement_order[n].is_target_reversed_order
+        )
         with unset_fake_temporarily():
-            sharded_param_dict[fqn] = nn.Parameter(
-                shard_node_given_placements(n, sharding_placement)
-            )
-            tgt_spec = sharding_placement[n].input_specs[0]
-            sharded_param_dict[fqn]._spec.shard_order = tgt_spec.shard_order
+            if needs_reversed:
+                reversed_shard_order = _compute_shard_order(
+                    tgt_spec.shard_order, reverse=True
+                )
+                strided_placements = DTensorSpec._convert_shard_order_to_StridedShard(
+                    reversed_shard_order, tgt_spec.placements, mesh
+                )
+                tensor = torch.empty(
+                    n.meta["val"].shape, dtype=n.meta["val"].dtype, device="meta"
+                )
+                curr_placement = (Replicate(),) * mesh.ndim
+                sharded_param_dict[fqn] = nn.Parameter(
+                    DTensor.from_local(tensor, mesh, curr_placement).redistribute(
+                        mesh, strided_placements
+                    )
+                )
+            else:
+                sharded_param_dict[fqn] = nn.Parameter(
+                    shard_node_given_placements(n, sharding_placement)
+                )
 
     sharded_buffer_dict = {}
     for fqn in buffers_spec:
@@ -530,12 +557,20 @@ def apply_sharding_to_model(gm, sharding_placement, params_spec, buffers_spec):
             fake_mode.shape_env = ShapeEnv()
             fake_mode.static_shapes = False
 
+    param_placement_order = compute_optimal_placement_order_for_parameters(
+        gm, sharding_placement
+    )
+
     local_args = _make_local_args(gm, sharding_placement)
     t1 = time.perf_counter()
 
     with use_min_cost_redistribution_plan():
         parallel_gm = _lower_to_parallel_graph(
-            gm, sharding_placement, local_args, dynamic
+            gm,
+            sharding_placement,
+            local_args,
+            dynamic,
+            param_placement_order=param_placement_order,
         )
     t2 = time.perf_counter()
 
@@ -543,7 +578,7 @@ def apply_sharding_to_model(gm, sharding_placement, params_spec, buffers_spec):
     t3 = time.perf_counter()
 
     sharded_param_dict, sharded_buffer_dict = _shard_params_and_buffers(
-        gm, sharding_placement, params_spec, buffers_spec
+        gm, sharding_placement, params_spec, buffers_spec, param_placement_order
     )
     t4 = time.perf_counter()
 

--- a/autoparallel/apply_sharding.py
+++ b/autoparallel/apply_sharding.py
@@ -290,6 +290,26 @@ class ApplyShardingInterpreter(torch.fx.Interpreter):
         return out
 
 
+def _get_effective_placements(node, sharding_placement, param_placement_order):
+    """Return the (mesh, placements) to use when sharding a node.
+
+    For reversed-order params, converts to _StridedShard placements so the
+    physical layout matches the intended shard order. For everything else,
+    returns the solver-assigned placements unchanged.
+    """
+    tgt_spec = sharding_placement[node].input_specs[0]
+    placements = tgt_spec.placements
+    if (
+        node in param_placement_order
+        and param_placement_order[node].is_target_reversed_order
+    ):
+        reversed_shard_order = _compute_shard_order(tgt_spec.shard_order, reverse=True)
+        placements = DTensorSpec._convert_shard_order_to_StridedShard(
+            reversed_shard_order, tgt_spec.placements, tgt_spec.mesh
+        )
+    return tgt_spec.mesh, placements
+
+
 def shard_node_given_placements(node, mesh, placements):
     curr_placement = (Replicate(),) * mesh.ndim
     tensor = node.meta["val"]
@@ -375,8 +395,9 @@ def _make_local_args(gm, sharding_placement, param_placement_order):
             local_args.append(val)
             continue
         tensor = val
-        tgt_spec = sharding_placement[node].input_specs[0]
-        mesh = tgt_spec.mesh
+        mesh, redistribute_placements = _get_effective_placements(
+            node, sharding_placement, param_placement_order
+        )
         curr_placement = (Replicate(),) * mesh.ndim
 
         # Use DTensor to compute the correct local shape and strides.
@@ -393,20 +414,6 @@ def _make_local_args(gm, sharding_placement, param_placement_order):
                     device=tensor.device,
                 )
 
-        # For reversed-order params, use _StridedShard placements so the
-        # local shape matches the actual runtime parameter shard layout.
-        redistribute_placements = tgt_spec.placements
-        if (
-            node in param_placement_order
-            and param_placement_order[node].is_target_reversed_order
-        ):
-            reversed_shard_order = _compute_shard_order(
-                tgt_spec.shard_order, reverse=True
-            )
-            redistribute_placements = DTensorSpec._convert_shard_order_to_StridedShard(
-                reversed_shard_order, tgt_spec.placements, mesh
-            )
-
         sharded = DTensor.from_local(
             concrete_tensor, mesh, curr_placement
         ).redistribute(mesh, redistribute_placements)
@@ -421,7 +428,9 @@ def _make_local_args(gm, sharding_placement, param_placement_order):
             dynamic_sizes = [
                 DimDynamic.DYNAMIC
                 if (isinstance(s, torch.SymInt) and not s.node.expr.is_number)
-                or _has_rank_varying_size(i, tensor.shape, tgt_spec)
+                or _has_rank_varying_size(
+                    i, tensor.shape, DTensorSpec(mesh, redistribute_placements)
+                )
                 else DimDynamic.STATIC
                 for i, s in enumerate(tensor.shape)
             ]
@@ -503,30 +512,21 @@ def _shard_params_and_buffers(
     sharded_param_dict = {}
     for fqn in params_spec:
         n = fqn_to_param[fqn]
-        tgt_spec = sharding_placement[n].input_specs[0]
-        placements = tgt_spec.placements
-        if (
-            n in param_placement_order
-            and param_placement_order[n].is_target_reversed_order
-        ):
-            reversed_shard_order = _compute_shard_order(
-                tgt_spec.shard_order, reverse=True
-            )
-            placements = DTensorSpec._convert_shard_order_to_StridedShard(
-                reversed_shard_order, tgt_spec.placements, tgt_spec.mesh
-            )
+        mesh, placements = _get_effective_placements(
+            n, sharding_placement, param_placement_order
+        )
         with unset_fake_temporarily():
             sharded_param_dict[fqn] = nn.Parameter(
-                shard_node_given_placements(n, tgt_spec.mesh, placements)
+                shard_node_given_placements(n, mesh, placements)
             )
 
     sharded_buffer_dict = {}
     for fqn in buffers_spec:
         n = fqn_to_buffer[fqn]
-        tgt_spec = sharding_placement[n].input_specs[0]
-        sharded_buffer_dict[fqn] = shard_node_given_placements(
-            n, tgt_spec.mesh, tgt_spec.placements
+        mesh, placements = _get_effective_placements(
+            n, sharding_placement, param_placement_order
         )
+        sharded_buffer_dict[fqn] = shard_node_given_placements(n, mesh, placements)
 
     return sharded_param_dict, sharded_buffer_dict
 

--- a/autoparallel/apply_sharding.py
+++ b/autoparallel/apply_sharding.py
@@ -290,9 +290,7 @@ class ApplyShardingInterpreter(torch.fx.Interpreter):
         return out
 
 
-def shard_node_given_placements(node, sharding_placement):
-    tgt_spec = sharding_placement[node].input_specs[0]
-    mesh = tgt_spec.mesh
+def shard_node_given_placements(node, mesh, placements):
     curr_placement = (Replicate(),) * mesh.ndim
     tensor = node.meta["val"]
 
@@ -302,7 +300,7 @@ def shard_node_given_placements(node, sharding_placement):
     with unset_fake_temporarily():
         tensor = torch.empty(tensor.shape, dtype=tensor.dtype, device="meta")
         sharded_tensor = DTensor.from_local(tensor, mesh, curr_placement).redistribute(
-            mesh, tgt_spec.placements
+            mesh, placements
         )
 
     return sharded_tensor
@@ -506,37 +504,29 @@ def _shard_params_and_buffers(
     for fqn in params_spec:
         n = fqn_to_param[fqn]
         tgt_spec = sharding_placement[n].input_specs[0]
-        mesh = tgt_spec.mesh
-        needs_reversed = (
+        placements = tgt_spec.placements
+        if (
             n in param_placement_order
             and param_placement_order[n].is_target_reversed_order
-        )
+        ):
+            reversed_shard_order = _compute_shard_order(
+                tgt_spec.shard_order, reverse=True
+            )
+            placements = DTensorSpec._convert_shard_order_to_StridedShard(
+                reversed_shard_order, tgt_spec.placements, tgt_spec.mesh
+            )
         with unset_fake_temporarily():
-            if needs_reversed:
-                reversed_shard_order = _compute_shard_order(
-                    tgt_spec.shard_order, reverse=True
-                )
-                strided_placements = DTensorSpec._convert_shard_order_to_StridedShard(
-                    reversed_shard_order, tgt_spec.placements, mesh
-                )
-                tensor = torch.empty(
-                    n.meta["val"].shape, dtype=n.meta["val"].dtype, device="meta"
-                )
-                curr_placement = (Replicate(),) * mesh.ndim
-                sharded_param_dict[fqn] = nn.Parameter(
-                    DTensor.from_local(tensor, mesh, curr_placement).redistribute(
-                        mesh, strided_placements
-                    )
-                )
-            else:
-                sharded_param_dict[fqn] = nn.Parameter(
-                    shard_node_given_placements(n, sharding_placement)
-                )
+            sharded_param_dict[fqn] = nn.Parameter(
+                shard_node_given_placements(n, tgt_spec.mesh, placements)
+            )
 
     sharded_buffer_dict = {}
     for fqn in buffers_spec:
         n = fqn_to_buffer[fqn]
-        sharded_buffer_dict[fqn] = shard_node_given_placements(n, sharding_placement)
+        tgt_spec = sharding_placement[n].input_specs[0]
+        sharded_buffer_dict[fqn] = shard_node_given_placements(
+            n, tgt_spec.mesh, tgt_spec.placements
+        )
 
     return sharded_param_dict, sharded_buffer_dict
 

--- a/tests/test_apply_sharding.py
+++ b/tests/test_apply_sharding.py
@@ -214,11 +214,13 @@ class TestShardOrderSpecIsolation:
             t: OpSpec(output_specs=shared_tgt_spec, input_specs=[shared_tgt_spec]),
         }
 
-        interp = ApplyShardingInterpreter(gm, sharding_placement)
-        # Manually set param_placement_order for the consuming node
-        interp.param_placement_order = {
-            t: OrderInfo(is_target_reversed_order=False, need_reorder=True),
-        }
+        interp = ApplyShardingInterpreter(
+            gm,
+            sharding_placement,
+            param_placement_order={
+                t: OrderInfo(is_target_reversed_order=False, need_reorder=True),
+            },
+        )
 
         # Call redistribute_tensor — this should NOT mutate shared_curr_spec
         local = torch.randn(2, 64, device="meta")

--- a/tests/test_apply_sharding.py
+++ b/tests/test_apply_sharding.py
@@ -214,9 +214,7 @@ class TestShardOrderSpecIsolation:
             t: OpSpec(output_specs=shared_tgt_spec, input_specs=[shared_tgt_spec]),
         }
 
-        interp = ApplyShardingInterpreter(
-            gm, sharding_placement, enable_ordered_sharding_optimization=False
-        )
+        interp = ApplyShardingInterpreter(gm, sharding_placement)
         # Manually set param_placement_order for the consuming node
         interp.param_placement_order = {
             t: OrderInfo(is_target_reversed_order=False, need_reorder=True),

--- a/tests/test_dcp_ordered_sharding.py
+++ b/tests/test_dcp_ordered_sharding.py
@@ -126,6 +126,48 @@ class TestChunkOffsetsForDCP:
                 expected_offset,
             ), f"rank {rank} coord {coord}: {offset} != ({expected_offset},)"
 
+    def test_uneven_shapes_local_sizes_differ(self):
+        """With uneven tensor sizes, default and reversed orders produce
+        different local shapes for some ranks — the bug that _make_local_args
+        would hit if it used default placements for reversed-order params."""
+        mesh_shape = (2, 4)
+        global_shape = (17,)  # 17 doesn't divide evenly by 2 or 4
+
+        default_placements = (Shard(0), Shard(0))
+        reversed_placements = (_StridedShard(0, split_factor=4), Shard(0))
+
+        shape_mismatches = 0
+        for rank in range(8):
+            coord = list(_mesh_coords(rank, mesh_shape))
+            default_shape, _ = _compute_local_shape_and_global_offset(
+                global_shape, mesh_shape, coord, default_placements
+            )
+            reversed_shape, _ = _compute_local_shape_and_global_offset(
+                global_shape, mesh_shape, coord, reversed_placements
+            )
+            if default_shape != reversed_shape:
+                shape_mismatches += 1
+
+        assert shape_mismatches > 0, (
+            "Uneven tensor size should produce different local shapes "
+            "for default vs reversed shard order"
+        )
+
+    def test_uneven_shapes_all_ranks_cover_full_tensor(self):
+        """With uneven sizes, _StridedShard shards still cover the full tensor."""
+        mesh_shape = (2, 4)
+        reversed_placements = (_StridedShard(0, split_factor=4), Shard(0))
+
+        global_tensor = torch.arange(17, dtype=torch.float)
+        shards = _shard_tensor(global_tensor, mesh_shape, reversed_placements)
+
+        all_values = set()
+        for rank in range(8):
+            for val in shards[rank].tolist():
+                all_values.add(int(val))
+
+        assert all_values == set(range(17))
+
     def test_reversed_order_offsets_differ(self):
         """_StridedShard offsets differ from regular Shard offsets."""
         mesh_shape = (2, 4)

--- a/tests/test_dcp_ordered_sharding.py
+++ b/tests/test_dcp_ordered_sharding.py
@@ -14,7 +14,11 @@ Uses a fake process group (single-process) and meta-device tensors so
 the tests can run without multiple GPUs.
 """
 
+import math
+
 import torch
+from torch.distributed._local_tensor import LocalTensor, LocalTensorMode
+from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from torch.distributed.tensor._utils import _compute_local_shape_and_global_offset
@@ -32,58 +36,28 @@ from autoparallel.apply_sharding import _compute_shard_order
 # ---------------------------------------------------------------------------
 
 
-def _rank_coord(rank, mesh_shape, mesh_dim):
-    stride = 1
-    for d in range(len(mesh_shape) - 1, mesh_dim, -1):
-        stride *= mesh_shape[d]
-    return (rank // stride) % mesh_shape[mesh_dim]
+def _mesh_coords(rank, mesh_shape):
+    """Compute a rank's coordinates in a mesh, using DeviceMesh's own logic."""
+    mesh_tensor = torch.arange(math.prod(mesh_shape)).view(mesh_shape)
+    return DeviceMesh._compute_coordinates_from_mesh(mesh_tensor, rank)
 
 
-def _shard_tensor_default_order(global_tensor, mesh_shape, placements):
-    """Shard a tensor using default (left-to-right) mesh dim order.
+def _shard_tensor(global_tensor, mesh, placements):
+    """Shard a tensor into per-rank local shards via DTensor redistribute.
 
-    Returns dict[rank -> local_tensor].
+    Uses LocalTensorMode to simulate multi-rank execution on a single process.
+    Returns dict[rank -> Tensor].
     """
-    world_size = 1
-    for s in mesh_shape:
-        world_size *= s
-
-    shards = {}
-    for rank in range(world_size):
-        shard = global_tensor
-        for mesh_dim, placement in enumerate(placements):
-            if isinstance(placement, Shard):
-                n_chunks = mesh_shape[mesh_dim]
-                coord = _rank_coord(rank, mesh_shape, mesh_dim)
-                chunk_size = shard.size(placement.dim) // n_chunks
-                shard = shard.narrow(placement.dim, coord * chunk_size, chunk_size)
-        shards[rank] = shard.contiguous().clone()
-    return shards
-
-
-def _shard_tensor_reversed_order(global_tensor, mesh_shape, shard_dim):
-    """Shard a tensor along shard_dim using reversed mesh dim order (dim 1 first, then dim 0).
-
-    This is the physical layout that _StridedShard produces for S(d)S(d) with
-    reversed shard order on a 2D mesh.
-
-    Returns dict[rank -> local_tensor].
-    """
-    assert len(mesh_shape) == 2
-    world_size = mesh_shape[0] * mesh_shape[1]
-
-    shards = {}
-    for rank in range(world_size):
-        coord0 = _rank_coord(rank, mesh_shape, 0)
-        coord1 = _rank_coord(rank, mesh_shape, 1)
-        # Reversed order: shard by mesh_dim_1 first, then mesh_dim_0.
-        total_size = global_tensor.size(shard_dim)
-        chunk1 = total_size // mesh_shape[1]
-        shard = global_tensor.narrow(shard_dim, coord1 * chunk1, chunk1)
-        chunk0 = chunk1 // mesh_shape[0]
-        shard = shard.narrow(shard_dim, coord0 * chunk0, chunk0)
-        shards[rank] = shard.contiguous().clone()
-    return shards
+    if isinstance(mesh, tuple):
+        mesh_shape = mesh
+        mesh = DeviceMesh("cuda", torch.arange(math.prod(mesh_shape)).view(mesh_shape))
+    world_size = mesh.mesh.numel()
+    ranks = frozenset(range(world_size))
+    replicated = LocalTensor({r: global_tensor.clone() for r in range(world_size)})
+    with LocalTensorMode(ranks):
+        dt = DTensor.from_local(replicated, mesh, (Replicate(),) * mesh.ndim)
+        dt = dt.redistribute(mesh, placements)
+    return dt._local_tensor._local_tensors
 
 
 # ---------------------------------------------------------------------------
@@ -141,7 +115,7 @@ class TestChunkOffsetsForDCP:
         placements = (Shard(0), Shard(0))
 
         for rank in range(8):
-            coord = [_rank_coord(rank, mesh_shape, d) for d in range(2)]
+            coord = list(_mesh_coords(rank, mesh_shape))
             local_shape, offset = _compute_local_shape_and_global_offset(
                 global_shape, mesh_shape, coord, placements
             )
@@ -164,7 +138,7 @@ class TestChunkOffsetsForDCP:
         default_offsets = {}
         reversed_offsets = {}
         for rank in range(8):
-            coord = [_rank_coord(rank, mesh_shape, d) for d in range(2)]
+            coord = list(_mesh_coords(rank, mesh_shape))
             _, d_off = _compute_local_shape_and_global_offset(
                 global_shape, mesh_shape, coord, default_placements
             )
@@ -181,16 +155,13 @@ class TestChunkOffsetsForDCP:
         """_StridedShard offsets match the actual data positions from reversed sharding."""
         mesh_shape = (2, 4)
         global_shape = (64,)
+        reversed_placements = (_StridedShard(0, split_factor=4), Shard(0))
 
         # Create a tensor with known values and shard it in reversed order.
         global_tensor = torch.arange(64, dtype=torch.float)
-        reversed_shards = _shard_tensor_reversed_order(
-            global_tensor, mesh_shape, shard_dim=0
-        )
-
-        reversed_placements = (_StridedShard(0, split_factor=4), Shard(0))
+        reversed_shards = _shard_tensor(global_tensor, mesh_shape, reversed_placements)
         for rank in range(8):
-            coord = [_rank_coord(rank, mesh_shape, d) for d in range(2)]
+            coord = list(_mesh_coords(rank, mesh_shape))
             _, offset = _compute_local_shape_and_global_offset(
                 global_shape, mesh_shape, coord, reversed_placements
             )
@@ -208,16 +179,14 @@ class TestChunkOffsetsForDCP:
 
         all_indices = set()
         for rank in range(8):
-            coord = [_rank_coord(rank, mesh_shape, d) for d in range(2)]
+            coord = list(_mesh_coords(rank, mesh_shape))
             local_shape, offset = _compute_local_shape_and_global_offset(
                 global_shape, mesh_shape, coord, reversed_placements
             )
             # For _StridedShard, indices may be non-contiguous, but local_shape
             # gives the number of elements this rank holds.
             global_tensor = torch.arange(64, dtype=torch.float)
-            local = _shard_tensor_reversed_order(
-                global_tensor, mesh_shape, shard_dim=0
-            )[rank]
+            local = _shard_tensor(global_tensor, mesh_shape, reversed_placements)[rank]
             for val in local.tolist():
                 all_indices.add(int(val))
 
@@ -298,7 +267,7 @@ class TestDCPRoundTrip:
         strided_placements = (_StridedShard(0, split_factor=4), Shard(0))
 
         for rank in range(8):
-            coord = [_rank_coord(rank, mesh_shape, d) for d in range(2)]
+            coord = list(_mesh_coords(rank, mesh_shape))
             save_shape, save_offset = _compute_local_shape_and_global_offset(
                 global_shape, mesh_shape, coord, strided_placements
             )
@@ -318,7 +287,7 @@ class TestDCPRoundTrip:
 
         mismatch_count = 0
         for rank in range(8):
-            coord = [_rank_coord(rank, mesh_shape, d) for d in range(2)]
+            coord = list(_mesh_coords(rank, mesh_shape))
             _, s_off = _compute_local_shape_and_global_offset(
                 global_shape, mesh_shape, coord, strided_placements
             )
@@ -340,14 +309,12 @@ class TestDCPRoundTrip:
         strided_placements = (_StridedShard(0, split_factor=4), Shard(0))
 
         global_tensor = torch.arange(64, dtype=torch.float)
-        reversed_shards = _shard_tensor_reversed_order(
-            global_tensor, mesh_shape, shard_dim=0
-        )
+        reversed_shards = _shard_tensor(global_tensor, mesh_shape, strided_placements)
 
         # "Save" side: each rank contributes its local shard with offset metadata.
         saved_chunks = {}
         for rank in range(8):
-            coord = [_rank_coord(rank, mesh_shape, d) for d in range(2)]
+            coord = list(_mesh_coords(rank, mesh_shape))
             local_shape, offset = _compute_local_shape_and_global_offset(
                 global_shape, mesh_shape, coord, strided_placements
             )
@@ -362,7 +329,7 @@ class TestDCPRoundTrip:
         covered = set()
         for rank in range(8):
             chunk = saved_chunks[rank]
-            coord = [_rank_coord(rank, mesh_shape, d) for d in range(2)]
+            coord = list(_mesh_coords(rank, mesh_shape))
             load_shape, load_offset = _compute_local_shape_and_global_offset(
                 global_shape, mesh_shape, coord, strided_placements
             )
@@ -392,11 +359,11 @@ class TestDCPRoundTrip:
         strided_placements = (_StridedShard(0, split_factor=4), Shard(0))
 
         global_tensor = torch.randn(64)
-        shards = _shard_tensor_reversed_order(global_tensor, mesh_shape, shard_dim=0)
+        shards = _shard_tensor(global_tensor, mesh_shape, strided_placements)
 
         # Verify each rank's chunk metadata is consistent between save and load.
         for rank in range(8):
-            coord = [_rank_coord(rank, mesh_shape, d) for d in range(2)]
+            coord = list(_mesh_coords(rank, mesh_shape))
             save_shape, save_off = _compute_local_shape_and_global_offset(
                 global_shape, mesh_shape, coord, strided_placements
             )
@@ -570,7 +537,7 @@ class TestShardParamsWithOrderedSharding:
         # Compute DCP chunk offsets for both.
         mismatch_count = 0
         for rank in range(mesh.size(0) * mesh.size(1)):
-            coord = [_rank_coord(rank, tuple(mesh.shape), d) for d in range(2)]
+            coord = list(_mesh_coords(rank, tuple(mesh.shape)))
             _, rev_off = _compute_local_shape_and_global_offset(
                 global_shape,
                 tuple(mesh.shape),

--- a/tests/test_dcp_ordered_sharding.py
+++ b/tests/test_dcp_ordered_sharding.py
@@ -342,56 +342,71 @@ class TestDCPRoundTrip:
         # At least some ranks should have different offsets.
         assert mismatch_count > 0
 
-    def test_data_integrity_after_simulated_round_trip(self):
-        """Simulate a DCP round-trip: shard with _StridedShard, compute
-        chunk metadata, then reassemble using those offsets. Verify the
-        reassembled tensor matches the original."""
+    def test_redistribute_round_trip(self):
+        """Shard with _StridedShard, then gather back to Replicate via
+        redistribute. Verify the reassembled tensor matches the original."""
         mesh_shape = (2, 4)
-        global_shape = (64,)
         strided_placements = (_StridedShard(0, split_factor=4), Shard(0))
 
         global_tensor = torch.arange(64, dtype=torch.float)
-        reversed_shards = _shard_tensor(global_tensor, mesh_shape, strided_placements)
+        shards = _shard_tensor(global_tensor, mesh_shape, strided_placements)
+        mesh = DeviceMesh("cuda", torch.arange(math.prod(mesh_shape)).view(mesh_shape))
+        replicated = (Replicate(),) * len(mesh_shape)
+        world_size = math.prod(mesh_shape)
+        ranks = frozenset(range(world_size))
+        with LocalTensorMode(ranks):
+            dt = DTensor.from_local(LocalTensor(shards), mesh, strided_placements)
+            gathered_dt = dt.redistribute(mesh, replicated)
 
-        # "Save" side: each rank contributes its local shard with offset metadata.
-        saved_chunks = {}
-        for rank in range(8):
+        for rank in range(world_size):
+            torch.testing.assert_close(
+                gathered_dt._local_tensor._local_tensors[rank].cpu(),
+                global_tensor,
+                msg=f"Round-trip mismatch on rank {rank}",
+            )
+
+    def test_dcp_chunk_metadata_matches_physical_layout(self):
+        """Verify that _compute_local_shape_and_global_offset (the function
+        DCP's planner calls to build chunk metadata) produces local shapes
+        and first-offsets consistent with the actual physical layout from
+        DTensor.redistribute.
+
+        For _StridedShard the local shard is non-contiguous in global index
+        space, so the first-offset alone can't reconstruct the full shard.
+        But DCP uses (first_offset, local_shape) to identify the chunk, and
+        the redistribute round-trip test above proves data correctness.
+        Here we verify the metadata interface itself."""
+        mesh_shape = (2, 4)
+        strided_placements = (_StridedShard(0, split_factor=4), Shard(0))
+        global_shape = (64,)
+        world_size = math.prod(mesh_shape)
+
+        global_tensor = torch.arange(64, dtype=torch.float)
+        shards = _shard_tensor(global_tensor, mesh_shape, strided_placements)
+
+        first_offsets = set()
+        for rank in range(world_size):
+            actual_shard = shards[rank]
             coord = list(_mesh_coords(rank, mesh_shape))
             local_shape, offset = _compute_local_shape_and_global_offset(
                 global_shape, mesh_shape, coord, strided_placements
             )
-            saved_chunks[rank] = {
-                "data": reversed_shards[rank],
-                "offset": offset,
-                "shape": local_shape,
-            }
 
-        # "Load" side: same placements, so offsets match. Reassemble.
-        reconstructed = torch.zeros(64, dtype=torch.float)
-        covered = set()
-        for rank in range(8):
-            chunk = saved_chunks[rank]
-            coord = list(_mesh_coords(rank, mesh_shape))
-            load_shape, load_offset = _compute_local_shape_and_global_offset(
-                global_shape, mesh_shape, coord, strided_placements
+            # Local shape from DCP metadata must match actual shard size.
+            assert local_shape == actual_shard.shape, (
+                f"rank {rank}: DCP local_shape {local_shape} != "
+                f"actual shard shape {tuple(actual_shard.shape)}"
             )
-            assert chunk["offset"] == load_offset
-            assert chunk["shape"] == load_shape
 
-            # Place data at the offset positions.
-            data = chunk["data"]
-            for i, val in enumerate(data.tolist()):
-                idx = load_offset[0] + i
-                reconstructed[idx] = val
-                covered.add(idx)
+            # First offset must match the first element of the actual shard.
+            assert offset[0] == int(actual_shard[0].item()), (
+                f"rank {rank}: DCP offset {offset[0]} != "
+                f"actual first element {int(actual_shard[0].item())}"
+            )
+            first_offsets.add(offset[0])
 
-        # For strided sharding, simple offset+i doesn't directly reconstruct
-        # because the data is non-contiguous in global space. Instead, verify
-        # that each rank's shard matches the expected slice of the global tensor.
-        for rank in range(8):
-            expected = reversed_shards[rank]
-            actual = saved_chunks[rank]["data"]
-            torch.testing.assert_close(actual, expected)
+        # All ranks should have distinct first-offsets (no overlap).
+        assert len(first_offsets) == world_size
 
     def test_load_into_same_placement_preserves_data(self):
         """When loading into a model with the same _StridedShard placements,

--- a/tests/test_dcp_ordered_sharding.py
+++ b/tests/test_dcp_ordered_sharding.py
@@ -437,6 +437,7 @@ def _build_linear_graph_and_placements(device_mesh_2d):
     from torch._functorch.aot_autograd import aot_export_joint_with_descriptors
     from torch.distributed.tensor._op_schema import OpSpec
 
+    from autoparallel.apply_sharding import _build_physical_placements
     from autoparallel.shardings.ordered_sharding import (
         build_param_grad_linear_chains,
         compute_optimal_placement_order_for_parameters,
@@ -478,8 +479,11 @@ def _build_linear_graph_and_placements(device_mesh_2d):
     param_placement_order = compute_optimal_placement_order_for_parameters(
         gm, sharding_placement
     )
+    physical_placements = _build_physical_placements(
+        sharding_placement, param_placement_order
+    )
 
-    return gm, sharding_placement, param_placement_order, param
+    return gm, sharding_placement, physical_placements, param_placement_order, param
 
 
 class TestShardParamsWithOrderedSharding:
@@ -494,7 +498,8 @@ class TestShardParamsWithOrderedSharding:
 
         (
             gm,
-            sharding_placement,
+            _,
+            physical_placements,
             param_placement_order,
             param_node,
         ) = _build_linear_graph_and_placements(device_mesh_2d)
@@ -507,7 +512,7 @@ class TestShardParamsWithOrderedSharding:
         params_spec = {fqn: None for fqn in fqn_to_param}
 
         sharded_params, _ = _shard_params_and_buffers(
-            gm, sharding_placement, params_spec, {}, param_placement_order
+            gm, physical_placements, params_spec, {}
         )
 
         # The single parameter should have _StridedShard placements.
@@ -523,18 +528,21 @@ class TestShardParamsWithOrderedSharding:
         """When param_placement_order is empty, params get regular Shard placements."""
         from torch._functorch._aot_autograd.fx_utils import get_named_param_nodes
 
-        from autoparallel.apply_sharding import _shard_params_and_buffers
+        from autoparallel.apply_sharding import (
+            _build_physical_placements,
+            _shard_params_and_buffers,
+        )
 
-        gm, sharding_placement, _, _ = _build_linear_graph_and_placements(
+        gm, sharding_placement, _, _, _ = _build_linear_graph_and_placements(
             device_mesh_2d
         )
+        default_physical = _build_physical_placements(sharding_placement, {})
 
         fqn_to_param = get_named_param_nodes(gm.graph)
         params_spec = {fqn: None for fqn in fqn_to_param}
-        empty_order = {}
 
         sharded_params, _ = _shard_params_and_buffers(
-            gm, sharding_placement, params_spec, {}, empty_order
+            gm, default_physical, params_spec, {}
         )
 
         param = next(iter(sharded_params.values()))
@@ -549,12 +557,16 @@ class TestShardParamsWithOrderedSharding:
         is genuinely different."""
         from torch._functorch._aot_autograd.fx_utils import get_named_param_nodes
 
-        from autoparallel.apply_sharding import _shard_params_and_buffers
+        from autoparallel.apply_sharding import (
+            _build_physical_placements,
+            _shard_params_and_buffers,
+        )
 
         (
             gm,
             sharding_placement,
-            param_placement_order,
+            physical_placements,
+            _,
             _,
         ) = _build_linear_graph_and_placements(device_mesh_2d)
 
@@ -563,11 +575,12 @@ class TestShardParamsWithOrderedSharding:
 
         # Shard with reversed order.
         reversed_params, _ = _shard_params_and_buffers(
-            gm, sharding_placement, params_spec, {}, param_placement_order
+            gm, physical_placements, params_spec, {}
         )
         # Shard with default order.
+        default_physical = _build_physical_placements(sharding_placement, {})
         default_params, _ = _shard_params_and_buffers(
-            gm, sharding_placement, params_spec, {}, {}
+            gm, default_physical, params_spec, {}
         )
 
         reversed_param = next(iter(reversed_params.values()))

--- a/tests/test_dcp_ordered_sharding.py
+++ b/tests/test_dcp_ordered_sharding.py
@@ -1,0 +1,591 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Tests for DCP (Distributed Checkpoint) compatibility with ordered sharding.
+
+Verifies that parameters sharded with reversed shard order (via _StridedShard
+placements) produce correct chunk metadata for DCP, and that a full
+save → load round-trip preserves data integrity.
+
+Uses a fake process group (single-process) and meta-device tensors so
+the tests can run without multiple GPUs.
+"""
+
+import torch
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor._dtensor_spec import DTensorSpec
+from torch.distributed.tensor._utils import _compute_local_shape_and_global_offset
+from torch.distributed.tensor.placement_types import (
+    Partial,
+    Replicate,
+    Shard,
+    _StridedShard,
+)
+
+from autoparallel.apply_sharding import _compute_shard_order
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _rank_coord(rank, mesh_shape, mesh_dim):
+    stride = 1
+    for d in range(len(mesh_shape) - 1, mesh_dim, -1):
+        stride *= mesh_shape[d]
+    return (rank // stride) % mesh_shape[mesh_dim]
+
+
+def _shard_tensor_default_order(global_tensor, mesh_shape, placements):
+    """Shard a tensor using default (left-to-right) mesh dim order.
+
+    Returns dict[rank -> local_tensor].
+    """
+    world_size = 1
+    for s in mesh_shape:
+        world_size *= s
+
+    shards = {}
+    for rank in range(world_size):
+        shard = global_tensor
+        for mesh_dim, placement in enumerate(placements):
+            if isinstance(placement, Shard):
+                n_chunks = mesh_shape[mesh_dim]
+                coord = _rank_coord(rank, mesh_shape, mesh_dim)
+                chunk_size = shard.size(placement.dim) // n_chunks
+                shard = shard.narrow(placement.dim, coord * chunk_size, chunk_size)
+        shards[rank] = shard.contiguous().clone()
+    return shards
+
+
+def _shard_tensor_reversed_order(global_tensor, mesh_shape, shard_dim):
+    """Shard a tensor along shard_dim using reversed mesh dim order (dim 1 first, then dim 0).
+
+    This is the physical layout that _StridedShard produces for S(d)S(d) with
+    reversed shard order on a 2D mesh.
+
+    Returns dict[rank -> local_tensor].
+    """
+    assert len(mesh_shape) == 2
+    world_size = mesh_shape[0] * mesh_shape[1]
+
+    shards = {}
+    for rank in range(world_size):
+        coord0 = _rank_coord(rank, mesh_shape, 0)
+        coord1 = _rank_coord(rank, mesh_shape, 1)
+        # Reversed order: shard by mesh_dim_1 first, then mesh_dim_0.
+        total_size = global_tensor.size(shard_dim)
+        chunk1 = total_size // mesh_shape[1]
+        shard = global_tensor.narrow(shard_dim, coord1 * chunk1, chunk1)
+        chunk0 = chunk1 // mesh_shape[0]
+        shard = shard.narrow(shard_dim, coord0 * chunk0, chunk0)
+        shards[rank] = shard.contiguous().clone()
+    return shards
+
+
+# ---------------------------------------------------------------------------
+# Tests: _StridedShard placement generation
+# ---------------------------------------------------------------------------
+
+
+class TestStridedShardFromReversedOrder:
+    """Verify that reversed shard_order produces _StridedShard placements."""
+
+    def test_reversed_order_produces_strided_shard(self, device_mesh_2d):
+        default_order = DTensorSpec.compute_default_shard_order((Shard(0), Shard(0)))
+        reversed_order = _compute_shard_order(default_order, reverse=True)
+
+        strided = DTensorSpec._convert_shard_order_to_StridedShard(
+            reversed_order, (Shard(0), Shard(0)), device_mesh_2d
+        )
+
+        # mesh_dim_0 should become _StridedShard (applied second in reversed order)
+        assert isinstance(strided[0], _StridedShard)
+        assert strided[0].dim == 0
+        assert strided[0].split_factor == device_mesh_2d.size(1)
+        # mesh_dim_1 stays as regular Shard (applied first in reversed order)
+        assert isinstance(strided[1], Shard) and not isinstance(
+            strided[1], _StridedShard
+        )
+        assert strided[1].dim == 0
+
+    def test_default_order_produces_no_strided_shard(self, device_mesh_2d):
+        default_order = DTensorSpec.compute_default_shard_order((Shard(0), Shard(0)))
+        result = DTensorSpec._convert_shard_order_to_StridedShard(
+            default_order, (Shard(0), Shard(0)), device_mesh_2d
+        )
+
+        assert all(
+            isinstance(p, Shard) and not isinstance(p, _StridedShard) for p in result
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: chunk offset computation for DCP
+# ---------------------------------------------------------------------------
+
+
+class TestChunkOffsetsForDCP:
+    """Verify compute_local_shape_and_global_offset handles _StridedShard correctly.
+
+    DCP uses this function to compute chunk metadata during save/load.
+    """
+
+    def test_default_order_offsets(self):
+        """Default S(0)S(0) on 2x4 mesh: contiguous chunks."""
+        mesh_shape = (2, 4)
+        global_shape = (64,)
+        placements = (Shard(0), Shard(0))
+
+        for rank in range(8):
+            coord = [_rank_coord(rank, mesh_shape, d) for d in range(2)]
+            local_shape, offset = _compute_local_shape_and_global_offset(
+                global_shape, mesh_shape, coord, placements
+            )
+            assert local_shape == (8,)
+            # Default order: contiguous blocks. rank (c0, c1) → offset = (c0*4 + c1) * 8
+            expected_offset = (coord[0] * mesh_shape[1] + coord[1]) * 8
+            assert offset == (
+                expected_offset,
+            ), f"rank {rank} coord {coord}: {offset} != ({expected_offset},)"
+
+    def test_reversed_order_offsets_differ(self):
+        """_StridedShard offsets differ from regular Shard offsets."""
+        mesh_shape = (2, 4)
+        global_shape = (64,)
+
+        default_placements = (Shard(0), Shard(0))
+        # Reversed: mesh_dim_1 first, then mesh_dim_0
+        reversed_placements = (_StridedShard(0, split_factor=4), Shard(0))
+
+        default_offsets = {}
+        reversed_offsets = {}
+        for rank in range(8):
+            coord = [_rank_coord(rank, mesh_shape, d) for d in range(2)]
+            _, d_off = _compute_local_shape_and_global_offset(
+                global_shape, mesh_shape, coord, default_placements
+            )
+            _, r_off = _compute_local_shape_and_global_offset(
+                global_shape, mesh_shape, coord, reversed_placements
+            )
+            default_offsets[rank] = d_off
+            reversed_offsets[rank] = r_off
+
+        # Offsets should differ for at least some ranks
+        assert default_offsets != reversed_offsets
+
+    def test_reversed_order_offsets_match_physical_layout(self):
+        """_StridedShard offsets match the actual data positions from reversed sharding."""
+        mesh_shape = (2, 4)
+        global_shape = (64,)
+
+        # Create a tensor with known values and shard it in reversed order.
+        global_tensor = torch.arange(64, dtype=torch.float)
+        reversed_shards = _shard_tensor_reversed_order(
+            global_tensor, mesh_shape, shard_dim=0
+        )
+
+        reversed_placements = (_StridedShard(0, split_factor=4), Shard(0))
+        for rank in range(8):
+            coord = [_rank_coord(rank, mesh_shape, d) for d in range(2)]
+            _, offset = _compute_local_shape_and_global_offset(
+                global_shape, mesh_shape, coord, reversed_placements
+            )
+            local = reversed_shards[rank]
+            # The first element of the local shard should match global[offset]
+            assert (
+                int(local[0].item()) == offset[0]
+            ), f"rank {rank}: local[0]={local[0].item()} != offset={offset[0]}"
+
+    def test_all_ranks_cover_full_tensor(self):
+        """All ranks' offsets together cover the entire global tensor (no overlap, no gaps)."""
+        mesh_shape = (2, 4)
+        global_shape = (64,)
+        reversed_placements = (_StridedShard(0, split_factor=4), Shard(0))
+
+        all_indices = set()
+        for rank in range(8):
+            coord = [_rank_coord(rank, mesh_shape, d) for d in range(2)]
+            local_shape, offset = _compute_local_shape_and_global_offset(
+                global_shape, mesh_shape, coord, reversed_placements
+            )
+            # For _StridedShard, indices may be non-contiguous, but local_shape
+            # gives the number of elements this rank holds.
+            global_tensor = torch.arange(64, dtype=torch.float)
+            local = _shard_tensor_reversed_order(
+                global_tensor, mesh_shape, shard_dim=0
+            )[rank]
+            for val in local.tolist():
+                all_indices.add(int(val))
+
+        assert all_indices == set(range(64))
+
+
+# ---------------------------------------------------------------------------
+# Tests: DTensor redistribute with _StridedShard
+# ---------------------------------------------------------------------------
+
+
+class TestDTensorRedistributeToStridedShard:
+    """Verify that redistributing from Replicate to _StridedShard produces
+    the correct physical layout."""
+
+    def test_redistribute_to_strided_shard(self, device_mesh_2d):
+        mesh = device_mesh_2d
+        global_tensor = torch.arange(
+            mesh.size(0) * mesh.size(1), dtype=torch.float, device="meta"
+        )
+        total = mesh.size(0) * mesh.size(1)
+
+        strided_placements = (_StridedShard(0, split_factor=mesh.size(1)), Shard(0))
+        curr_placement = (Replicate(),) * mesh.ndim
+
+        from torch._subclasses.fake_tensor import unset_fake_temporarily
+
+        with unset_fake_temporarily():
+            dtensor = DTensor.from_local(
+                global_tensor, mesh, curr_placement
+            ).redistribute(mesh, strided_placements)
+
+        # The DTensor should have _StridedShard in its placements.
+        assert isinstance(dtensor.placements[0], _StridedShard)
+        assert isinstance(dtensor.placements[1], Shard)
+
+        # Local shape should be total / world_size per rank.
+        expected_local_numel = total // (mesh.size(0) * mesh.size(1))
+        assert dtensor._local_tensor.numel() == expected_local_numel
+
+    def test_strided_shard_spec_has_correct_use_flag(self, device_mesh_2d):
+        """_StridedShard DTensors should have use_strided_shard_as_shard_order=True."""
+        mesh = device_mesh_2d
+        tensor = torch.randn(mesh.size(0) * mesh.size(1), device="meta")
+        strided_placements = (_StridedShard(0, split_factor=mesh.size(1)), Shard(0))
+
+        from torch._subclasses.fake_tensor import unset_fake_temporarily
+
+        with unset_fake_temporarily():
+            dtensor = DTensor.from_local(
+                tensor, mesh, (Replicate(),) * mesh.ndim
+            ).redistribute(mesh, strided_placements)
+
+        assert dtensor._spec.use_strided_shard_as_shard_order is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: DCP round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestDCPRoundTrip:
+    """Test that DCP save/load preserves data for _StridedShard parameters.
+
+    Uses the internal _compute_local_shape_and_global_offset function to
+    simulate what DCP's planner does: given a DTensor's placements, it
+    computes chunk metadata (offset + size) per rank. On the load side,
+    it computes the same metadata for the target DTensor. If the placements
+    match, chunks align and data is copied directly.
+
+    We verify this alignment holds for _StridedShard parameters.
+    """
+
+    def test_save_load_chunk_alignment(self):
+        """Chunks computed at save time match chunks at load time for _StridedShard."""
+        mesh_shape = (2, 4)
+        global_shape = (64,)
+        strided_placements = (_StridedShard(0, split_factor=4), Shard(0))
+
+        for rank in range(8):
+            coord = [_rank_coord(rank, mesh_shape, d) for d in range(2)]
+            save_shape, save_offset = _compute_local_shape_and_global_offset(
+                global_shape, mesh_shape, coord, strided_placements
+            )
+            load_shape, load_offset = _compute_local_shape_and_global_offset(
+                global_shape, mesh_shape, coord, strided_placements
+            )
+            assert save_shape == load_shape
+            assert save_offset == load_offset
+
+    def test_strided_vs_default_chunks_differ(self):
+        """If source uses _StridedShard and target uses plain Shard,
+        chunk offsets differ — DCP would correctly reshard."""
+        mesh_shape = (2, 4)
+        global_shape = (64,)
+        strided_placements = (_StridedShard(0, split_factor=4), Shard(0))
+        default_placements = (Shard(0), Shard(0))
+
+        mismatch_count = 0
+        for rank in range(8):
+            coord = [_rank_coord(rank, mesh_shape, d) for d in range(2)]
+            _, s_off = _compute_local_shape_and_global_offset(
+                global_shape, mesh_shape, coord, strided_placements
+            )
+            _, d_off = _compute_local_shape_and_global_offset(
+                global_shape, mesh_shape, coord, default_placements
+            )
+            if s_off != d_off:
+                mismatch_count += 1
+
+        # At least some ranks should have different offsets.
+        assert mismatch_count > 0
+
+    def test_data_integrity_after_simulated_round_trip(self):
+        """Simulate a DCP round-trip: shard with _StridedShard, compute
+        chunk metadata, then reassemble using those offsets. Verify the
+        reassembled tensor matches the original."""
+        mesh_shape = (2, 4)
+        global_shape = (64,)
+        strided_placements = (_StridedShard(0, split_factor=4), Shard(0))
+
+        global_tensor = torch.arange(64, dtype=torch.float)
+        reversed_shards = _shard_tensor_reversed_order(
+            global_tensor, mesh_shape, shard_dim=0
+        )
+
+        # "Save" side: each rank contributes its local shard with offset metadata.
+        saved_chunks = {}
+        for rank in range(8):
+            coord = [_rank_coord(rank, mesh_shape, d) for d in range(2)]
+            local_shape, offset = _compute_local_shape_and_global_offset(
+                global_shape, mesh_shape, coord, strided_placements
+            )
+            saved_chunks[rank] = {
+                "data": reversed_shards[rank],
+                "offset": offset,
+                "shape": local_shape,
+            }
+
+        # "Load" side: same placements, so offsets match. Reassemble.
+        reconstructed = torch.zeros(64, dtype=torch.float)
+        covered = set()
+        for rank in range(8):
+            chunk = saved_chunks[rank]
+            coord = [_rank_coord(rank, mesh_shape, d) for d in range(2)]
+            load_shape, load_offset = _compute_local_shape_and_global_offset(
+                global_shape, mesh_shape, coord, strided_placements
+            )
+            assert chunk["offset"] == load_offset
+            assert chunk["shape"] == load_shape
+
+            # Place data at the offset positions.
+            data = chunk["data"]
+            for i, val in enumerate(data.tolist()):
+                idx = load_offset[0] + i
+                reconstructed[idx] = val
+                covered.add(idx)
+
+        # For strided sharding, simple offset+i doesn't directly reconstruct
+        # because the data is non-contiguous in global space. Instead, verify
+        # that each rank's shard matches the expected slice of the global tensor.
+        for rank in range(8):
+            expected = reversed_shards[rank]
+            actual = saved_chunks[rank]["data"]
+            torch.testing.assert_close(actual, expected)
+
+    def test_load_into_same_placement_preserves_data(self):
+        """When loading into a model with the same _StridedShard placements,
+        each rank's data is preserved exactly."""
+        mesh_shape = (2, 4)
+        global_shape = (64,)
+        strided_placements = (_StridedShard(0, split_factor=4), Shard(0))
+
+        global_tensor = torch.randn(64)
+        shards = _shard_tensor_reversed_order(global_tensor, mesh_shape, shard_dim=0)
+
+        # Verify each rank's chunk metadata is consistent between save and load.
+        for rank in range(8):
+            coord = [_rank_coord(rank, mesh_shape, d) for d in range(2)]
+            save_shape, save_off = _compute_local_shape_and_global_offset(
+                global_shape, mesh_shape, coord, strided_placements
+            )
+            load_shape, load_off = _compute_local_shape_and_global_offset(
+                global_shape, mesh_shape, coord, strided_placements
+            )
+            assert save_shape == load_shape == (8,)
+            assert save_off == load_off
+            # Data would be copied as-is since offsets match.
+            assert shards[rank].shape == (8,)
+
+
+# ---------------------------------------------------------------------------
+# Tests: end-to-end _shard_params_and_buffers with ordered sharding
+# ---------------------------------------------------------------------------
+
+
+def _build_linear_graph_and_placements(device_mesh_2d):
+    """Build a joint graph for a simple linear model and construct
+    sharding_placement that triggers the S(0)S(0) → RS(0) pattern.
+
+    Uses the same approach as test_ordered_sharding.py: manually construct
+    sharding_placement with the desired specs rather than depending on the solver.
+    """
+    from contextlib import ExitStack
+
+    from torch import nn
+    from torch._functorch._aot_autograd.fx_utils import get_param_and_grad_nodes
+    from torch._functorch.aot_autograd import aot_export_joint_with_descriptors
+    from torch.distributed.tensor._op_schema import OpSpec
+
+    from autoparallel.shardings.ordered_sharding import (
+        build_param_grad_linear_chains,
+        compute_optimal_placement_order_for_parameters,
+    )
+
+    dim = 64
+    model = nn.Linear(dim, dim, bias=False)
+    sample_input = torch.randn(8, dim, requires_grad=True)
+
+    with ExitStack() as stack:
+        jwd = aot_export_joint_with_descriptors(stack, model, (sample_input,))
+        gm = jwd.graph_module
+        param_grad_nodes = list(get_param_and_grad_nodes(gm.graph).values())
+
+    assert len(param_grad_nodes) == 1
+    param, grad = param_grad_nodes[0]
+    assert grad is not None
+
+    node_to_source, source_to_chain = build_param_grad_linear_chains(param_grad_nodes)
+    param_chain = source_to_chain[param]
+    grad_chain = source_to_chain[grad]
+
+    t_node = param_chain[1]
+    grad_boundary_node = grad_chain[-1].all_input_nodes[0]
+
+    mesh = device_mesh_2d
+    ss_spec = DTensorSpec(mesh, (Shard(0), Shard(0)))
+    rs_spec = DTensorSpec(mesh, (Replicate(), Shard(0)))
+    ps_spec = DTensorSpec(mesh, (Partial(), Shard(0)))
+
+    sharding_placement = {
+        param: OpSpec(output_specs=ss_spec, input_specs=[ss_spec]),
+        t_node: OpSpec(output_specs=rs_spec, input_specs=[rs_spec]),
+        grad_boundary_node: OpSpec(output_specs=ps_spec),
+    }
+    for node in grad_chain:
+        sharding_placement[node] = OpSpec(output_specs=ss_spec, input_specs=[ss_spec])
+
+    param_placement_order = compute_optimal_placement_order_for_parameters(
+        gm, sharding_placement
+    )
+
+    return gm, sharding_placement, param_placement_order, param
+
+
+class TestShardParamsWithOrderedSharding:
+    """Test that _shard_params_and_buffers produces _StridedShard on
+    reversed-order parameters when given a manually-constructed
+    S(0)S(0) → RS(0) sharding scenario."""
+
+    def test_reversed_param_gets_strided_shard(self, device_mesh_2d):
+        from torch._functorch._aot_autograd.fx_utils import get_named_param_nodes
+
+        from autoparallel.apply_sharding import _shard_params_and_buffers
+
+        (
+            gm,
+            sharding_placement,
+            param_placement_order,
+            param_node,
+        ) = _build_linear_graph_and_placements(device_mesh_2d)
+
+        # Verify the param node is in placement_order with reversed flag.
+        assert param_node in param_placement_order
+        assert param_placement_order[param_node].is_target_reversed_order is True
+
+        fqn_to_param = get_named_param_nodes(gm.graph)
+        params_spec = {fqn: None for fqn in fqn_to_param}
+
+        sharded_params, _ = _shard_params_and_buffers(
+            gm, sharding_placement, params_spec, {}, param_placement_order
+        )
+
+        # The single parameter should have _StridedShard placements.
+        assert len(sharded_params) == 1
+        param = next(iter(sharded_params.values()))
+        assert isinstance(param, torch.nn.Parameter)
+        assert any(
+            isinstance(p, _StridedShard) for p in param.placements
+        ), f"Expected _StridedShard, got {param.placements}"
+        assert param._spec.use_strided_shard_as_shard_order is True
+
+    def test_default_order_param_gets_regular_shard(self, device_mesh_2d):
+        """When param_placement_order is empty, params get regular Shard placements."""
+        from torch._functorch._aot_autograd.fx_utils import get_named_param_nodes
+
+        from autoparallel.apply_sharding import _shard_params_and_buffers
+
+        gm, sharding_placement, _, _ = _build_linear_graph_and_placements(
+            device_mesh_2d
+        )
+
+        fqn_to_param = get_named_param_nodes(gm.graph)
+        params_spec = {fqn: None for fqn in fqn_to_param}
+        empty_order = {}
+
+        sharded_params, _ = _shard_params_and_buffers(
+            gm, sharding_placement, params_spec, {}, empty_order
+        )
+
+        param = next(iter(sharded_params.values()))
+        assert all(
+            isinstance(p, Shard) and not isinstance(p, _StridedShard)
+            for p in param.placements
+        )
+
+    def test_strided_shard_chunk_offsets_match_dcp(self, device_mesh_2d):
+        """The _StridedShard parameter's chunk offsets (used by DCP) should
+        differ from default Shard offsets, confirming the physical layout
+        is genuinely different."""
+        from torch._functorch._aot_autograd.fx_utils import get_named_param_nodes
+
+        from autoparallel.apply_sharding import _shard_params_and_buffers
+
+        (
+            gm,
+            sharding_placement,
+            param_placement_order,
+            _,
+        ) = _build_linear_graph_and_placements(device_mesh_2d)
+
+        fqn_to_param = get_named_param_nodes(gm.graph)
+        params_spec = {fqn: None for fqn in fqn_to_param}
+
+        # Shard with reversed order.
+        reversed_params, _ = _shard_params_and_buffers(
+            gm, sharding_placement, params_spec, {}, param_placement_order
+        )
+        # Shard with default order.
+        default_params, _ = _shard_params_and_buffers(
+            gm, sharding_placement, params_spec, {}, {}
+        )
+
+        reversed_param = next(iter(reversed_params.values()))
+        default_param = next(iter(default_params.values()))
+
+        mesh = device_mesh_2d
+        global_shape = reversed_param.shape
+
+        # Compute DCP chunk offsets for both.
+        mismatch_count = 0
+        for rank in range(mesh.size(0) * mesh.size(1)):
+            coord = [_rank_coord(rank, tuple(mesh.shape), d) for d in range(2)]
+            _, rev_off = _compute_local_shape_and_global_offset(
+                global_shape,
+                tuple(mesh.shape),
+                coord,
+                tuple(reversed_param.placements),
+            )
+            _, def_off = _compute_local_shape_and_global_offset(
+                global_shape,
+                tuple(mesh.shape),
+                coord,
+                tuple(default_param.placements),
+            )
+            if rev_off != def_off:
+                mismatch_count += 1
+
+        assert (
+            mismatch_count > 0
+        ), "Expected different DCP chunk offsets for reversed vs default order"

--- a/tests/test_dynamic_shapes.py
+++ b/tests/test_dynamic_shapes.py
@@ -588,7 +588,7 @@ class TestShapeEnvSwap:
                 },
             )(),
         ):
-            (local_arg,) = _make_local_args(gm, sharding_placement)
+            (local_arg,) = _make_local_args(gm, sharding_placement, {})
 
         assert local_arg.requires_grad
 
@@ -838,7 +838,7 @@ class TestHasRankVaryingSize:
                     },
                 )(),
             ):
-                (local_param,) = _make_local_args(gm, sharding_placement)
+                (local_param,) = _make_local_args(gm, sharding_placement, {})
 
         # dim 0 is unevenly sharded (400 % 7 != 0) so it should be symbolic
         assert any(isinstance(s, torch.SymInt) for s in local_param.shape), (

--- a/tests/test_dynamic_shapes.py
+++ b/tests/test_dynamic_shapes.py
@@ -575,7 +575,7 @@ class TestShapeEnvSwap:
             placements=(Replicate(),),
             tensor_meta=TensorMeta(torch.Size([16, 128]), (128, 1), torch.float32),
         )
-        sharding_placement = {x: type("Placement", (), {"input_specs": (spec,)})()}
+        sharding_placement = {x: spec}
 
         with patch(
             "autoparallel.apply_sharding.DTensor.from_local",
@@ -588,7 +588,7 @@ class TestShapeEnvSwap:
                 },
             )(),
         ):
-            (local_arg,) = _make_local_args(gm, sharding_placement, {})
+            (local_arg,) = _make_local_args(gm, sharding_placement)
 
         assert local_arg.requires_grad
 
@@ -816,9 +816,7 @@ class TestHasRankVaryingSize:
             placements=(Replicate(), Shard(0)),
             tensor_meta=TensorMeta(torch.Size([400, 100]), (100, 1), torch.float32),
         )
-        sharding_placement = {
-            p: type("P", (), {"input_specs": (spec,)})(),
-        }
+        sharding_placement = {p: spec}
 
         # Swap ShapeEnv (as apply_sharding_to_model does)
         fake_mode.shape_env = ShapeEnv()
@@ -838,7 +836,7 @@ class TestHasRankVaryingSize:
                     },
                 )(),
             ):
-                (local_param,) = _make_local_args(gm, sharding_placement, {})
+                (local_param,) = _make_local_args(gm, sharding_placement)
 
         # dim 0 is unevenly sharded (400 % 7 != 0) so it should be symbolic
         assert any(isinstance(s, torch.SymInt) for s in local_param.shape), (


### PR DESCRIPTION
Previously, parameters identified for reversed shard order by `compute_optimal_placement_order_for_parameters` were always physically sharded in default (left-to-right) mesh dimension order. The reversed ordering was only applied as a runtime hint during the interpreter's redistribution pass. This meant DCP's chunk offset computation (`compute_local_shape_and_global_offset`) — which reads placements, not `shard_order` metadata — would produce incorrect metadata for these parameters.

This PR fixes both issues by using `_StridedShard` placements on reversed-order parameters. `_StridedShard` encodes the non-default shard order directly in the placement tuple, so:

1. The physical data layout is correct (sharded in reversed mesh dim order).
2. DCP computes correct chunk offsets natively, since `compute_local_shape_and_global_offset` already handles `_StridedShard`.

The `param_placement_order` dict (previously computed inside `ApplyShardingInterpreter.__init__`) is now computed once in `apply_sharding_to_model` and shared with both the interpreter and `_shard_params_and_buffers`.

A new test file (`test_dcp_ordered_sharding.py`) validates the full chain: `_StridedShard` generation from reversed shard order, DCP chunk offset correctness, DTensor redistribute, simulated DCP round-trips, and end-to-end parameter sharding through `_shard_params_and_buffers`.

Authored with Claude.