### PR TITLE
Use upstream DTensor scatter strategy

### DIFF
--- a/autoparallel/shardings/propagation_rules.py
+++ b/autoparallel/shardings/propagation_rules.py
@@ -653,45 +653,6 @@ def einsum_rule(mesh, op_schema):
     return out_strat
 
 
-@register_rule(torch.ops.aten.scatter.src)
-def scatter_strategy(mesh, op_schema: OpSchema):
-    # taken from scatter_add strategy from PyTorch
-    from torch.distributed.tensor._ops._tensor_ops import (
-        PlacementList,
-        expand_to_full_mesh_op_strategy,
-        normalize_dim,
-    )
-
-    input_strategy = op_schema.args_schema[0]
-    dim = op_schema.args_schema[1]
-    index_strategy = op_schema.args_schema[2]
-
-    assert isinstance(input_strategy, OpStrategy)
-    assert isinstance(index_strategy, OpStrategy)
-    assert isinstance(dim, int)
-    dim = normalize_dim(dim, input_strategy.ndim)
-    mesh = input_strategy.mesh
-    input_shape = input_strategy.shape
-    index_shape = index_strategy.shape
-
-    single_mesh_dim_strategies = []
-
-    # placement list stores placements of [output, input, index, src]
-    # first we always have replicate all for inputs and output
-    all_replicate: PlacementList = [Replicate()] * 4
-    single_mesh_dim_strategies.append(all_replicate)
-
-    if len(input_shape) == len(index_shape):
-        for d in range(len(input_shape)):
-            if d != dim and input_shape[d] == index_shape[d]:
-                sharding: PlacementList = [Shard(d), Shard(d), Shard(d), Shard(d)]
-                single_mesh_dim_strategies.append(sharding)
-
-    return expand_to_full_mesh_op_strategy(
-        mesh, op_schema, single_mesh_dim_strategies, input_index=1
-    )
-
-
 @register_rule(torch.ops.aten.stack.default)
 def stack_strategy(mesh, op_schema: OpSchema):
     from torch.distributed.tensor._ops._tensor_ops import (


### PR DESCRIPTION
Stacked PRs:
 * #504
 * #503
 * __->__#502
 * #501
 * #500
 * #499
 * #498
 * #497
 * #496
 * #495
 * #494
 * #493
 * #492
 * #491
 * #490


--- --- ---

### Use upstream DTensor scatter strategy


PyTorch now provides a scatter.src strategy that preserves AutoParallel's local sharding cases and also validates src shape compatibility, so the local scatter rule can be removed.

Authored with Claude.
