### PR TITLE
Remove obsolete SDPA sharding overrides and enable cuDNN attention on H100+

### DIFF
--- a/autoparallel/_testing/models/llama3.py
+++ b/autoparallel/_testing/models/llama3.py
@@ -36,13 +36,13 @@ class ScaledDotProductAttention(torch.nn.Module):
         if cls.backends:
             return
 
-        # Add CuDNN on B200 w/ highest priority
+        # Add CuDNN on H100+ (capability >= 9.0) w/ highest priority
         cls.backends = [
             SDPBackend.FLASH_ATTENTION,
             SDPBackend.EFFICIENT_ATTENTION,
             SDPBackend.MATH,
         ]
-        if has_cuda_capability(10, 0):
+        if has_cuda_capability(9, 0):
             cls.backends.insert(0, SDPBackend.CUDNN_ATTENTION)
 
     def forward(

--- a/autoparallel/shardings/propagation_rules.py
+++ b/autoparallel/shardings/propagation_rules.py
@@ -808,45 +808,6 @@ def _unsafe_index_rule(mesh, op_schema):
     raise NotImplementedError()
 
 
-def sdpa_rule(op, mesh, op_schema):
-    out_strat = get_op_strategy(op, op_schema)
-    # remove wrong context-parallel strategy
-    # https://github.com/pytorch/pytorch/pull/131351#discussion_r1716164659
-    new_strats = []
-    for ss in out_strat.strategies:
-        if (
-            torch.distributed.tensor.placement_types.Shard(2)
-            not in ss.input_specs[0].placements
-        ):
-            new_strats.append(ss)
-    out_strat.strategies = new_strats
-    return out_strat
-
-
-@register_rule(torch.ops.aten._scaled_dot_product_efficient_attention.default)
-def _(mesh, op_schema):
-    op = torch.ops.aten._scaled_dot_product_efficient_attention.default
-    return sdpa_rule(op, mesh, op_schema)
-
-
-@register_rule(torch.ops.aten._scaled_dot_product_flash_attention.default)
-def _(mesh, op_schema):
-    op = torch.ops.aten._scaled_dot_product_flash_attention.default
-    return sdpa_rule(op, mesh, op_schema)
-
-
-@register_rule(torch.ops.aten._scaled_dot_product_flash_attention_backward.default)
-def _(mesh, op_schema):
-    op = torch.ops.aten._scaled_dot_product_flash_attention_backward.default
-    return sdpa_rule(op, mesh, op_schema)
-
-
-@register_rule(torch.ops.aten._scaled_dot_product_efficient_attention_backward.default)
-def _(mesh, op_schema):
-    op = torch.ops.aten._scaled_dot_product_efficient_attention_backward.default
-    return sdpa_rule(op, mesh, op_schema)
-
-
 @register_rule(torch.ops.aten.reshape.default)
 def reshape_rule(mesh, op_schema):
     op = torch.ops.aten.reshape.default


### PR DESCRIPTION
The SDPA sharding rules in `propagation_rules.py` existed to filter out an incorrect context-parallel strategy (`Shard(2)`) that PyTorch's DTensor emitted for the four `_scaled_dot_product_*` ops. Upstream has since removed those wrong strategies https://github.com/pytorch/pytorch/pull/167381 (the current `_matrix_ops.py` only emits Replicate, batch `Shard(0)`, and heads `Shard(1)`), so the `sdpa_rule` helper and its four registration shims are now dead code. Drop them.

While here, lower the cuDNN attention gate in the LLaMA-3 test model from B200 (capability 10.0) to H100+ (capability 9.0), since cuDNN attention is the fastest backend available on Hopper-class GPUs as well.

Authored with Claude.