### PR TITLE
Add module-level activation checkpointing from TorchTitan and fix AC tag propagation through mm→einsum conversion

### DIFF
--- a/autoparallel/_testing/models/llama3.py
+++ b/autoparallel/_testing/models/llama3.py
@@ -3,8 +3,9 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 
+from collections import defaultdict
 from dataclasses import dataclass
-from typing import ClassVar, Optional
+from typing import ClassVar, Literal, Optional
 
 import torch
 import torch.nn.functional as F
@@ -544,3 +545,111 @@ class Transformer(nn.Module):
         h = self.norm(h) if self.norm else h
         output = self.output(h) if self.output else h
         return output
+
+
+# Ops whose outputs are saved (not recomputed) during selective AC.
+# Matches TorchTitan's _op_sac_save_list.
+_OP_SAC_SAVE_LIST: set = {
+    torch.ops.aten.mm.default,
+    torch.ops.aten._scaled_dot_product_efficient_attention.default,
+    torch.ops.aten._scaled_dot_product_flash_attention.default,
+    torch.ops.aten._scaled_dot_product_cudnn_attention.default,
+    torch.ops.aten._scaled_dot_product_attention_math.default,
+    torch.ops.aten._scaled_dot_product_fused_attention_overrideable.default,
+    torch.ops._c10d_functional.reduce_scatter_tensor.default,
+    torch.ops.aten.max.default,
+    torch._higher_order_ops.flex_attention,
+    torch._higher_order_ops.inductor_compiled_code,
+}
+
+# torch_attn._varlen_attn may not exist in all PyTorch builds
+if hasattr(torch.ops, "torch_attn") and hasattr(torch.ops.torch_attn, "_varlen_attn"):
+    _OP_SAC_SAVE_LIST.add(torch.ops.torch_attn._varlen_attn.default)
+
+
+def _apply_full_ac(module: nn.Module) -> nn.Module:
+    from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+        checkpoint_wrapper,
+    )
+
+    return checkpoint_wrapper(module)
+
+
+def _apply_layer_sac(module: nn.Module, layer_idx: int, ac_freq: int) -> nn.Module:
+    if not ac_freq or layer_idx % ac_freq == 0:
+        return _apply_full_ac(module)
+    return module
+
+
+def _apply_op_sac(module: nn.Module) -> nn.Module:
+    from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+        checkpoint_wrapper,
+    )
+    from torch.utils.checkpoint import (
+        CheckpointPolicy,
+        create_selective_checkpoint_contexts,
+    )
+
+    def _get_custom_policy(meta):
+        def _custom_policy(ctx, func, *args, **kwargs):
+            mode = "recompute" if ctx.is_recompute else "forward"
+            mm_count_key = f"{mode}_mm_count"
+            if func == torch.ops.aten.mm.default:
+                meta[mm_count_key] += 1
+            # Save output of all ops in save list, except every 2nd matmul
+            to_save = func in _OP_SAC_SAVE_LIST and not (
+                func == torch.ops.aten.mm.default and meta[mm_count_key] % 2 == 0
+            )
+            return (
+                CheckpointPolicy.MUST_SAVE
+                if to_save
+                else CheckpointPolicy.PREFER_RECOMPUTE
+            )
+
+        return _custom_policy
+
+    def selective_checkpointing_context_fn():
+        meta = defaultdict(int)
+        return create_selective_checkpoint_contexts(_get_custom_policy(meta))
+
+    return checkpoint_wrapper(module, context_fn=selective_checkpointing_context_fn)
+
+
+def apply_ac(
+    model: Transformer,
+    mode: Literal["full", "selective"] = "full",
+    selective_ac_option: str = "2",
+) -> None:
+    """Apply activation checkpointing to each TransformerBlock in the model.
+
+    Mirrors TorchTitan's activation checkpointing. Should be called on the
+    model before passing it to AutoParallel.
+
+    Args:
+        model: A Transformer model with a ``layers`` ModuleDict.
+        mode: ``"full"`` checkpoints every layer; ``"selective"`` uses
+            ``selective_ac_option`` to pick a strategy.
+        selective_ac_option: When mode is ``"selective"``, either a digit
+            string like ``"2"`` (checkpoint every nth layer) or ``"op"``
+            (per-op policy that recomputes every 2nd matmul).
+    """
+    for layer_id, transformer_block in model.layers.named_children():
+        if mode == "full":
+            transformer_block = _apply_full_ac(transformer_block)
+        elif mode == "selective":
+            if selective_ac_option == "op":
+                transformer_block = _apply_op_sac(transformer_block)
+            elif selective_ac_option.isdigit():
+                transformer_block = _apply_layer_sac(
+                    transformer_block, int(layer_id), int(selective_ac_option)
+                )
+            else:
+                raise ValueError(
+                    f"Invalid selective_ac_option: {selective_ac_option!r}. "
+                    "Use 'op' or a positive integer string like '2'."
+                )
+        else:
+            raise ValueError(
+                f"Invalid AC mode: {mode!r}. Valid modes: 'full', 'selective'."
+            )
+        model.layers.register_module(layer_id, transformer_block)

