### PR TITLE
Exclude node-constrained parameters from memory budget

### DIFF
--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -240,6 +240,11 @@ class ShardingOptimizer:
             force_grad_reduce_in_higher_precision
         )
         self._constraint_log: list[tuple[str, dict]] = []
+        self._memory_constraint: tuple[float, float] | None = None
+        # Maps ILP constraint name → node_name for active node constraints,
+        # so that _apply_memory_constraint can exclude constrained params and
+        # remove_constraints can keep this in sync.
+        self._node_constraint_names: dict[str, str] = {}
         self._name_counters: dict[str, int] = {}
         t0 = time.perf_counter()
         self.strats = self.build_sharding_metadata()
@@ -880,6 +885,7 @@ class ShardingOptimizer:
         self.prob += pulp.lpSum(terms)
 
     def _solve(self, verbose=False):
+        self._apply_memory_constraint()
         solver = pulp.PULP_CBC_CMD(msg=verbose)
         # Use a dedicated temp directory for PuLP's intermediate files (.mps,
         # .sol, etc.) so they are always cleaned up, even if the process is
@@ -975,8 +981,12 @@ class ShardingOptimizer:
     def remove_constraints(self, names):
         """Remove constraints by name, allowing re-solve to revert to the
         unconstrained optimum."""
+        memory_names = {"memory_constraint_high", "memory_constraint_low"}
         for name in names:
             del self.prob.constraints[name]
+            self._node_constraint_names.pop(name, None)
+            if name in memory_names:
+                self._memory_constraint = None
 
     def diff_solutions(self, solution_a, solution_b):
         """Compare two solutions and report placement changes and cost diffs.
@@ -1599,6 +1609,11 @@ class ShardingOptimizer:
         """USER (Category 5b): Constrain total parameter memory usage.
 
         Σ_{params} (size_ratio * x_{param}) ≤ memory_limit
