### PR TITLE
Emit autoparallel solution as a TORCH_TRACE artifact

### DIFF
--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -54,7 +54,7 @@ jobs:
         pip install --quiet .
         run_timed() { local start=$SECONDS; "$@"; echo "$* : $((SECONDS - start))s" >> /tmp/timings.txt; }
         run_timed python examples/example_autoparallel.py
-        run_timed python examples/example_llama3.py
+        run_timed env AUTOPARALLEL_VERBOSE=1 python examples/example_llama3.py
         run_timed python examples/example_local_map.py
         echo "========== Timings =========="
         cat /tmp/timings.txt

--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import copy
+import json
 import logging
 import operator
 import time
@@ -397,7 +398,7 @@ class AutoParallel:
         self.sharding_optimizer.add_sharded_output_constraint(constraints)
         self.output_constraints = constraints
 
-    def optimize_placement(self, verbose=True):
+    def optimize_placement(self, verbose=False):
         self._assert_entered()
 
         self.sharding_placement = self.sharding_optimizer.get_solution(verbose=False)
@@ -425,6 +426,15 @@ class AutoParallel:
                 "constraints, and consider relaxing input/output constraints or "
                 "using a larger mesh."
             )
+
+        trace_structured(
+            "artifact",
+            metadata_fn=lambda: {
+                "name": "autoparallel_solution",
+                "encoding": "json",
+            },
+            payload_fn=lambda: json.dumps(self.sharding_optimizer.get_json()),
+        )
 
         return self.sharding_placement
 

--- a/examples/example_hf.py
+++ b/examples/example_hf.py
@@ -23,6 +23,7 @@ Usage:
 import argparse
 import logging
 import math
+import os
 import time
 
 import torch
@@ -170,7 +171,9 @@ def main():
         autop.add_input_constraints(input_constraints)
         autop.add_parameter_memory_constraint(low=None, high=None)
 
-        sharding_placement = autop.optimize_placement(verbose=True)
+        sharding_placement = autop.optimize_placement(
+            verbose=bool(int(os.environ.get("AUTOPARALLEL_VERBOSE", "0")))
+        )
         parallel_mod = autop.apply_placement(sharding_placement)
 
     print(f"\nAutoParallel pipeline completed in {time.time() - t0:.2f}s")

--- a/examples/example_llama3.py
+++ b/examples/example_llama3.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
+import os
 import time
 from functools import partial
 
@@ -259,7 +260,9 @@ with AutoParallel(model, input_fn, mesh, mp_policy, repeated_subgraphs=True) as 
         torch._inductor.config.post_grad_custom_post_pass = _pass
 
     t = time.time()
-    sharding_placement = autop.optimize_placement(verbose=True)
+    sharding_placement = autop.optimize_placement(
+        verbose=bool(int(os.environ.get("AUTOPARALLEL_VERBOSE", "0")))
+    )
     print(f"Took {time.time() - t:.2f} s")
     parallel_mod = autop.apply_placement(sharding_placement)
 


### PR DESCRIPTION
Adds a structured `autoparallel_solution` artifact (JSON payload of `ShardingOptimizer.get_json()`) emitted via `trace_structured` right after a feasible ILP solve, so the optimizer solution is captured next to the FX graph and optimizer log in tlparse without any manual `save()` call. Emission is skipped on infeasible solves (the existing optimizer-log artifact still fires, which is what's useful for debugging an infeasibility).

Since the optimizer log is now always available through tlparse, `optimize_placement`'s `verbose` default flips to `False` to keep normal runs quiet. Examples that previously hardcoded `verbose=True` (`example_llama3.py`, `example_hf.py`) now read an `AUTOPARALLEL_VERBOSE` env var, and CI sets `AUTOPARALLEL_VERBOSE=1` on `example_llama3.py` so the stdout log is preserved in CI output.

Authored with Claude.