### PR TITLE
Support kwargs in AutoParallel input_fn via TracedInputs

### DIFF
--- a/autoparallel/__init__.py
+++ b/autoparallel/__init__.py
@@ -6,10 +6,12 @@
 from autoparallel.api import AutoParallel, auto_parallel
 from autoparallel.collectives import with_sharding_constraint
 from autoparallel.compile import autoparallel_backend
+from autoparallel.input_validation import TracedInputs
 
 __all__ = [
     "auto_parallel",
     "AutoParallel",
     "autoparallel_backend",
+    "TracedInputs",
     "with_sharding_constraint",
 ]

--- a/autoparallel/__init__.py
+++ b/autoparallel/__init__.py
@@ -6,12 +6,12 @@
 from autoparallel.api import AutoParallel, auto_parallel
 from autoparallel.collectives import with_sharding_constraint
 from autoparallel.compile import autoparallel_backend
-from autoparallel.input_validation import TracedInputs
+from autoparallel.input_validation import ForwardInputs
 
 __all__ = [
     "auto_parallel",
     "AutoParallel",
     "autoparallel_backend",
-    "TracedInputs",
+    "ForwardInputs",
     "with_sharding_constraint",
 ]

--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -36,7 +36,7 @@ from .graph_passes.graph_utils import (
     update_joint_with_descriptors,
 )
 from .input_validation import (
-    TracedInputs,
+    ForwardInputs,
     _check_forward_args,
     _compute_expected_inputs,
     _extract_input_info,
@@ -94,8 +94,7 @@ def _suppress_wait_tensor_side_effect():
 class JointGraphResult:
     gm: torch.fx.GraphModule
     joint_with_descriptors: Any
-    traced_inputs: list[Any]
-    traced_kwargs: dict[str, Any]
+    traced_inputs: "ForwardInputs"
 
 
 def _make_inputs_dynamic(
@@ -138,23 +137,20 @@ def build_joint_graph(
     with fake_mode:
         raw_inputs = input_fn()
 
-    if isinstance(raw_inputs, TracedInputs):
-        formatted_args: tuple[Any, ...] = tuple(raw_inputs.args)
-        formatted_kwargs: dict[str, Any] = dict(raw_inputs.kwargs)
+    if isinstance(raw_inputs, ForwardInputs):
+        traced_inputs = ForwardInputs(
+            args=tuple(raw_inputs.args), kwargs=dict(raw_inputs.kwargs)
+        )
     elif isinstance(raw_inputs, tuple):
-        formatted_args = raw_inputs
-        formatted_kwargs = {}
+        traced_inputs = ForwardInputs(args=raw_inputs)
     else:
-        formatted_args = (raw_inputs,)
-        formatted_kwargs = {}
+        traced_inputs = ForwardInputs(args=(raw_inputs,))
 
     if fake_mode.shape_env is not None:
-        formatted_args, formatted_kwargs = _make_inputs_dynamic(
-            (formatted_args, formatted_kwargs), fake_mode
+        args, kwargs = _make_inputs_dynamic(
+            (traced_inputs.args, traced_inputs.kwargs), fake_mode
         )
-
-    traced_inputs = list(formatted_args)
-    traced_kwargs = formatted_kwargs
+        traced_inputs = ForwardInputs(args=args, kwargs=kwargs)
 
     with (
         set_dtype_cast(True),
@@ -162,7 +158,7 @@ def build_joint_graph(
         torch._dynamo.utils._disable_saved_tensors_hooks_during_tracing(),
     ):
         torch_ir_with_fqn = _dynamo_graph_capture_for_export(model)(
-            *formatted_args, **formatted_kwargs
+            *traced_inputs.args, **traced_inputs.kwargs
         )
         _restore_state_dict(model, torch_ir_with_fqn)
         _add_unused_params_and_buffers(model, torch_ir_with_fqn)
@@ -171,8 +167,8 @@ def build_joint_graph(
         joint_with_descriptors = aot_export_joint_with_descriptors(
             stack,
             torch_ir_with_fqn,
-            formatted_args,
-            formatted_kwargs or None,
+            traced_inputs.args,
+            traced_inputs.kwargs or None,
             decompositions=decomp_table,
         )
     gm = joint_with_descriptors.graph_module
@@ -200,7 +196,6 @@ def build_joint_graph(
         gm=gm,
         joint_with_descriptors=joint_with_descriptors,
         traced_inputs=traced_inputs,
-        traced_kwargs=traced_kwargs,
     )
 
 
@@ -342,7 +337,6 @@ class AutoParallel:
         self.gm = result.gm
         self.joint_with_descriptors = result.joint_with_descriptors
         self._traced_inputs = result.traced_inputs
-        self._traced_kwargs = result.traced_kwargs
 
     # TODO: Specify what the low/high meaning is (percentage?)
     def add_parameter_memory_constraint(self, low=None, high=None):
@@ -564,7 +558,6 @@ class AutoParallel:
 
         expected_inputs, dynamic_dims = _compute_expected_inputs(
             self._traced_inputs,
-            self._traced_kwargs,
             solved_input_placements,
             self.mesh,
         )
@@ -575,9 +568,9 @@ class AutoParallel:
         from torch.export._tree_utils import reorder_kwargs
 
         trace_in_spec = torch.utils._pytree.tree_flatten(
-            (tuple(self._traced_inputs), self._traced_kwargs)
+            (tuple(self._traced_inputs.args), self._traced_inputs.kwargs)
         )[1]
-        has_traced_kwargs = bool(self._traced_kwargs)
+        has_traced_kwargs = bool(self._traced_inputs.kwargs)
 
         def forward(self, *args, **kwargs):
             if has_traced_kwargs or kwargs:
@@ -700,8 +693,8 @@ def auto_parallel(
         >>> parallel_model = auto_parallel(model, mesh, sample_inputs, out_shardings=...)
 
     Example with keyword-only forward args:
-        >>> from autoparallel import TracedInputs
-        >>> sample_inputs = TracedInputs(
+        >>> from autoparallel import ForwardInputs
+        >>> sample_inputs = ForwardInputs(
         ...     args=(tokens,),
         ...     kwargs={"attention_masks": mask, "positions": pos},
         ... )
@@ -713,7 +706,7 @@ def auto_parallel(
     else:
         raw_inputs = sample_inputs
 
-    if isinstance(raw_inputs, TracedInputs):
+    if isinstance(raw_inputs, ForwardInputs):
         (
             args_shapes,
             args_dtypes,

--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -37,12 +37,10 @@ from .graph_passes.graph_utils import (
 )
 from .input_validation import (
     ForwardInputs,
+    _build_input_fn_from_sample,
     _check_forward_args,
-    _compute_expected_inputs,
-    _extract_input_info,
     _flatten_out_shardings,
-    _make_input_fn,
-    _make_input_fn_with_kwargs,
+    flatten_and_convert_inputs_to_local_shapes,
 )
 from .module_construction import make_parallel_module
 from .optimize_sharding import ShardingOptimizer
@@ -556,7 +554,7 @@ class AutoParallel:
             strategy = sharding_placement[node]
             solved_input_placements.append(tuple(strategy.output_specs.placements))
 
-        expected_inputs, dynamic_dims = _compute_expected_inputs(
+        expected_inputs, dynamic_dims = flatten_and_convert_inputs_to_local_shapes(
             self._traced_inputs,
             solved_input_placements,
             self.mesh,
@@ -706,41 +704,7 @@ def auto_parallel(
     else:
         raw_inputs = sample_inputs
 
-    if isinstance(raw_inputs, ForwardInputs):
-        (
-            args_shapes,
-            args_dtypes,
-            args_placements,
-            args_spec,
-            args_devices,
-        ) = _extract_input_info(raw_inputs.args, mesh)
-        (
-            kwargs_shapes,
-            kwargs_dtypes,
-            kwargs_placements,
-            kwargs_spec,
-            kwargs_devices,
-        ) = _extract_input_info(raw_inputs.kwargs, mesh)
-        input_placements = args_placements + kwargs_placements
-        input_fn: Callable[[], Any] = _make_input_fn_with_kwargs(
-            args_shapes,
-            args_dtypes,
-            args_devices,
-            args_spec,
-            kwargs_shapes,
-            kwargs_dtypes,
-            kwargs_devices,
-            kwargs_spec,
-        )
-    else:
-        # Extract metadata and placements (does not materialize tensors)
-        shapes, dtypes, input_placements, treespec, devices = _extract_input_info(
-            raw_inputs, mesh
-        )
-
-        # Create input_fn that will be called inside FakeTensorMode
-        # It creates fresh tensors (which become fake tensors inside FakeTensorMode)
-        input_fn = _make_input_fn(shapes, dtypes, treespec, devices=devices)
+    input_fn, input_placements = _build_input_fn_from_sample(raw_inputs, mesh)
 
     # Flatten out_shardings to list
     output_placements = _flatten_out_shardings(out_shardings)

--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -36,11 +36,13 @@ from .graph_passes.graph_utils import (
     update_joint_with_descriptors,
 )
 from .input_validation import (
+    TracedInputs,
     _check_forward_args,
     _compute_expected_inputs,
     _extract_input_info,
     _flatten_out_shardings,
     _make_input_fn,
+    _make_input_fn_with_kwargs,
 )
 from .module_construction import make_parallel_module
 from .optimize_sharding import ShardingOptimizer
@@ -93,6 +95,7 @@ class JointGraphResult:
     gm: torch.fx.GraphModule
     joint_with_descriptors: Any
     traced_inputs: list[Any]
+    traced_kwargs: dict[str, Any]
 
 
 def _make_inputs_dynamic(
@@ -135,19 +138,32 @@ def build_joint_graph(
     with fake_mode:
         raw_inputs = input_fn()
 
-    formatted_inputs = raw_inputs if isinstance(raw_inputs, tuple) else (raw_inputs,)
+    if isinstance(raw_inputs, TracedInputs):
+        formatted_args: tuple[Any, ...] = tuple(raw_inputs.args)
+        formatted_kwargs: dict[str, Any] = dict(raw_inputs.kwargs)
+    elif isinstance(raw_inputs, tuple):
+        formatted_args = raw_inputs
+        formatted_kwargs = {}
+    else:
+        formatted_args = (raw_inputs,)
+        formatted_kwargs = {}
 
     if fake_mode.shape_env is not None:
-        formatted_inputs = _make_inputs_dynamic(formatted_inputs, fake_mode)
+        formatted_args, formatted_kwargs = _make_inputs_dynamic(
+            (formatted_args, formatted_kwargs), fake_mode
+        )
 
-    traced_inputs = list(formatted_inputs)
+    traced_inputs = list(formatted_args)
+    traced_kwargs = formatted_kwargs
 
     with (
         set_dtype_cast(True),
         enable_local_map_wrapping(),
         torch._dynamo.utils._disable_saved_tensors_hooks_during_tracing(),
     ):
-        torch_ir_with_fqn = _dynamo_graph_capture_for_export(model)(*formatted_inputs)
+        torch_ir_with_fqn = _dynamo_graph_capture_for_export(model)(
+            *formatted_args, **formatted_kwargs
+        )
         _restore_state_dict(model, torch_ir_with_fqn)
         _add_unused_params_and_buffers(model, torch_ir_with_fqn)
         # TODO Can't use fake mode here because it clashes with the user level
@@ -155,7 +171,8 @@ def build_joint_graph(
         joint_with_descriptors = aot_export_joint_with_descriptors(
             stack,
             torch_ir_with_fqn,
-            formatted_inputs,
+            formatted_args,
+            formatted_kwargs or None,
             decompositions=decomp_table,
         )
     gm = joint_with_descriptors.graph_module
@@ -183,6 +200,7 @@ def build_joint_graph(
         gm=gm,
         joint_with_descriptors=joint_with_descriptors,
         traced_inputs=traced_inputs,
+        traced_kwargs=traced_kwargs,
     )
 
 
@@ -324,6 +342,7 @@ class AutoParallel:
         self.gm = result.gm
         self.joint_with_descriptors = result.joint_with_descriptors
         self._traced_inputs = result.traced_inputs
+        self._traced_kwargs = result.traced_kwargs
 
     # TODO: Specify what the low/high meaning is (percentage?)
     def add_parameter_memory_constraint(self, low=None, high=None):
@@ -544,15 +563,34 @@ class AutoParallel:
             solved_input_placements.append(tuple(strategy.output_specs.placements))
 
         expected_inputs, dynamic_dims = _compute_expected_inputs(
-            self._traced_inputs, solved_input_placements, self.mesh
+            self._traced_inputs,
+            self._traced_kwargs,
+            solved_input_placements,
+            self.mesh,
         )
 
+        # Spec of (args, kwargs) at trace time. Used at runtime to reorder
+        # caller-supplied kwargs back into the canonical leaf order that the
+        # compiled graph expects (matches Dynamo+AOT placeholder order).
+        from torch.export._tree_utils import reorder_kwargs
+
+        trace_in_spec = torch.utils._pytree.tree_flatten(
+            (tuple(self._traced_inputs), self._traced_kwargs)
+        )[1]
+        has_traced_kwargs = bool(self._traced_kwargs)
+
         def forward(self, *args, **kwargs):
-            # Flatten pytree args (e.g. dicts, nested structures) to tensor
-            # leaves, matching how Dynamo flattened the inputs during tracing.
-            flat_args, _ = torch.utils._pytree.tree_flatten(args)
-            if len(flat_args) != len(expected_inputs):
+            if has_traced_kwargs or kwargs:
+                if kwargs:
+                    kwargs = reorder_kwargs(kwargs, trace_in_spec)
                 flat_args, _ = torch.utils._pytree.tree_flatten((args, kwargs))
+            else:
+                # Positional-only fast path. Flatten args directly so that a
+                # single pytree positional (e.g. a dict batch) keeps working
+                # exactly as before.
+                flat_args, _ = torch.utils._pytree.tree_flatten(args)
+                if len(flat_args) != len(expected_inputs):
+                    flat_args, _ = torch.utils._pytree.tree_flatten((args, kwargs))
             _check_forward_args(flat_args, expected_inputs, dynamic_dims)
             # NB: don't close over the parameters/buffers, as the user may
             # reassign the module!
@@ -561,13 +599,22 @@ class AutoParallel:
             params = [
                 self.get_parameter(fqn).to_local() for fqn in graph_param_fqns
             ] + [self.get_buffer(fqn).to_local() for fqn in graph_buffer_fqns]
-            boxed_args = [*params, *flat_args]
-            del params
             if torch.is_grad_enabled():
-                # NB: don't do self.parallel_model_fn work around Dynamo bug
-                out = parallel_model_fn(boxed_args)
+                # parallel_model_fn is AOT's unflattened wrapper; it calls
+                # `reorder_kwargs(kwargs, in_spec)` and re-flattens
+                # `(args, kwargs)`. We must hand it kwargs by name when the
+                # traced graph had them, otherwise the keyword-mismatch check
+                # rejects the call. For the no-kwargs case keep the historical
+                # single-boxed-list shape so behavior is bit-identical.
+                if has_traced_kwargs:
+                    out = parallel_model_fn(*params, *args, **kwargs)
+                else:
+                    boxed_args = [*params, *flat_args]
+                    out = parallel_model_fn(boxed_args)
             else:
+                boxed_args = [*params, *flat_args]
                 out = _inference_fn(boxed_args)
+            del params
             return out
 
         self.parallel_model = make_parallel_module(
@@ -651,6 +698,14 @@ def auto_parallel(
         ...     "attention_mask": DTensor.from_local(mask, mesh, [Shard(0)]),
         ... }
         >>> parallel_model = auto_parallel(model, mesh, sample_inputs, out_shardings=...)
+
+    Example with keyword-only forward args:
+        >>> from autoparallel import TracedInputs
+        >>> sample_inputs = TracedInputs(
+        ...     args=(tokens,),
+        ...     kwargs={"attention_masks": mask, "positions": pos},
+        ... )
+        >>> parallel_model = auto_parallel(model, mesh, sample_inputs, out_shardings=...)
     """
     # Handle callable sample_inputs
     if callable(sample_inputs):
@@ -658,17 +713,44 @@ def auto_parallel(
     else:
         raw_inputs = sample_inputs
 
-    # Extract metadata and placements (does not materialize tensors)
-    shapes, dtypes, input_placements, treespec, devices = _extract_input_info(
-        raw_inputs, mesh
-    )
+    if isinstance(raw_inputs, TracedInputs):
+        (
+            args_shapes,
+            args_dtypes,
+            args_placements,
+            args_spec,
+            args_devices,
+        ) = _extract_input_info(raw_inputs.args, mesh)
+        (
+            kwargs_shapes,
+            kwargs_dtypes,
+            kwargs_placements,
+            kwargs_spec,
+            kwargs_devices,
+        ) = _extract_input_info(raw_inputs.kwargs, mesh)
+        input_placements = args_placements + kwargs_placements
+        input_fn: Callable[[], Any] = _make_input_fn_with_kwargs(
+            args_shapes,
+            args_dtypes,
+            args_devices,
+            args_spec,
+            kwargs_shapes,
+            kwargs_dtypes,
+            kwargs_devices,
+            kwargs_spec,
+        )
+    else:
+        # Extract metadata and placements (does not materialize tensors)
+        shapes, dtypes, input_placements, treespec, devices = _extract_input_info(
+            raw_inputs, mesh
+        )
+
+        # Create input_fn that will be called inside FakeTensorMode
+        # It creates fresh tensors (which become fake tensors inside FakeTensorMode)
+        input_fn = _make_input_fn(shapes, dtypes, treespec, devices=devices)
 
     # Flatten out_shardings to list
     output_placements = _flatten_out_shardings(out_shardings)
-
-    # Create input_fn that will be called inside FakeTensorMode
-    # It creates fresh tensors (which become fake tensors inside FakeTensorMode)
-    input_fn = _make_input_fn(shapes, dtypes, treespec, devices=devices)
 
     # Use AutoParallel context manager
     with AutoParallel(

--- a/autoparallel/input_validation.py
+++ b/autoparallel/input_validation.py
@@ -3,21 +3,39 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 
+from dataclasses import dataclass, field
 from typing import Any, Callable
 
 import torch
 from torch.distributed.tensor import DeviceMesh
 
 
-def _compute_expected_inputs(traced_inputs, input_placements, mesh):
+@dataclass(frozen=True)
+class TracedInputs:
+    """Explicit ``(args, kwargs)`` container for AutoParallel's ``input_fn``.
+
+    Return this from ``input_fn`` (or pass as ``sample_inputs`` to
+    ``auto_parallel``) to trace a model whose ``forward`` takes keyword-only
+    arguments. Any other return value is interpreted positionally, preserving
+    the historical contract.
+    """
+
+    args: tuple = ()
+    kwargs: dict = field(default_factory=dict)
+
+
+def _compute_expected_inputs(traced_args, traced_kwargs, input_placements, mesh):
     """Compute expected runtime inputs by applying sharding to traced global shapes.
 
-    traced_inputs may contain pytree structures (dicts, nested tuples, etc.).
-    We flatten them to tensor leaves before applying sharding, since the compiled
-    graph operates on flat tensor args.
+    ``traced_args`` and ``traced_kwargs`` may contain pytree structures (dicts,
+    nested tuples, etc.). We flatten ``(args, kwargs)`` together to tensor
+    leaves before applying sharding, since the compiled graph operates on flat
+    tensor args in that canonical order (matching how Dynamo and AOT autograd
+    lay out placeholders).
 
     Args:
-        traced_inputs: The inputs used during tracing (may contain pytrees).
+        traced_args: The positional inputs used during tracing (may contain pytrees).
+        traced_kwargs: The keyword inputs used during tracing (may contain pytrees).
         input_placements: A placement tuple for each tensor leaf, as determined
             by the solver's solution.
         mesh: The device mesh.
@@ -31,7 +49,7 @@ def _compute_expected_inputs(traced_inputs, input_placements, mesh):
     import torch.utils._pytree as pytree
     from torch.distributed.tensor.placement_types import Shard
 
-    flat_inputs, _ = pytree.tree_flatten(traced_inputs)
+    flat_inputs, _ = pytree.tree_flatten((tuple(traced_args), traced_kwargs))
 
     result = []
     dynamic_dims: set[tuple[int, int]] = set()
@@ -196,6 +214,44 @@ def _make_input_fn(
             return result
         else:
             return (result,)
+
+    return input_fn
+
+
+def _make_input_fn_with_kwargs(
+    args_shapes: list[tuple[int, ...]],
+    args_dtypes: list[torch.dtype],
+    args_devices: list[torch.device],
+    args_spec: Any,
+    kwargs_shapes: list[tuple[int, ...]],
+    kwargs_dtypes: list[torch.dtype],
+    kwargs_devices: list[torch.device],
+    kwargs_spec: Any,
+) -> Callable[[], TracedInputs]:
+    """Create an input_fn that returns a ``TracedInputs(args, kwargs)``.
+
+    Mirrors ``_make_input_fn`` but reconstructs the positional and keyword
+    pytrees separately so that the user-provided ``forward`` keyword-only
+    parameters are preserved through tracing.
+    """
+    import torch.utils._pytree as pytree
+
+    def input_fn() -> TracedInputs:
+        args_tensors = [
+            torch.empty(shape, dtype=dtype, device=device)
+            for shape, dtype, device in zip(args_shapes, args_dtypes, args_devices)
+        ]
+        kwargs_tensors = [
+            torch.empty(shape, dtype=dtype, device=device)
+            for shape, dtype, device in zip(
+                kwargs_shapes, kwargs_dtypes, kwargs_devices
+            )
+        ]
+        args = pytree.tree_unflatten(args_tensors, args_spec)
+        kwargs = pytree.tree_unflatten(kwargs_tensors, kwargs_spec)
+        if not isinstance(args, tuple):
+            args = (args,)
+        return TracedInputs(args=args, kwargs=kwargs)
 
     return input_fn
 

--- a/autoparallel/input_validation.py
+++ b/autoparallel/input_validation.py
@@ -24,7 +24,7 @@ class ForwardInputs:
     kwargs: dict = field(default_factory=dict)
 
 
-def _compute_expected_inputs(traced_inputs, input_placements, mesh):
+def flatten_and_convert_inputs_to_local_shapes(traced_inputs, input_placements, mesh):
     """Compute expected runtime inputs by applying sharding to traced global shapes.
 
     ``traced_inputs`` is a :class:`ForwardInputs` carrying the ``(args, kwargs)``
@@ -88,7 +88,7 @@ def _check_forward_args(args, expected_inputs, dynamic_dims=frozenset()):
 
     Args:
         args: The actual forward arguments (flat list).
-        expected_inputs: Expected shapes from _compute_expected_inputs.
+        expected_inputs: Expected shapes from flatten_and_convert_inputs_to_local_shapes.
         dynamic_dims: Set of (arg_index, dim) pairs for dynamic dimensions.
     """
     if len(args) != len(expected_inputs):
@@ -187,40 +187,6 @@ def _extract_input_info(
 
 
 def _make_input_fn(
-    shapes: list[tuple[int, ...]],
-    dtypes: list[torch.dtype],
-    treespec: Any,
-    devices: list[torch.device],
-) -> Callable[[], tuple[Any, ...]]:
-    """
-    Create an input_fn that creates tensors with the given shapes/dtypes/devices.
-
-    The returned function should be called inside FakeTensorMode.
-    It creates new tensors (which will be fake tensors when called in FakeTensorMode).
-
-    Returns:
-        Callable that returns inputs as a tuple.
-    """
-    import torch.utils._pytree as pytree
-
-    def input_fn() -> tuple[Any, ...]:
-        # Create tensors inside FakeTensorMode - they'll be fake tensors
-        tensors = [
-            torch.empty(shape, dtype=dtype, device=device)
-            for shape, dtype, device in zip(shapes, dtypes, devices)
-        ]
-        result = pytree.tree_unflatten(tensors, treespec)
-
-        # AutoParallel expects input_fn to return a tuple
-        if isinstance(result, tuple):
-            return result
-        else:
-            return (result,)
-
-    return input_fn
-
-
-def _make_input_fn_with_kwargs(
     args_shapes: list[tuple[int, ...]],
     args_dtypes: list[torch.dtype],
     args_devices: list[torch.device],
@@ -232,9 +198,11 @@ def _make_input_fn_with_kwargs(
 ) -> Callable[[], ForwardInputs]:
     """Create an input_fn that returns a ``ForwardInputs(args, kwargs)``.
 
-    Mirrors ``_make_input_fn`` but reconstructs the positional and keyword
-    pytrees separately so that the user-provided ``forward`` keyword-only
-    parameters are preserved through tracing.
+    The returned function should be called inside FakeTensorMode; it creates
+    new tensors (which will be fake tensors under that mode). Positional and
+    keyword pytrees are reconstructed separately so that keyword-only
+    ``forward`` parameters survive tracing. The no-kwargs case is just empty
+    ``kwargs_shapes`` / ``kwargs_spec``.
     """
     import torch.utils._pytree as pytree
 
@@ -256,6 +224,59 @@ def _make_input_fn_with_kwargs(
         return ForwardInputs(args=args, kwargs=kwargs)
 
     return input_fn
+
+
+def _normalize_sample_inputs(sample_inputs: Any) -> ForwardInputs:
+    """Coerce ``sample_inputs`` (any legacy shape) into a canonical ``ForwardInputs``.
+
+    - ``ForwardInputs`` is returned as-is.
+    - A ``tuple`` becomes ``ForwardInputs(args=raw)`` (positional pytree).
+    - Anything else becomes ``ForwardInputs(args=(raw,))`` (single positional
+      pytree leaf — preserves the historical dict/tensor handling).
+    """
+    if isinstance(sample_inputs, ForwardInputs):
+        return sample_inputs
+    if isinstance(sample_inputs, tuple):
+        return ForwardInputs(args=sample_inputs)
+    return ForwardInputs(args=(sample_inputs,))
+
+
+def _build_input_fn_from_sample(
+    sample_inputs: Any, mesh: DeviceMesh
+) -> tuple[Callable[[], ForwardInputs], list[tuple[Any, ...]]]:
+    """Extract metadata from ``sample_inputs`` and build a matching ``input_fn``.
+
+    Returns the ``input_fn`` (which produces a ``ForwardInputs`` of fresh
+    tensors under FakeTensorMode) and the flat list of input placements in
+    ``tree_flatten((args, kwargs))`` leaf order (positional first, then kwargs
+    in dict key order — matching how Dynamo and AOT lay out placeholders).
+    """
+    forward_inputs = _normalize_sample_inputs(sample_inputs)
+    (
+        args_shapes,
+        args_dtypes,
+        args_placements,
+        args_spec,
+        args_devices,
+    ) = _extract_input_info(forward_inputs.args, mesh)
+    (
+        kwargs_shapes,
+        kwargs_dtypes,
+        kwargs_placements,
+        kwargs_spec,
+        kwargs_devices,
+    ) = _extract_input_info(forward_inputs.kwargs, mesh)
+    input_fn = _make_input_fn(
+        args_shapes,
+        args_dtypes,
+        args_devices,
+        args_spec,
+        kwargs_shapes,
+        kwargs_dtypes,
+        kwargs_devices,
+        kwargs_spec,
+    )
+    return input_fn, args_placements + kwargs_placements
 
 
 def _flatten_out_shardings(

--- a/autoparallel/input_validation.py
+++ b/autoparallel/input_validation.py
@@ -11,7 +11,7 @@ from torch.distributed.tensor import DeviceMesh
 
 
 @dataclass(frozen=True)
-class TracedInputs:
+class ForwardInputs:
     """Explicit ``(args, kwargs)`` container for AutoParallel's ``input_fn``.
 
     Return this from ``input_fn`` (or pass as ``sample_inputs`` to
@@ -24,18 +24,18 @@ class TracedInputs:
     kwargs: dict = field(default_factory=dict)
 
 
-def _compute_expected_inputs(traced_args, traced_kwargs, input_placements, mesh):
+def _compute_expected_inputs(traced_inputs, input_placements, mesh):
     """Compute expected runtime inputs by applying sharding to traced global shapes.
 
-    ``traced_args`` and ``traced_kwargs`` may contain pytree structures (dicts,
+    ``traced_inputs`` is a :class:`ForwardInputs` carrying the ``(args, kwargs)``
+    used during tracing. Each side may contain pytree structures (dicts,
     nested tuples, etc.). We flatten ``(args, kwargs)`` together to tensor
     leaves before applying sharding, since the compiled graph operates on flat
     tensor args in that canonical order (matching how Dynamo and AOT autograd
     lay out placeholders).
 
     Args:
-        traced_args: The positional inputs used during tracing (may contain pytrees).
-        traced_kwargs: The keyword inputs used during tracing (may contain pytrees).
+        traced_inputs: The ``ForwardInputs`` used during tracing.
         input_placements: A placement tuple for each tensor leaf, as determined
             by the solver's solution.
         mesh: The device mesh.
@@ -49,7 +49,9 @@ def _compute_expected_inputs(traced_args, traced_kwargs, input_placements, mesh)
     import torch.utils._pytree as pytree
     from torch.distributed.tensor.placement_types import Shard
 
-    flat_inputs, _ = pytree.tree_flatten((tuple(traced_args), traced_kwargs))
+    flat_inputs, _ = pytree.tree_flatten(
+        (tuple(traced_inputs.args), traced_inputs.kwargs)
+    )
 
     result = []
     dynamic_dims: set[tuple[int, int]] = set()
@@ -227,8 +229,8 @@ def _make_input_fn_with_kwargs(
     kwargs_dtypes: list[torch.dtype],
     kwargs_devices: list[torch.device],
     kwargs_spec: Any,
-) -> Callable[[], TracedInputs]:
-    """Create an input_fn that returns a ``TracedInputs(args, kwargs)``.
+) -> Callable[[], ForwardInputs]:
+    """Create an input_fn that returns a ``ForwardInputs(args, kwargs)``.
 
     Mirrors ``_make_input_fn`` but reconstructs the positional and keyword
     pytrees separately so that the user-provided ``forward`` keyword-only
@@ -236,7 +238,7 @@ def _make_input_fn_with_kwargs(
     """
     import torch.utils._pytree as pytree
 
-    def input_fn() -> TracedInputs:
+    def input_fn() -> ForwardInputs:
         args_tensors = [
             torch.empty(shape, dtype=dtype, device=device)
             for shape, dtype, device in zip(args_shapes, args_dtypes, args_devices)
@@ -251,7 +253,7 @@ def _make_input_fn_with_kwargs(
         kwargs = pytree.tree_unflatten(kwargs_tensors, kwargs_spec)
         if not isinstance(args, tuple):
             args = (args,)
-        return TracedInputs(args=args, kwargs=kwargs)
+        return ForwardInputs(args=args, kwargs=kwargs)
 
     return input_fn
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,6 +13,7 @@ from torch.distributed.tensor.placement_types import Replicate, Shard
 
 from autoparallel.api import AutoParallel, auto_parallel
 from autoparallel.compile import autoparallel_backend
+from autoparallel.input_validation import TracedInputs
 
 
 def test_from_meta_model(device_mesh_1d):
@@ -887,3 +888,174 @@ def test_compile_fullgraph_no_recompilation(device_mesh_1d):
                 compiled(torch.randn(bs, dim, device="cuda"))
     finally:
         torch._dynamo.config.error_on_recompile = False
+
+
+class _KwargOnlyModel(nn.Module):
+    """Model whose forward has keyword-only arguments."""
+
+    def __init__(self, dim):
+        super().__init__()
+        self.linear = nn.Linear(dim, dim)
+
+    def forward(self, tokens, *, attention_masks=None, positions=None):
+        x = self.linear(tokens.to(self.linear.weight.dtype))
+        if attention_masks is not None:
+            x = x + attention_masks.to(x.dtype).unsqueeze(-1)
+        if positions is not None:
+            x = x + positions.to(x.dtype)
+        return x
+
+    def init_weights(self):
+        nn.init.ones_(self.linear.weight)
+        nn.init.zeros_(self.linear.bias)
+
+
+def test_input_fn_traced_inputs_kwargs(device_mesh_1d):
+    """input_fn returning TracedInputs traces a kwarg-only forward end-to-end."""
+    dim = 128
+    batch_size = 512
+    local_bs = batch_size // device_mesh_1d.size()
+
+    with torch.device("meta"):
+        model = _KwargOnlyModel(dim)
+
+    def input_fn():
+        tokens = torch.randn(batch_size, dim, device="cuda")
+        masks = torch.ones(batch_size, device="cuda")
+        positions = torch.zeros(batch_size, dim, device="cuda")
+        return TracedInputs(
+            args=(tokens,),
+            kwargs={"attention_masks": masks, "positions": positions},
+        )
+
+    with AutoParallel(model, input_fn, device_mesh_1d, None) as autop:
+        autop.add_input_constraints([(Shard(0),), (Shard(0),), (Shard(0),)])
+        autop.add_output_constraints([(Shard(0),)])
+        sharding_placement = autop.optimize_placement(verbose=False)
+        parallel_mod = autop.apply_placement(sharding_placement)
+
+    parallel_mod.to_empty(device="cuda")
+    parallel_mod.init_weights()
+
+    tokens = torch.randn(local_bs, dim, device="cuda")
+    masks = torch.ones(local_bs, device="cuda")
+    positions = torch.zeros(local_bs, dim, device="cuda")
+    out = parallel_mod(tokens, attention_masks=masks, positions=positions)
+    assert out.shape == (local_bs, dim)
+
+
+def test_input_fn_traced_inputs_kwargs_reorder(device_mesh_1d):
+    """Caller may pass kwargs in any order; reorder_kwargs aligns them."""
+    dim = 128
+    batch_size = 512
+    local_bs = batch_size // device_mesh_1d.size()
+
+    with torch.device("meta"):
+        model = _KwargOnlyModel(dim)
+
+    def input_fn():
+        return TracedInputs(
+            args=(torch.randn(batch_size, dim, device="cuda"),),
+            kwargs={
+                "attention_masks": torch.ones(batch_size, device="cuda"),
+                "positions": torch.zeros(batch_size, dim, device="cuda"),
+            },
+        )
+
+    with AutoParallel(model, input_fn, device_mesh_1d, None) as autop:
+        autop.add_input_constraints([(Shard(0),), (Shard(0),), (Shard(0),)])
+        autop.add_output_constraints([(Shard(0),)])
+        sharding_placement = autop.optimize_placement(verbose=False)
+        parallel_mod = autop.apply_placement(sharding_placement)
+
+    parallel_mod.to_empty(device="cuda")
+    parallel_mod.init_weights()
+
+    tokens = torch.randn(local_bs, dim, device="cuda")
+    masks = torch.ones(local_bs, device="cuda")
+    positions = torch.zeros(local_bs, dim, device="cuda")
+    # Caller passes kwargs in the opposite order from input_fn.
+    out = parallel_mod(tokens, positions=positions, attention_masks=masks)
+    assert out.shape == (local_bs, dim)
+
+
+def test_input_fn_positional_bc(device_mesh_1d):
+    """Existing positional input_fn return values keep working unchanged."""
+    dim = 128
+    batch_size = 512
+    local_bs = batch_size // device_mesh_1d.size()
+
+    class M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(dim, dim)
+
+        def forward(self, x):
+            return self.linear(x)
+
+        def init_weights(self):
+            nn.init.ones_(self.linear.weight)
+            nn.init.zeros_(self.linear.bias)
+
+    with torch.device("meta"):
+        model = M()
+
+    def input_fn():
+        return (torch.randn(batch_size, dim, device="cuda"),)
+
+    with AutoParallel(model, input_fn, device_mesh_1d, None) as autop:
+        autop.add_input_constraints([(Shard(0),)])
+        autop.add_output_constraints([(Shard(0),)])
+        sharding_placement = autop.optimize_placement(verbose=False)
+        parallel_mod = autop.apply_placement(sharding_placement)
+
+    parallel_mod.to_empty(device="cuda")
+    parallel_mod.init_weights()
+
+    out = parallel_mod(torch.randn(local_bs, dim, device="cuda"))
+    assert out.shape == (local_bs, dim)
+
+
+def test_auto_parallel_traced_inputs(device_mesh_1d):
+    """Simple auto_parallel(...) accepts TracedInputs sample_inputs."""
+    dim = 128
+    batch_size = 512
+    local_bs = batch_size // device_mesh_1d.size()
+
+    with torch.device("meta"):
+        model = _KwargOnlyModel(dim)
+
+    tokens = DTensor.from_local(
+        torch.randn(local_bs, dim, device="cuda"),
+        device_mesh_1d,
+        [Shard(0)],
+    )
+    masks = DTensor.from_local(
+        torch.ones(local_bs, device="cuda"),
+        device_mesh_1d,
+        [Shard(0)],
+    )
+    positions = DTensor.from_local(
+        torch.zeros(local_bs, dim, device="cuda"),
+        device_mesh_1d,
+        [Shard(0)],
+    )
+
+    parallel_mod = auto_parallel(
+        model,
+        device_mesh_1d,
+        sample_inputs=TracedInputs(
+            args=(tokens,),
+            kwargs={"attention_masks": masks, "positions": positions},
+        ),
+        out_shardings=(Shard(0),),
+    )
+    parallel_mod.to_empty(device="cuda")
+    parallel_mod.init_weights()
+
+    out = parallel_mod(
+        torch.randn(local_bs, dim, device="cuda"),
+        attention_masks=torch.ones(local_bs, device="cuda"),
+        positions=torch.zeros(local_bs, dim, device="cuda"),
+    )
+    assert out.shape == (local_bs, dim)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,7 +13,7 @@ from torch.distributed.tensor.placement_types import Replicate, Shard
 
 from autoparallel.api import AutoParallel, auto_parallel
 from autoparallel.compile import autoparallel_backend
-from autoparallel.input_validation import TracedInputs
+from autoparallel.input_validation import ForwardInputs
 
 
 def test_from_meta_model(device_mesh_1d):
@@ -910,8 +910,8 @@ class _KwargOnlyModel(nn.Module):
         nn.init.zeros_(self.linear.bias)
 
 
-def test_input_fn_traced_inputs_kwargs(device_mesh_1d):
-    """input_fn returning TracedInputs traces a kwarg-only forward end-to-end."""
+def test_input_fn_forward_inputs_kwargs(device_mesh_1d):
+    """input_fn returning ForwardInputs traces a kwarg-only forward end-to-end."""
     dim = 128
     batch_size = 512
     local_bs = batch_size // device_mesh_1d.size()
@@ -923,7 +923,7 @@ def test_input_fn_traced_inputs_kwargs(device_mesh_1d):
         tokens = torch.randn(batch_size, dim, device="cuda")
         masks = torch.ones(batch_size, device="cuda")
         positions = torch.zeros(batch_size, dim, device="cuda")
-        return TracedInputs(
+        return ForwardInputs(
             args=(tokens,),
             kwargs={"attention_masks": masks, "positions": positions},
         )
@@ -944,7 +944,7 @@ def test_input_fn_traced_inputs_kwargs(device_mesh_1d):
     assert out.shape == (local_bs, dim)
 
 
-def test_input_fn_traced_inputs_kwargs_reorder(device_mesh_1d):
+def test_input_fn_forward_inputs_kwargs_reorder(device_mesh_1d):
     """Caller may pass kwargs in any order; reorder_kwargs aligns them."""
     dim = 128
     batch_size = 512
@@ -954,7 +954,7 @@ def test_input_fn_traced_inputs_kwargs_reorder(device_mesh_1d):
         model = _KwargOnlyModel(dim)
 
     def input_fn():
-        return TracedInputs(
+        return ForwardInputs(
             args=(torch.randn(batch_size, dim, device="cuda"),),
             kwargs={
                 "attention_masks": torch.ones(batch_size, device="cuda"),
@@ -1016,8 +1016,8 @@ def test_input_fn_positional_bc(device_mesh_1d):
     assert out.shape == (local_bs, dim)
 
 
-def test_auto_parallel_traced_inputs(device_mesh_1d):
-    """Simple auto_parallel(...) accepts TracedInputs sample_inputs."""
+def test_auto_parallel_forward_inputs(device_mesh_1d):
+    """Simple auto_parallel(...) accepts ForwardInputs sample_inputs."""
     dim = 128
     batch_size = 512
     local_bs = batch_size // device_mesh_1d.size()
@@ -1044,7 +1044,7 @@ def test_auto_parallel_traced_inputs(device_mesh_1d):
     parallel_mod = auto_parallel(
         model,
         device_mesh_1d,
-        sample_inputs=TracedInputs(
+        sample_inputs=ForwardInputs(
             args=(tokens,),
             kwargs={"attention_masks": masks, "positions": positions},
         ),

--- a/tests/test_dynamic_shapes.py
+++ b/tests/test_dynamic_shapes.py
@@ -992,8 +992,8 @@ class TestDynamicDimsParameter:
         with pytest.raises(ValueError, match="has shape"):
             _check_forward_args([torch.randn(4, 9)], expected)
 
-    def test_compute_expected_inputs_detects_dynamic_dims(self):
-        """_compute_expected_inputs correctly identifies SymInt dims."""
+    def test_flatten_and_convert_inputs_to_local_shapes_detects_dynamic_dims(self):
+        """flatten_and_convert_inputs_to_local_shapes correctly identifies SymInt dims."""
         from torch._subclasses import FakeTensorMode
         from torch.fx.experimental.symbolic_shapes import (
             DimDynamic,
@@ -1003,7 +1003,7 @@ class TestDynamicDimsParameter:
 
         from autoparallel.input_validation import (
             ForwardInputs,
-            _compute_expected_inputs,
+            flatten_and_convert_inputs_to_local_shapes,
         )
 
         shape_env = ShapeEnv()
@@ -1031,7 +1031,7 @@ class TestDynamicDimsParameter:
             def size(self, dim=0):
                 return 1
 
-        _, dynamic_dims = _compute_expected_inputs(
+        _, dynamic_dims = flatten_and_convert_inputs_to_local_shapes(
             ForwardInputs(args=(t1, t2)), [(), ()], FakeMesh()
         )
         assert (0, 0) in dynamic_dims, "t1 dim 0 should be dynamic"
@@ -1040,7 +1040,7 @@ class TestDynamicDimsParameter:
         assert (1, 1) not in dynamic_dims, "t2 dim 1 should be static"
         assert (1, 2) in dynamic_dims, "t2 dim 2 should be dynamic"
 
-    def test_compute_expected_inputs_non_tensor_indexing(self):
+    def test_flatten_and_convert_inputs_to_local_shapes_non_tensor_indexing(self):
         """Non-tensor inputs don't shift the dynamic_dims arg indices."""
         from torch._subclasses import FakeTensorMode
         from torch.fx.experimental.symbolic_shapes import (
@@ -1051,7 +1051,7 @@ class TestDynamicDimsParameter:
 
         from autoparallel.input_validation import (
             ForwardInputs,
-            _compute_expected_inputs,
+            flatten_and_convert_inputs_to_local_shapes,
         )
 
         shape_env = ShapeEnv()
@@ -1069,7 +1069,7 @@ class TestDynamicDimsParameter:
                 return 1
 
         # Non-tensor followed by tensor: the tensor is result_idx=1
-        _, dynamic_dims = _compute_expected_inputs(
+        _, dynamic_dims = flatten_and_convert_inputs_to_local_shapes(
             ForwardInputs(args=(42, t1)), [()], FakeMesh()
         )
         assert (1, 0) in dynamic_dims, "tensor at result_idx=1, dim 0 should be dynamic"
@@ -1367,7 +1367,7 @@ def test_dynamic_check_forward_args_accepts_different_batch(device_mesh_1d):
     """_check_forward_args should accept different batch sizes with dynamic shapes."""
     from autoparallel.input_validation import (
         _check_forward_args,
-        _compute_expected_inputs,
+        flatten_and_convert_inputs_to_local_shapes,
     )
 
     dim1, dim2 = 1024, 4096
@@ -1385,7 +1385,7 @@ def test_dynamic_check_forward_args_accepts_different_batch(device_mesh_1d):
         autop.add_output_constraints([placement])
         autop.optimize_placement(verbose=False)
 
-        expected, dynamic_dims = _compute_expected_inputs(
+        expected, dynamic_dims = flatten_and_convert_inputs_to_local_shapes(
             autop._traced_inputs,
             autop.input_constraints,
             device_mesh_1d,

--- a/tests/test_dynamic_shapes.py
+++ b/tests/test_dynamic_shapes.py
@@ -1028,7 +1028,7 @@ class TestDynamicDimsParameter:
             def size(self, dim=0):
                 return 1
 
-        _, dynamic_dims = _compute_expected_inputs([t1, t2], [(), ()], FakeMesh())
+        _, dynamic_dims = _compute_expected_inputs([t1, t2], {}, [(), ()], FakeMesh())
         assert (0, 0) in dynamic_dims, "t1 dim 0 should be dynamic"
         assert (0, 1) not in dynamic_dims, "t1 dim 1 should be static"
         assert (1, 0) in dynamic_dims, "t2 dim 0 should be dynamic"
@@ -1061,7 +1061,7 @@ class TestDynamicDimsParameter:
                 return 1
 
         # Non-tensor followed by tensor: the tensor is result_idx=1
-        _, dynamic_dims = _compute_expected_inputs([42, t1], [()], FakeMesh())
+        _, dynamic_dims = _compute_expected_inputs([42, t1], {}, [()], FakeMesh())
         assert (1, 0) in dynamic_dims, "tensor at result_idx=1, dim 0 should be dynamic"
         assert (0, 0) not in dynamic_dims, "result_idx=0 is a non-tensor"
 
@@ -1376,7 +1376,10 @@ def test_dynamic_check_forward_args_accepts_different_batch(device_mesh_1d):
         autop.optimize_placement(verbose=False)
 
         expected, dynamic_dims = _compute_expected_inputs(
-            autop._traced_inputs, autop.input_constraints, device_mesh_1d
+            autop._traced_inputs,
+            autop._traced_kwargs,
+            autop.input_constraints,
+            device_mesh_1d,
         )
 
     # The expected shapes should have SymInt for the batch dim

--- a/tests/test_dynamic_shapes.py
+++ b/tests/test_dynamic_shapes.py
@@ -1001,7 +1001,10 @@ class TestDynamicDimsParameter:
             StatelessSymbolicContext,
         )
 
-        from autoparallel.input_validation import _compute_expected_inputs
+        from autoparallel.input_validation import (
+            ForwardInputs,
+            _compute_expected_inputs,
+        )
 
         shape_env = ShapeEnv()
         fake_mode = FakeTensorMode(shape_env=shape_env, static_shapes=False)
@@ -1028,7 +1031,9 @@ class TestDynamicDimsParameter:
             def size(self, dim=0):
                 return 1
 
-        _, dynamic_dims = _compute_expected_inputs([t1, t2], {}, [(), ()], FakeMesh())
+        _, dynamic_dims = _compute_expected_inputs(
+            ForwardInputs(args=(t1, t2)), [(), ()], FakeMesh()
+        )
         assert (0, 0) in dynamic_dims, "t1 dim 0 should be dynamic"
         assert (0, 1) not in dynamic_dims, "t1 dim 1 should be static"
         assert (1, 0) in dynamic_dims, "t2 dim 0 should be dynamic"
@@ -1044,7 +1049,10 @@ class TestDynamicDimsParameter:
             StatelessSymbolicContext,
         )
 
-        from autoparallel.input_validation import _compute_expected_inputs
+        from autoparallel.input_validation import (
+            ForwardInputs,
+            _compute_expected_inputs,
+        )
 
         shape_env = ShapeEnv()
         fake_mode = FakeTensorMode(shape_env=shape_env, static_shapes=False)
@@ -1061,7 +1069,9 @@ class TestDynamicDimsParameter:
                 return 1
 
         # Non-tensor followed by tensor: the tensor is result_idx=1
-        _, dynamic_dims = _compute_expected_inputs([42, t1], {}, [()], FakeMesh())
+        _, dynamic_dims = _compute_expected_inputs(
+            ForwardInputs(args=(42, t1)), [()], FakeMesh()
+        )
         assert (1, 0) in dynamic_dims, "tensor at result_idx=1, dim 0 should be dynamic"
         assert (0, 0) not in dynamic_dims, "result_idx=0 is a non-tensor"
 
@@ -1377,7 +1387,6 @@ def test_dynamic_check_forward_args_accepts_different_batch(device_mesh_1d):
 
         expected, dynamic_dims = _compute_expected_inputs(
             autop._traced_inputs,
-            autop._traced_kwargs,
             autop.input_constraints,
             device_mesh_1d,
         )

--- a/tests/test_flex_attention.py
+++ b/tests/test_flex_attention.py
@@ -315,17 +315,13 @@ def test_flex_attention_block_mask_sharding_matches_shape(device_mesh_1d):
 
     from autoparallel.api import AutoParallel
     from autoparallel.input_validation import (
-        _extract_input_info,
+        _build_input_fn_from_sample,
         _flatten_out_shardings,
-        _make_input_fn,
     )
 
     def _get_flex_attn_strat(model):
         x = _make_input(mesh, DIM)
-        shapes, dtypes, input_placements, treespec, devices = _extract_input_info(
-            (x,), mesh
-        )
-        input_fn = _make_input_fn(shapes, dtypes, treespec, devices)
+        input_fn, input_placements = _build_input_fn_from_sample((x,), mesh)
         output_placements = _flatten_out_shardings(_out_shardings(mesh))
 
         with AutoParallel(model, input_fn, mesh) as autop:
@@ -403,19 +399,15 @@ def test_flex_attention_gqa_head_sharding(device_mesh_2d):
 
     from autoparallel.api import AutoParallel
     from autoparallel.input_validation import (
-        _extract_input_info,
+        _build_input_fn_from_sample,
         _flatten_out_shardings,
-        _make_input_fn,
     )
 
     with torch.device("meta"):
         model = FlexAttnGQAModel(DIM, N_HEADS, n_kv_heads)
 
     x = _make_input(mesh, DIM)
-    shapes, dtypes, input_placements, treespec, devices = _extract_input_info(
-        (x,), mesh
-    )
-    input_fn = _make_input_fn(shapes, dtypes, treespec, devices)
+    input_fn, input_placements = _build_input_fn_from_sample((x,), mesh)
     output_placements = _flatten_out_shardings(_out_shardings(mesh))
 
     with AutoParallel(model, input_fn, mesh) as autop:
@@ -476,16 +468,12 @@ def test_flex_attention_other_buffers_replicated(device_mesh_1d):
 
     from autoparallel.api import AutoParallel
     from autoparallel.input_validation import (
-        _extract_input_info,
+        _build_input_fn_from_sample,
         _flatten_out_shardings,
-        _make_input_fn,
     )
 
     x = _make_input(mesh, DIM)
-    shapes, dtypes, input_placements, treespec, devices = _extract_input_info(
-        (x,), mesh
-    )
-    input_fn = _make_input_fn(shapes, dtypes, treespec, devices)
+    input_fn, input_placements = _build_input_fn_from_sample((x,), mesh)
     output_placements = _flatten_out_shardings(_out_shardings(mesh))
 
     with AutoParallel(model, input_fn, mesh) as autop:

--- a/tests/test_inference_path.py
+++ b/tests/test_inference_path.py
@@ -34,16 +34,12 @@ def _auto_parallel_with_internals(model, mesh, sample_inputs, out_shardings):
     """Like auto_parallel but also returns the AutoParallel instance."""
     from autoparallel.api import (
         AutoParallel,
-        _extract_input_info,
+        _build_input_fn_from_sample,
         _flatten_out_shardings,
-        _make_input_fn,
     )
 
-    shapes, dtypes, input_placements, treespec, devices = _extract_input_info(
-        sample_inputs, mesh
-    )
+    input_fn, input_placements = _build_input_fn_from_sample(sample_inputs, mesh)
     output_placements = _flatten_out_shardings(out_shardings)
-    input_fn = _make_input_fn(shapes, dtypes, treespec, devices)
 
     with AutoParallel(model, input_fn, mesh) as autop:
         autop.add_input_constraints(input_placements)

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -11,6 +11,7 @@ from torch.distributed.tensor.placement_types import Replicate, Shard
 
 from autoparallel.api import auto_parallel
 from autoparallel.input_validation import (
+    TracedInputs,
     _check_forward_args,
     _compute_expected_inputs,
     _extract_input_info,
@@ -60,7 +61,7 @@ def test_compute_expected_inputs(device_mesh_1d):
     traced = [torch.empty(512, 128, device="meta")]
     placements = [(Shard(0),)]
 
-    result, _dynamic_dims = _compute_expected_inputs(traced, placements, mesh)
+    result, _dynamic_dims = _compute_expected_inputs(traced, {}, placements, mesh)
     assert len(result) == 1
     assert result[0].shape == (512 // world_size, 128)
     assert result[0].dtype == torch.float32
@@ -73,7 +74,7 @@ def test_compute_expected_inputs_replicated(device_mesh_1d):
     traced = [torch.empty(512, 128, device="meta")]
     placements = [(Replicate(),)]
 
-    result, _dynamic_dims = _compute_expected_inputs(traced, placements, mesh)
+    result, _dynamic_dims = _compute_expected_inputs(traced, {}, placements, mesh)
     assert len(result) == 1
     assert result[0].shape == (512, 128)
 
@@ -86,7 +87,7 @@ def test_compute_expected_inputs_uneven(device_mesh_2d):
     traced = [torch.empty(10, 128, device="meta")]
     placements = [(Replicate(), Shard(0))]
 
-    result, _dynamic_dims = _compute_expected_inputs(traced, placements, mesh)
+    result, _dynamic_dims = _compute_expected_inputs(traced, {}, placements, mesh)
     assert len(result) == 1
     expected_dim0 = (10 + tp_size - 1) // tp_size  # ceil(10/8) = 2
     assert result[0].shape == (expected_dim0, 128)
@@ -154,7 +155,7 @@ def test_compute_expected_inputs_dict_pytree(device_mesh_1d):
     ]
     constraints = [(Shard(0),), (Shard(0),)]
 
-    result, _dynamic_dims = _compute_expected_inputs(traced, constraints, mesh)
+    result, _dynamic_dims = _compute_expected_inputs(traced, {}, constraints, mesh)
     assert len(result) == 2
     assert result[0].shape == (512 // world_size, 128)
     assert result[1].shape == (512 // world_size, 64)
@@ -240,3 +241,42 @@ def test_dict_input_integration(device_mesh_1d):
     # Validation should reject wrong shape inside a dict
     with pytest.raises(ValueError, match="shape"):
         parallel_mod({"x": torch.rand(local_batch_size + 1, dim, device="cuda")})
+
+
+def test_traced_inputs_defaults_and_frozen():
+    """TracedInputs has empty defaults and is frozen."""
+    ti = TracedInputs()
+    assert ti.args == ()
+    assert ti.kwargs == {}
+
+    ti2 = TracedInputs(args=(1, 2), kwargs={"k": 3})
+    assert ti2.args == (1, 2)
+    assert ti2.kwargs == {"k": 3}
+
+    with pytest.raises(Exception):
+        ti2.args = (4,)  # frozen dataclass forbids reassignment
+
+
+def test_compute_expected_inputs_with_kwargs(device_mesh_1d):
+    """Kwargs leaves contribute placements after positional leaves in dict order."""
+    mesh = device_mesh_1d
+    world_size = mesh.size()
+
+    traced_args = [torch.empty(512, 128, device="meta")]
+    traced_kwargs = {
+        "mask": torch.empty(512, device="meta"),
+        "positions": torch.empty(512, 64, device="meta"),
+    }
+    # Order matches tree_flatten((args, kwargs)): args first, then kwargs in
+    # dict key order.
+    placements = [
+        (Shard(0),),  # traced_args[0]
+        (Shard(0),),  # mask
+        (Replicate(),),  # positions
+    ]
+
+    result, _ = _compute_expected_inputs(traced_args, traced_kwargs, placements, mesh)
+    assert len(result) == 3
+    assert result[0].shape == (512 // world_size, 128)
+    assert result[1].shape == (512 // world_size,)
+    assert result[2].shape == (512, 64)

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -13,9 +13,9 @@ from autoparallel.api import auto_parallel
 from autoparallel.input_validation import (
     ForwardInputs,
     _check_forward_args,
-    _compute_expected_inputs,
     _extract_input_info,
     _make_input_fn,
+    flatten_and_convert_inputs_to_local_shapes,
 )
 
 
@@ -53,7 +53,7 @@ def test_check_forward_args_non_tensor_value():
         _check_forward_args((99,), expected)
 
 
-def test_compute_expected_inputs(device_mesh_1d):
+def test_flatten_and_convert_inputs_to_local_shapes(device_mesh_1d):
     """Test local shape computation from global shape + Shard placement."""
     mesh = device_mesh_1d
     world_size = mesh.size()
@@ -61,7 +61,7 @@ def test_compute_expected_inputs(device_mesh_1d):
     traced = [torch.empty(512, 128, device="meta")]
     placements = [(Shard(0),)]
 
-    result, _dynamic_dims = _compute_expected_inputs(
+    result, _dynamic_dims = flatten_and_convert_inputs_to_local_shapes(
         ForwardInputs(args=tuple(traced)), placements, mesh
     )
     assert len(result) == 1
@@ -69,21 +69,21 @@ def test_compute_expected_inputs(device_mesh_1d):
     assert result[0].dtype == torch.float32
 
 
-def test_compute_expected_inputs_replicated(device_mesh_1d):
+def test_flatten_and_convert_inputs_to_local_shapes_replicated(device_mesh_1d):
     """Test that Replicate placement leaves shape unchanged."""
     mesh = device_mesh_1d
 
     traced = [torch.empty(512, 128, device="meta")]
     placements = [(Replicate(),)]
 
-    result, _dynamic_dims = _compute_expected_inputs(
+    result, _dynamic_dims = flatten_and_convert_inputs_to_local_shapes(
         ForwardInputs(args=tuple(traced)), placements, mesh
     )
     assert len(result) == 1
     assert result[0].shape == (512, 128)
 
 
-def test_compute_expected_inputs_uneven(device_mesh_2d):
+def test_flatten_and_convert_inputs_to_local_shapes_uneven(device_mesh_2d):
     """Uneven shard uses ceiling division for expected local shape."""
     mesh = device_mesh_2d
     tp_size = mesh.size(1)  # 8
@@ -91,7 +91,7 @@ def test_compute_expected_inputs_uneven(device_mesh_2d):
     traced = [torch.empty(10, 128, device="meta")]
     placements = [(Replicate(), Shard(0))]
 
-    result, _dynamic_dims = _compute_expected_inputs(
+    result, _dynamic_dims = flatten_and_convert_inputs_to_local_shapes(
         ForwardInputs(args=tuple(traced)), placements, mesh
     )
     assert len(result) == 1
@@ -146,7 +146,7 @@ def test_forward_input_validation_integration(device_mesh_1d):
         parallel_mod(42)
 
 
-def test_compute_expected_inputs_dict_pytree(device_mesh_1d):
+def test_flatten_and_convert_inputs_to_local_shapes_dict_pytree(device_mesh_1d):
     """Test that dict pytree inputs are flattened before applying sharding."""
     mesh = device_mesh_1d
     world_size = mesh.size()
@@ -161,7 +161,7 @@ def test_compute_expected_inputs_dict_pytree(device_mesh_1d):
     ]
     constraints = [(Shard(0),), (Shard(0),)]
 
-    result, _dynamic_dims = _compute_expected_inputs(
+    result, _dynamic_dims = flatten_and_convert_inputs_to_local_shapes(
         ForwardInputs(args=tuple(traced)), constraints, mesh
     )
     assert len(result) == 2
@@ -192,18 +192,39 @@ def test_make_input_fn_dict_roundtrip(device_mesh_1d):
         "a": torch.rand(4, 8),
         "b": torch.rand(4, 16),
     }
-    shapes, dtypes, _, treespec, devices = _extract_input_info(sample, mesh)
-    input_fn = _make_input_fn(shapes, dtypes, treespec, devices)
+    args_shapes, args_dtypes, _, args_spec, args_devices = _extract_input_info(
+        (sample,), mesh
+    )
+    (
+        kwargs_shapes,
+        kwargs_dtypes,
+        _,
+        kwargs_spec,
+        kwargs_devices,
+    ) = _extract_input_info({}, mesh)
+    input_fn = _make_input_fn(
+        args_shapes,
+        args_dtypes,
+        args_devices,
+        args_spec,
+        kwargs_shapes,
+        kwargs_dtypes,
+        kwargs_devices,
+        kwargs_spec,
+    )
     result = input_fn()
-    # Dict is wrapped in a tuple
-    assert isinstance(result, tuple) and len(result) == 1
-    assert isinstance(result[0], dict)
-    assert set(result[0].keys()) == {"a", "b"}
-    assert result[0]["a"].shape == (4, 8)
-    assert result[0]["b"].shape == (4, 16)
+    assert isinstance(result, ForwardInputs)
+    assert result.kwargs == {}
+    # The dict was a single positional pytree leaf, so args is a 1-tuple
+    # wrapping the dict.
+    assert isinstance(result.args, tuple) and len(result.args) == 1
+    assert isinstance(result.args[0], dict)
+    assert set(result.args[0].keys()) == {"a", "b"}
+    assert result.args[0]["a"].shape == (4, 8)
+    assert result.args[0]["b"].shape == (4, 16)
     # Verify per-tensor devices are preserved
-    assert result[0]["a"].device == torch.device("cpu")
-    assert result[0]["b"].device == torch.device("cpu")
+    assert result.args[0]["a"].device == torch.device("cpu")
+    assert result.args[0]["b"].device == torch.device("cpu")
 
 
 def test_dict_input_integration(device_mesh_1d):
@@ -265,7 +286,7 @@ def test_forward_inputs_defaults_and_frozen():
         ti2.args = (4,)  # frozen dataclass forbids reassignment
 
 
-def test_compute_expected_inputs_with_kwargs(device_mesh_1d):
+def test_flatten_and_convert_inputs_to_local_shapes_with_kwargs(device_mesh_1d):
     """Kwargs leaves contribute placements after positional leaves in dict order."""
     mesh = device_mesh_1d
     world_size = mesh.size()
@@ -285,7 +306,7 @@ def test_compute_expected_inputs_with_kwargs(device_mesh_1d):
         (Replicate(),),  # positions
     ]
 
-    result, _ = _compute_expected_inputs(traced, placements, mesh)
+    result, _ = flatten_and_convert_inputs_to_local_shapes(traced, placements, mesh)
     assert len(result) == 3
     assert result[0].shape == (512 // world_size, 128)
     assert result[1].shape == (512 // world_size,)

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -11,7 +11,7 @@ from torch.distributed.tensor.placement_types import Replicate, Shard
 
 from autoparallel.api import auto_parallel
 from autoparallel.input_validation import (
-    TracedInputs,
+    ForwardInputs,
     _check_forward_args,
     _compute_expected_inputs,
     _extract_input_info,
@@ -61,7 +61,9 @@ def test_compute_expected_inputs(device_mesh_1d):
     traced = [torch.empty(512, 128, device="meta")]
     placements = [(Shard(0),)]
 
-    result, _dynamic_dims = _compute_expected_inputs(traced, {}, placements, mesh)
+    result, _dynamic_dims = _compute_expected_inputs(
+        ForwardInputs(args=tuple(traced)), placements, mesh
+    )
     assert len(result) == 1
     assert result[0].shape == (512 // world_size, 128)
     assert result[0].dtype == torch.float32
@@ -74,7 +76,9 @@ def test_compute_expected_inputs_replicated(device_mesh_1d):
     traced = [torch.empty(512, 128, device="meta")]
     placements = [(Replicate(),)]
 
-    result, _dynamic_dims = _compute_expected_inputs(traced, {}, placements, mesh)
+    result, _dynamic_dims = _compute_expected_inputs(
+        ForwardInputs(args=tuple(traced)), placements, mesh
+    )
     assert len(result) == 1
     assert result[0].shape == (512, 128)
 
@@ -87,7 +91,9 @@ def test_compute_expected_inputs_uneven(device_mesh_2d):
     traced = [torch.empty(10, 128, device="meta")]
     placements = [(Replicate(), Shard(0))]
 
-    result, _dynamic_dims = _compute_expected_inputs(traced, {}, placements, mesh)
+    result, _dynamic_dims = _compute_expected_inputs(
+        ForwardInputs(args=tuple(traced)), placements, mesh
+    )
     assert len(result) == 1
     expected_dim0 = (10 + tp_size - 1) // tp_size  # ceil(10/8) = 2
     assert result[0].shape == (expected_dim0, 128)
@@ -145,7 +151,7 @@ def test_compute_expected_inputs_dict_pytree(device_mesh_1d):
     mesh = device_mesh_1d
     world_size = mesh.size()
 
-    # Simulate traced_inputs containing a dict (as produced by build_joint_graph
+    # Simulate traced inputs containing a dict (as produced by build_joint_graph
     # when the model takes a dict argument)
     traced = [
         {
@@ -155,7 +161,9 @@ def test_compute_expected_inputs_dict_pytree(device_mesh_1d):
     ]
     constraints = [(Shard(0),), (Shard(0),)]
 
-    result, _dynamic_dims = _compute_expected_inputs(traced, {}, constraints, mesh)
+    result, _dynamic_dims = _compute_expected_inputs(
+        ForwardInputs(args=tuple(traced)), constraints, mesh
+    )
     assert len(result) == 2
     assert result[0].shape == (512 // world_size, 128)
     assert result[1].shape == (512 // world_size, 64)
@@ -243,13 +251,13 @@ def test_dict_input_integration(device_mesh_1d):
         parallel_mod({"x": torch.rand(local_batch_size + 1, dim, device="cuda")})
 
 
-def test_traced_inputs_defaults_and_frozen():
-    """TracedInputs has empty defaults and is frozen."""
-    ti = TracedInputs()
+def test_forward_inputs_defaults_and_frozen():
+    """ForwardInputs has empty defaults and is frozen."""
+    ti = ForwardInputs()
     assert ti.args == ()
     assert ti.kwargs == {}
 
-    ti2 = TracedInputs(args=(1, 2), kwargs={"k": 3})
+    ti2 = ForwardInputs(args=(1, 2), kwargs={"k": 3})
     assert ti2.args == (1, 2)
     assert ti2.kwargs == {"k": 3}
 
@@ -262,20 +270,22 @@ def test_compute_expected_inputs_with_kwargs(device_mesh_1d):
     mesh = device_mesh_1d
     world_size = mesh.size()
 
-    traced_args = [torch.empty(512, 128, device="meta")]
-    traced_kwargs = {
-        "mask": torch.empty(512, device="meta"),
-        "positions": torch.empty(512, 64, device="meta"),
-    }
+    traced = ForwardInputs(
+        args=(torch.empty(512, 128, device="meta"),),
+        kwargs={
+            "mask": torch.empty(512, device="meta"),
+            "positions": torch.empty(512, 64, device="meta"),
+        },
+    )
     # Order matches tree_flatten((args, kwargs)): args first, then kwargs in
     # dict key order.
     placements = [
-        (Shard(0),),  # traced_args[0]
+        (Shard(0),),  # args[0]
         (Shard(0),),  # mask
         (Replicate(),),  # positions
     ]
 
-    result, _ = _compute_expected_inputs(traced_args, traced_kwargs, placements, mesh)
+    result, _ = _compute_expected_inputs(traced, placements, mesh)
     assert len(result) == 3
     assert result[0].shape == (512 // world_size, 128)
     assert result[1].shape == (512 // world_size,)


### PR DESCRIPTION
Today AutoParallel's `input_fn` returns a positional tuple that is splatted into the model, so models with keyword-only `forward` parameters — e.g.

```python
def forward(self, tokens, *, attention_masks=None, positions=None):
```

require a positional-arg wrapper before tracing.

This PR adds a small public sentinel, `TracedInputs(args, kwargs)`, that `input_fn` (and `auto_parallel(...)`'s `sample_inputs`) can return to thread keyword arguments through Dynamo and AOT autograd. Existing `input_fn`s (returning a tensor, tuple, or dict pytree) keep their current semantics unchanged — the new path is fully opt-in and backwards-compatible.

Internally we canonicalize to `(args, kwargs)` and rely on `tree_flatten((args, kwargs))` matching the placeholder order produced by `_dynamo_graph_capture_for_export(*args, **kwargs)` and `aot_export_joint_with_descriptors(..., args, kwargs)`. The runtime `forward` wrapper uses `torch.export._tree_utils.reorder_kwargs` so callers may pass kwargs in any order at call time.

Review order

1. `autoparallel/input_validation.py` — new `TracedInputs` dataclass, the extended `_compute_expected_inputs(traced_args, traced_kwargs, ...)` signature, and the new `_make_input_fn_with_kwargs` factory.
2. `autoparallel/api.py` — `build_joint_graph` threads `(args, kwargs)` through both tracing primitives; `AutoParallel` persists `_traced_kwargs`; the runtime `forward` wrapper reorders caller kwargs and calls `parallel_model_fn(*params, *args, **kwargs)` when kwargs were traced (AOT's `unflattened_compiled_fn` requires kwargs by name). The simple `auto_parallel(...)` API gains an additive branch for `TracedInputs` `sample_inputs`.
3. Tests — `tests/test_input_validation.py` (frozen-dataclass + kwargs leaf-order) and `tests/test_api.py` (kwarg-only forward end-to-end, kwarg reorder robustness, positional BC sanity, simple-API `TracedInputs`). Mechanical signature updates in `tests/test_dynamic_shapes.py` and the existing `_compute_expected_inputs` direct-call tests.

Test plan

- [x] `pytest tests/` — 493 passed, 1 xfailed
- [x] `pre-commit run` — black / flake8 / isort / mypy clean on touched files

Authored with Claude.