### PR TITLE
Use upstream DTensor constant pad strategy

### DIFF
--- a/autoparallel/shardings/propagation_rules.py
+++ b/autoparallel/shardings/propagation_rules.py
@@ -738,40 +738,6 @@ def convert_element_type_rule(mesh, op_schema):
     return out_strat
 
 
-@register_rule(torch.ops.aten.constant_pad_nd.default)
-def constant_pad_nd_rule(mesh, op_schema):
-    from torch.distributed.tensor._ops._tensor_ops import (
-        propagate_single_input_strategy,
-    )
-
-    out_strat = propagate_single_input_strategy(op_schema)
-    pad = op_schema.args_schema[1]
-    ndim = len(out_strat.strategies[0].output_specs.tensor_meta.shape)
-    dims_to_remove = [
-        ndim - i - 1
-        for i in range(len(pad) // 2)
-        if pad[i * 2] != 0 or pad[i * 2 + 1] != 0
-    ]
-
-    to_remove = []
-    filtered_strats = []
-    for idx, strat in enumerate(out_strat.strategies):
-        remove_this = False
-        for plc in strat.output_specs.placements:
-            if plc.is_shard() and plc.dim in dims_to_remove:
-                to_remove.append(idx)
-                remove_this = True
-                break
-        if not remove_this:
-            filtered_strats.append(strat)
-
-    for strat in filtered_strats:
-        for idx in to_remove:
-            strat.redistribute_cost[0][idx] = math.inf
-
-    return OpStrategy(filtered_strats)
-
-
 @register_rule(torch.ops.aten.split.Tensor)
 def split_rule(mesh, op_schema):
     strat = op_schema.args_schema


### PR DESCRIPTION
Stacked PRs:
 * #504
 * #503
 * #502
 * #501
 * #500
 * #499
 * #498
 * #497
 * #496
 * #495
 * __->__#494
 * #493
 * #492
 * #491
 * #490


--- --- ---

### Use upstream DTensor constant pad strategy


PyTorch now provides a single-dim strategy for aten.constant_pad_nd.default that bans sharding on padded dimensions, so AutoParallel can remove its local filter rule.

Authored with Claude.