+
+        The actual ILP constraints are added lazily at solve time so that
+        node constraints registered after this call are still respected.
+        Parameters with user-defined node constraints are excluded to avoid
+        infeasible problems.
         """
         self._constraint_log.append(
             (
@@ -1609,11 +1624,31 @@ class ShardingOptimizer:
                 },
             )
         )
+        self._memory_constraint = (memory_factor_low, memory_factor_high)
+
+    def _apply_memory_constraint(self):
+        """Rebuild the parameter memory constraint in the ILP.
+
+        Called on every solve so that node constraints added after
+        add_parameter_memory_constraint() are always respected.
+        """
+        if self._memory_constraint is None:
+            return
+        memory_factor_low, memory_factor_high = self._memory_constraint
+
+        # Remove previous memory constraints before rebuilding
+        for name in ("memory_constraint_high", "memory_constraint_low"):
+            self.prob.constraints.pop(name, None)
+
+        user_constrained_names = set(self._node_constraint_names.values())
+
         param_nodes: list[torch.fx.Node] = get_param_nodes(self.graph)
         elms: list[pulp.LpAffineExpression] = []
         budget_low: float = 0.0
         budget_high: float = 0.0
         for node in param_nodes:
+            if node.name in user_constrained_names:
+                continue
             node_idx = self.node_map[node]
             num_out_strat = len(self.strats[node].strategies)
             ratios: list[float] = []
@@ -1673,11 +1708,14 @@ class ShardingOptimizer:
             raise RuntimeError(
                 f"Couldn't find appropriate constraint {node} {constraint_name} {placement}"
             )
-        return self._add_node_constraint(
+        names = self._add_node_constraint(
             node,
             output_constraint_indices=output_constraint_indices,
             constraint_name=constraint_name,
         )
+        for name in names:
+            self._node_constraint_names[name] = node.name
+        return names
 
     def _add_io_placement_constraints(
         self,

--- a/autoparallel/serialization.py
+++ b/autoparallel/serialization.py
@@ -261,6 +261,8 @@ def load_optimizer(cls, path):
         "force_grad_reduce_in_higher_precision"
     ]
     opt._constraint_log = []
+    opt._memory_constraint = None
+    opt._node_constraint_names = {}
     opt._name_counters = {}
 
     # Reconstruct cluster_links by expanding the node-level mapping over

--- a/tests/test_optimize_placement.py
+++ b/tests/test_optimize_placement.py
@@ -594,3 +594,250 @@ def test_world_size_larger_than_parameter(device_mesh_1d):
     param_nodes = get_param_nodes(autop.gm.graph)
     for node in param_nodes:
         assert sharding_placement[node].output_specs.placements == (Replicate(),)
+
+
+def _setup_memory_and_node_constraint(mesh, memory_first):
+    """Set up a model where one param is forced to Replicate via add_node_constraint
+    while add_parameter_memory_constraint wants to shard everything.
+
+    Without lazy application, the memory constraint would count the
+    Replicate-constrained param and become infeasible.
+
+    Args:
+        memory_first: if True, add_parameter_memory_constraint is called before
+            add_node_constraint (the previously-broken order).
+    """
+    dim1 = 1024
+    dim2 = 4096
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear1 = nn.Linear(dim1, dim2, bias=False)
+            self.linear2 = nn.Linear(dim2, dim1, bias=False)
+
+        def forward(self, x):
+            return self.linear2(F.relu(self.linear1(x)))
+
+    bs = 2048 * mesh.shape[0]
+
+    def input_fn():
+        return torch.rand(bs, dim1, device="cuda", requires_grad=True)
+
+    with torch.device("meta"):
+        model = Model()
+
+    autop = AutoParallel(model, input_fn, mesh)
+    autop.__enter__()
+
+    opt = autop.sharding_optimizer
+    # Pick the first param node and force it to Replicate, which conflicts with
+    # a tight memory budget that expects all params to be sharded.
+    param_nodes = get_param_nodes(opt.graph)
+    constrained_node = param_nodes[0]
+    orig_constrained_node = opt._concrete_to_orig.get(
+        constrained_node, constrained_node
+    )
+    replicate_placement = (Replicate(),) * mesh.ndim
+
+    x_sharding = (Shard(0),) + (Replicate(),) * (mesh.ndim - 1)
+    autop.add_input_constraints([x_sharding])
+    autop.add_output_constraints([x_sharding])
+
+    if memory_first:
+        autop.add_parameter_memory_constraint(low=None, high=None)
+        opt.add_node_constraint(constrained_node, placement=replicate_placement)
+    else:
+        opt.add_node_constraint(constrained_node, placement=replicate_placement)
+        autop.add_parameter_memory_constraint(low=None, high=None)
+
+    return autop, opt, orig_constrained_node, replicate_placement
+
+
+@apply_cuda_patches
+@pytest.mark.parametrize("memory_first", [True, False])
+def test_node_constraint_excludes_from_memory_budget_get_solution(
+    device_mesh_1d, memory_first
+):
+    """add_node_constraint + add_parameter_memory_constraint should not conflict,
+    regardless of call order.  Verified via get_solution (the primary solve path)."""
+    (
+        autop,
+        opt,
+        constrained_node,
+        replicate_placement,
+    ) = _setup_memory_and_node_constraint(device_mesh_1d, memory_first)
+    try:
+        solution = autop.optimize_placement()
+        assert solution[constrained_node].output_specs.placements == replicate_placement
+    finally:
+        autop.__exit__(None, None, None)
+
+
+@apply_cuda_patches
+@pytest.mark.parametrize("memory_first", [True, False])
+def test_node_constraint_excludes_from_memory_budget_resolve(
+    device_mesh_1d, memory_first
+):
+    """Same as the get_solution test but exercises the resolve() path."""
+    (
+        autop,
+        opt,
+        constrained_node,
+        replicate_placement,
+    ) = _setup_memory_and_node_constraint(device_mesh_1d, memory_first)
+    try:
+        # First solve to set the objective
+        autop.optimize_placement()
+        # Re-solve via resolve()
+        solution = opt.resolve()
+        assert solution[constrained_node].output_specs.placements == replicate_placement
+    finally:
+        autop.__exit__(None, None, None)
+
+
+@apply_cuda_patches
+def test_node_constraint_after_solve_resolve(device_mesh_1d):
+    """Solve once with memory constraint, then add a node constraint and resolve().
+
+    The memory constraint must be rebuilt to exclude the newly constrained
+    param, otherwise the re-solve becomes infeasible.
+    """
+    dim1 = 1024
+    dim2 = 4096
+    mesh = device_mesh_1d
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear1 = nn.Linear(dim1, dim2, bias=False)
+            self.linear2 = nn.Linear(dim2, dim1, bias=False)
+
+        def forward(self, x):
+            return self.linear2(F.relu(self.linear1(x)))
+
+    bs = 2048 * mesh.shape[0]
+
+    def input_fn():
+        return torch.rand(bs, dim1, device="cuda", requires_grad=True)
+
+    with torch.device("meta"):
+        model = Model()
+
+    with AutoParallel(model, input_fn, mesh) as autop:
+        x_sharding = (Shard(0),)
+        autop.add_input_constraints([x_sharding])
+        autop.add_output_constraints([x_sharding])
+        autop.add_parameter_memory_constraint(low=None, high=None)
+
+        # First solve — all params can be sharded
+        autop.optimize_placement()
+
+        # Now force one param to Replicate and re-solve
+        opt = autop.sharding_optimizer
+        param_nodes = get_param_nodes(opt.graph)
+        constrained_node = param_nodes[0]
+        orig_node = opt._concrete_to_orig.get(constrained_node, constrained_node)
+        replicate = (Replicate(),)
+        opt.add_node_constraint(constrained_node, placement=replicate)
+
+        solution = opt.resolve()
+        assert solution[orig_node].output_specs.placements == replicate
+
+
+@apply_cuda_patches
+def test_remove_memory_constraint_then_resolve(device_mesh_1d):
+    """Removing the memory constraint by name should prevent it from being
+    rebuilt on the next resolve()."""
+    dim1 = 1024
+    dim2 = 4096
+    mesh = device_mesh_1d
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear1 = nn.Linear(dim1, dim2, bias=False)
+            self.linear2 = nn.Linear(dim2, dim1, bias=False)
+
+        def forward(self, x):
+            return self.linear2(F.relu(self.linear1(x)))
+
+    bs = 2048 * mesh.shape[0]
+
+    def input_fn():
+        return torch.rand(bs, dim1, device="cuda", requires_grad=True)
+
+    with torch.device("meta"):
+        model = Model()
+
+    with AutoParallel(model, input_fn, mesh) as autop:
+        x_sharding = (Shard(0),)
+        autop.add_input_constraints([x_sharding])
+        autop.add_output_constraints([x_sharding])
+        # Memory constraint forces sharding
+        autop.add_parameter_memory_constraint(low=None, high=None)
+        solution = autop.optimize_placement()
+
+        opt = autop.sharding_optimizer
+        param_nodes = get_param_nodes(opt.graph)
+        for node in param_nodes:
+            orig = opt._concrete_to_orig.get(node, node)
+            assert solution[orig].output_specs.placements == (Shard(0),)
+
+        # Remove memory constraint and re-solve — optimizer is free to replicate
+        opt.remove_constraints(["memory_constraint_high", "memory_constraint_low"])
+        solution = opt.resolve()
+        assert "memory_constraint_high" not in opt.prob.constraints
+        assert "memory_constraint_low" not in opt.prob.constraints
+
+
+@apply_cuda_patches
+def test_remove_node_constraint_restores_memory_budget(device_mesh_1d):
+    """After removing a node constraint, that param should be included in the
+    memory budget again on the next resolve()."""
+    dim1 = 1024
+    dim2 = 4096
+    mesh = device_mesh_1d
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear1 = nn.Linear(dim1, dim2, bias=False)
+            self.linear2 = nn.Linear(dim2, dim1, bias=False)
+
+        def forward(self, x):
+            return self.linear2(F.relu(self.linear1(x)))
+
+    bs = 2048 * mesh.shape[0]
+
+    def input_fn():
+        return torch.rand(bs, dim1, device="cuda", requires_grad=True)
+
+    with torch.device("meta"):
+        model = Model()
+
+    with AutoParallel(model, input_fn, mesh) as autop:
+        x_sharding = (Shard(0),)
+        autop.add_input_constraints([x_sharding])
+        autop.add_output_constraints([x_sharding])
+        autop.add_parameter_memory_constraint(low=None, high=None)
+
+        opt = autop.sharding_optimizer
+        param_nodes = get_param_nodes(opt.graph)
+        constrained_node = param_nodes[0]
+        orig_node = opt._concrete_to_orig.get(constrained_node, constrained_node)
+        replicate = (Replicate(),)
+
+        # Force one param to Replicate (excluded from memory budget)
+        constraint_names = opt.add_node_constraint(
+            constrained_node, placement=replicate
+        )
+        solution = autop.optimize_placement()
+        assert solution[orig_node].output_specs.placements == replicate
+
+        # Remove the node constraint — param should be back in the memory budget
+        opt.remove_constraints(constraint_names)
+        solution = opt.resolve()
+        # With memory budget enforced and no node constraint, the optimizer
+        # should shard this param again
+        assert solution[orig_node].output_specs.placements == (Shard(0),)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -236,3 +236,26 @@ def test_save_placements_is_valid_json(device_mesh_1d):
     assert "placements" in data
     assert isinstance(data["placements"], dict)
     assert len(data["placements"]) > 0
+
+
+@apply_cuda_patches
+def test_loaded_optimizer_resolve_without_memory_constraint(device_mesh_1d):
+    """A loaded optimizer that never had a memory constraint should be
+    able to call resolve() without crashing."""
+    dim = 64
+    with torch.device("meta"):
+        model = _SimpleModel(dim)
+
+    autop = _setup_autop(model, dim, device_mesh_1d)
+    with autop:
+        autop.add_input_constraints([(Shard(0),)])
+        autop.add_output_constraints([(Shard(0),)])
+        opt = autop.sharding_optimizer
+        opt.get_solution()
+
+    with tempfile.NamedTemporaryFile(suffix=".ap") as f:
+        opt.save(f.name)
+        loaded = type(opt).load(f.name)
+
+    solution = loaded.resolve()
+    assert len(solution) > 0


### PR DESCRIPTION
`add_parameter_memory_constraint` now excludes parameters that have user-defined node constraints from the memory budget. Previously, forcing a parameter to e.g. `Replicate()` via `add_node_constraint` while having a tight memory budget (which expects sharding) would make the ILP infeasible.

To make this work regardless of call order, the memory constraint is now a persistent setting rebuilt on every solve inside `_solve()`, rather than being materialized immediately. A new `_node_constraint_names` dict tracks active node constraints so that `remove_constraints()` stays consistent — removing a node constraint re-includes that parameter in the memory budget, and removing the memory constraint itself prevents it from being rebuilt.

Start with `optimize_sharding.py` (the core change), then `serialization.py` (one-line init for loaded optimizers), then the tests.

Co-authored-by: Claude