### PR TITLE
Use upstream DTensor convert strategy

### DIFF
--- a/autoparallel/shardings/propagation_rules.py
+++ b/autoparallel/shardings/propagation_rules.py
@@ -723,13 +723,8 @@ def native_layer_norm_backward_rule(mesh, op_schema):
     return OpStrategy(kept)
 
 
-@register_rule(
-    [
-        torch.ops.prims.convert_element_type.default,
-        torch.ops.autoparallel.dtype_cast.default,
-    ]
-)
-def convert_element_type_rule(mesh, op_schema):
+@register_rule(torch.ops.autoparallel.dtype_cast.default)
+def dtype_cast_rule(mesh, op_schema):
     from torch.distributed.tensor._ops._tensor_ops import (
         propagate_single_input_strategy,
     )


### PR DESCRIPTION
Stacked PRs:
 * #504
 * #503
 * #502
 * #501
 * #500
 * #499
 * #498
 * #497
 * #496
 * __->__#495
 * #494
 * #493
 * #492
 * #491
 * #490


--- --- ---

### Use upstream DTensor convert strategy


PyTorch now provides a single-dim strategy for prims.convert_element_type.default, so AutoParallel only needs to keep the local propagation rule for its custom dtype_cast op.

Authored with Claude.
