### PR TITLE
Use upstream DTensor diagonal scatter strategy

### DIFF
--- a/autoparallel/shardings/propagation_rules.py
+++ b/autoparallel/shardings/propagation_rules.py
@@ -1031,39 +1031,6 @@ def uniform_strategy(mesh, op_schema: OpSchema):
 # Scatter ops
 
 
-@register_rule(torch.ops.aten.diagonal_scatter.default)
-def diagonal_scatter_strategy(mesh, op_schema: OpSchema):
-    from torch.distributed.tensor._ops.utils import (
-        expand_to_full_mesh_op_strategy,
-        normalize_dim,
-    )
-
-    input_strategy = op_schema.args_schema[0]
-    assert isinstance(input_strategy, OpStrategy)
-    ndim = input_strategy.ndim
-
-    dim1 = op_schema.args_schema[3] if len(op_schema.args_schema) > 3 else 0
-    dim2 = op_schema.args_schema[4] if len(op_schema.args_schema) > 4 else 1
-    assert isinstance(dim1, int)
-    assert isinstance(dim2, int)
-    dim1 = normalize_dim(dim1, ndim)
-    dim2 = normalize_dim(dim2, ndim)
-    min_d, max_d = min(dim1, dim2), max(dim1, dim2)
-
-    # [output, input, src]
-    single_mesh_dim_strategies: list[list[Placement | None]] = [[Replicate()] * 3]
-    for d in range(ndim):
-        if d == dim1 or d == dim2:
-            continue
-        # src shape has dim1/dim2 removed, diagonal appended
-        removed = (1 if d > min_d else 0) + (1 if d > max_d else 0)
-        single_mesh_dim_strategies.append([Shard(d), Shard(d), Shard(d - removed)])
-
-    return expand_to_full_mesh_op_strategy(
-        mesh, op_schema, single_mesh_dim_strategies, input_index=1
-    )
-
-
 @register_rule(torch.ops.aten.select_scatter.default)
 def select_scatter_strategy(mesh, op_schema: OpSchema):
     from torch.distributed.tensor._ops.utils import (


### PR DESCRIPTION
Stacked PRs:
 * #504
 * #503
 * #502
 * #501
 * #500
 * #499
 * #498
 * #497
 * __->__#496
 * #495
 * #494
 * #493
 * #492
 * #491
 * #490


--- --- ---

### Use upstream DTensor diagonal scatter strategy


PyTorch now provides a single-dim strategy for aten.diagonal_scatter.default with the same non-diagonal sharding mapping, so AutoParallel can remove its local rule.

Authored with Claude.