--- a/autoparallel/graph_passes/graph_utils.py
+++ b/autoparallel/graph_passes/graph_utils.py
@@ -427,8 +427,12 @@ def _replace_view_mm_view_with_einsum(gm):
             new_node.meta.update(replaced_node.meta)
             # Preserve the mm node's seq_nr so that forward/backward
             # einsum pairs remain matched by autograd's sequence numbering.
-            if "seq_nr" in node.meta:
-                new_node.meta["seq_nr"] = node.meta["seq_nr"]
+            # Also preserve recompute/ac_graph_id from the mm node so that
+            # activation checkpointing policies (e.g. selective AC) survive
+            # the mm → einsum conversion.
+            for key in ("seq_nr", "recompute", "ac_graph_id"):
+                if key in node.meta:
+                    new_node.meta[key] = node.meta[key]
             replaced_node.replace_all_uses_with(new_node)
     gm.graph.eliminate_dead_code()
     gm.graph.lint()

--- a/examples/example_llama3.py
+++ b/examples/example_llama3.py
@@ -12,7 +12,11 @@ from torch.distributed.fsdp import MixedPrecisionPolicy
 from torch.distributed.tensor.placement_types import Partial, Replicate, Shard
 from torch.testing._internal.distributed.fake_pg import FakeStore
 
-from autoparallel._testing.models.llama3 import Transformer, TransformerModelArgs
+from autoparallel._testing.models.llama3 import (
+    Transformer,
+    TransformerModelArgs,
+    apply_ac,
+)
 from autoparallel.api import AutoParallel
 from autoparallel.compile import autoparallel_backend
 from autoparallel.cost_models.collective_runtime_estimation import set_nccl_topo_config
@@ -128,6 +132,8 @@ else:
 # parallelize the model
 with torch.device("meta"):
     model = model_fn()
+
+apply_ac(model, mode="selective", selective_ac_option="op")
 
 mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16, reduce_dtype=torch.float32)
 
@@ -262,7 +268,9 @@ parallel_mod.to_empty(device="cuda")
 parallel_mod.init_weights()
 
 # Compile with AutoParallel-optimized Inductor passes
-parallel_mod = torch.compile(parallel_mod, backend=autoparallel_backend())
+parallel_mod = torch.compile(
+    parallel_mod, backend=autoparallel_backend(enable_ac=False)
+)
 
 # now let's run it
 x = (

--- a/tests/test_activation_checkpointing.py
+++ b/tests/test_activation_checkpointing.py
@@ -706,6 +706,117 @@ def test_user_ac_tags_survive_compile_roundtrip_no_rng(device_mesh_2d):
 
 
 # ---------------------------------------------------------------------------
+# Family 2c: recompute tags survive mm → einsum conversion
+# ---------------------------------------------------------------------------
+
+
+def _make_alternating_mm_policy(meta):
+    """Save every odd mm, recompute every even mm. Save everything else."""
+
+    def _policy(ctx, func, *args, **kwargs):
+        mode = "recompute" if ctx.is_recompute else "forward"
+        mm_count_key = f"{mode}_mm_count"
+        if func == torch.ops.aten.mm.default:
+            meta[mm_count_key] += 1
+            if meta[mm_count_key] % 2 == 0:
+                return CheckpointPolicy.PREFER_RECOMPUTE
+        return CheckpointPolicy.MUST_SAVE
+
+    return _policy
+
+
+def _alternating_ac_context_fn():
+    from collections import defaultdict
+
+    meta = defaultdict(int)
+    return create_selective_checkpoint_contexts(_make_alternating_mm_policy(meta))
+
+
+class MLPBlockWithAlternatingAC(nn.Module):
+    """MLP with alternating mm AC policy. Four linears inside the checkpoint
+    region produce four mm ops; the policy saves odd mm outputs and recomputes
+    even ones. After mm→einsum conversion, the einsum nodes should carry the
+    same alternating tags.
+
+    Uses checkpoint_wrapper (same as apply_ac) rather than calling
+    torch.utils.checkpoint.checkpoint directly."""
+
+    def __init__(self, nheads, dim, ffn_dim):
+        super().__init__()
+        from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+            checkpoint_wrapper,
+        )
+
+        self.mlp = checkpoint_wrapper(
+            nn.Sequential(
+                nn.Linear(dim, ffn_dim, bias=False),
+                nn.ReLU(),
+                nn.Linear(ffn_dim, dim, bias=False),
+                nn.ReLU(),
+                nn.Linear(dim, ffn_dim, bias=False),
+                nn.ReLU(),
+                nn.Linear(ffn_dim, dim, bias=False),
+            ),
+            context_fn=_alternating_ac_context_fn,
+        )
+
+    def forward(self, x):
+        return self.mlp(x) + x
+
+
+def test_einsum_conversion_preserves_alternating_recompute_tags(device_mesh_1d):
+    """When _replace_view_mm_view_with_einsum converts mm → einsum, the
+    recompute tags from the user's selective AC policy must transfer to the
+    einsum nodes (not be lost by copying only the replaced view node's meta)."""
+    nheads, dim, ffn_dim = 8, 128, 512
+    bs, seq_len = 32, 32
+
+    def input_fn():
+        return torch.rand(bs, seq_len, dim, device="cuda")
+
+    with torch.device("meta"):
+        model = MLPBlockWithAlternatingAC(nheads, dim, ffn_dim)
+
+    gm = _build_joint_graph(model, input_fn, device_mesh_1d)
+
+    # After build_model_graph, mm nodes are converted to einsum if the
+    # view-mm-view pattern matches (batch dims present).
+    einsum_nodes = gm.graph.find_nodes(
+        op="call_function", target=torch.ops.aten.einsum.default
+    )
+    mm_nodes = gm.graph.find_nodes(op="call_function", target=torch.ops.aten.mm.default)
+    linear_nodes = einsum_nodes + mm_nodes
+    assert len(linear_nodes) > 0, "Expected mm or einsum nodes in the graph"
+
+    fwd_linear = [
+        n for n in linear_nodes if n.meta.get("partitioner_tag", "") != "is_backward"
+    ]
+    assert len(fwd_linear) >= 4, (
+        f"Expected at least 4 forward mm/einsum nodes (from 4 linears), "
+        f"got {len(fwd_linear)}"
+    )
+
+    # Every forward mm/einsum inside the checkpoint region must have a
+    # recompute tag — the alternating policy tags all of them (MUST_SAVE
+    # for odd, PREFER_RECOMPUTE for even).
+    for n in fwd_linear:
+        assert n.meta.get("recompute") is not None, (
+            f"Forward {n.target.__name__} node {n} has no recompute tag — "
+            f"AC metadata was lost during mm → einsum conversion"
+        )
+
+    # Verify the alternating pattern: at least one MUST_SAVE and at least
+    # one PREFER_RECOMPUTE among the forward nodes.
+    tags = [n.meta["recompute"] for n in fwd_linear]
+    assert (
+        CheckpointPolicy.MUST_SAVE in tags
+    ), "Expected at least one MUST_SAVE from alternating policy"
+    assert (
+        CheckpointPolicy.PREFER_RECOMPUTE in tags
+    ), "Expected at least one PREFER_RECOMPUTE from alternating policy"
+
+
+# ---------------------------------------------------------------------------
 # Family 3: local_map + activation checkpointing
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Two related changes:

1. Port TorchTitan's `apply_ac` into AutoParallel's LLaMA3 model definition, supporting full, layer-selective, and per-op selective checkpointing via `checkpoint_wrapper`. The example switches from the autoparallel backend's graph-level AC (`enable_ac=True`) to this module-level AC applied before tracing, matching how TorchTitan applies activation checkpointing.

2. Fix AC metadata (`recompute`, `ac_graph_id`) being lost when `_replace_view_mm_view_with_einsum` converts view-mm-view chains into einsum nodes. Previously, the einsum only inherited metadata from the replaced view/permute node, which doesn't carry AC tags. Now the mm node's AC-relevant fields are explicitly copied onto the einsum. A new test validates this with an alternating save/recompute policy across four matmuls.

Authored with Claude.