### PR TITLE
Support context-parallel local_map in AutoParallel

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -50,6 +50,7 @@ from .optimize_sharding import ShardingOptimizer
 from .shardings.placement_options import _get_device_from_mesh
 from .tracing import (
     _add_unused_params_and_buffers,
+    _enable_local_map_in_grad_placements,
     _get_decomp_table,
     enable_local_map_wrapping,
     move_to_fake,
@@ -461,7 +462,7 @@ class AutoParallel:
             mesh = self.mesh
             if mesh.ndim != 1:
                 mesh._flatten()
-        with self.fake_mode:
+        with self.fake_mode, _enable_local_map_in_grad_placements():
             (
                 parallel_gm,
                 sharded_param_dict,

--- a/autoparallel/context_parallel.py
+++ b/autoparallel/context_parallel.py
@@ -1,0 +1,211 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+from typing import Callable
+
+import torch
+import torch.nn.functional as F
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor.placement_types import (
+    Partial,
+    Placement,
+    Replicate,
+    Shard,
+)
+
+from .collectives import local_map
+
+_DP_REPLICATE_NAMES = {"dp_replicate", "ddp"}
+_DP_SHARD_NAMES = {"dp", "dp_shard", "fsdp", "data", "data_parallel"}
+_CP_NAMES = {"cp", "context", "context_parallel"}
+_TP_NAMES = {"tp", "tensor", "tensor_parallel"}
+
+
+@dataclass(frozen=True)
+class ContextParallelPlacements:
+    """Placement groups for context-parallel attention."""
+
+    q: tuple[Placement, ...]
+    kv: tuple[Placement, ...]
+    out: tuple[Placement, ...]
+    q_grad: tuple[Placement, ...]
+    kv_grad: tuple[Placement, ...]
+
+    @property
+    def in_placements(self) -> tuple[tuple[Placement, ...], ...]:
+        return (self.q, self.kv, self.kv)
+
+    @property
+    def out_placements(self) -> tuple[tuple[Placement, ...], ...]:
+        return (self.out,)
+
+    @property
+    def in_grad_placements(self) -> tuple[tuple[Placement, ...], ...]:
+        return (self.q_grad, self.kv_grad, self.kv_grad)
+
+
+def _mesh_dim_names(mesh: DeviceMesh) -> tuple[str, ...]:
+    names = getattr(mesh, "mesh_dim_names", None)
+    if names is not None and all(name is not None for name in names):
+        return tuple(names)
+
+    # 2-D meshes are ambiguous: [dp_shard, cp] and [dp_shard, tp] both
+    # matter for CP. Require names there so K/V are not silently misplaced.
+    if mesh.ndim == 3:
+        return ("dp_shard", "cp", "tp")
+    if mesh.ndim == 4:
+        return ("dp_replicate", "dp_shard", "cp", "tp")
+    raise ValueError(
+        "context_parallel_attention_placements requires mesh_dim_names for "
+        "1-D/2-D meshes. Use names such as ('dp_shard', 'cp') or "
+        "('dp_shard', 'tp')."
+    )
+
+
+def _mesh_axis_role(name: str) -> str:
+    normalized = name.lower()
+    if normalized in _DP_REPLICATE_NAMES:
+        return "dp_replicate"
+    if normalized in _DP_SHARD_NAMES:
+        return "dp_shard"
+    if normalized in _CP_NAMES:
+        return "cp"
+    if normalized in _TP_NAMES:
+        return "tp"
+    raise ValueError(
+        f"Unsupported mesh axis {name!r} for context parallel attention. "
+        "Expected axes like dp_shard/dp, cp, tp, and optionally dp_replicate."
+    )
+
+
+def context_parallel_attention_placements(
+    mesh: DeviceMesh,
+    *,
+    batch_dim: int = 0,
+    seq_dim: int = 1,
+    head_dim: int = 2,
+) -> ContextParallelPlacements:
+    """Return attention placements for the given mesh.
+
+    Args:
+        mesh: Device mesh with named DP, CP, and/or TP dimensions.
+        batch_dim: Batch dimension in Q/K/V tensors.
+        seq_dim: Sequence dimension in Q/K/V tensors.
+        head_dim: Head dimension in Q/K/V tensors.
+    """
+
+    q: list[Placement] = []
+    kv: list[Placement] = []
+    q_grad: list[Placement] = []
+    kv_grad: list[Placement] = []
+
+    for name in _mesh_dim_names(mesh):
+        role = _mesh_axis_role(name)
+        if role in ("dp_replicate", "dp_shard"):
+            q_p = kv_p = q_grad_p = kv_grad_p = Shard(batch_dim)
+        elif role == "cp":
+            q_p = q_grad_p = Shard(seq_dim)
+            kv_p = Replicate()
+            kv_grad_p = Partial()
+        elif role == "tp":
+            q_p = kv_p = q_grad_p = kv_grad_p = Shard(head_dim)
+
+        q.append(q_p)
+        kv.append(kv_p)
+        q_grad.append(q_grad_p)
+        kv_grad.append(kv_grad_p)
+
+    q_t = tuple(q)
+    return ContextParallelPlacements(
+        q=q_t,
+        kv=tuple(kv),
+        out=q_t,
+        q_grad=tuple(q_grad),
+        kv_grad=tuple(kv_grad),
+    )
+
+
+def context_parallel_local_map(
+    fn: Callable | None = None,
+    *,
+    mesh: DeviceMesh,
+    batch_dim: int = 0,
+    seq_dim: int = 1,
+    head_dim: int = 2,
+    redistribute_inputs: bool = True,
+):
+    """Wrap an attention callable with context-parallel placements.
+
+    Args:
+        fn: Callable whose first three arguments are Q, K, and V tensors.
+        mesh: Device mesh with named DP, CP, and/or TP dimensions.
+        batch_dim: Batch dimension in Q/K/V tensors.
+        seq_dim: Sequence dimension in Q/K/V tensors.
+        head_dim: Head dimension in Q/K/V tensors.
+        redistribute_inputs: Whether to redistribute inputs to the requested
+            placements.
+    """
+
+    placements = context_parallel_attention_placements(
+        mesh, batch_dim=batch_dim, seq_dim=seq_dim, head_dim=head_dim
+    )
+
+    def wrap(inner_fn: Callable):
+        return local_map(
+            inner_fn,
+            out_placements=placements.out_placements,
+            in_placements=placements.in_placements,
+            redistribute_inputs=redistribute_inputs,
+            in_grad_placements=placements.in_grad_placements,
+            device_mesh=mesh,
+        )
+
+    if fn is None:
+        return wrap
+    return wrap(fn)
+
+
+def make_context_parallel_sdpa(
+    mesh: DeviceMesh,
+    *,
+    batch_dim: int = 0,
+    seq_dim: int = 2,
+    head_dim: int = 1,
+    is_causal: bool = True,
+    dropout_p: float = 0.0,
+    scale: float | None = None,
+    enable_gqa: bool = False,
+):
+    """Build a context-parallel SDPA callable.
+
+    Args:
+        mesh: Device mesh with named DP, CP, and/or TP dimensions.
+        batch_dim: Batch dimension in Q/K/V tensors.
+        seq_dim: Sequence dimension in Q/K/V tensors.
+        head_dim: Head dimension in Q/K/V tensors.
+        is_causal: Whether SDPA applies a causal mask.
+        dropout_p: Dropout probability for SDPA.
+        scale: Optional SDPA scale value.
+        enable_gqa: Whether SDPA uses grouped query attention.
+    """
+
+    @context_parallel_local_map(
+        mesh=mesh,
+        batch_dim=batch_dim,
+        seq_dim=seq_dim,
+        head_dim=head_dim,
+    )
+    def _context_parallel_sdpa(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor):
+        kwargs = {
+            "is_causal": is_causal,
+            "dropout_p": dropout_p,
+            "enable_gqa": enable_gqa,
+        }
+        if scale is not None:
+            kwargs["scale"] = scale
+        return F.scaled_dot_product_attention(q, k, v, **kwargs)
+
+    return _context_parallel_sdpa

--- a/autoparallel/shardings/placement_options.py
+++ b/autoparallel/shardings/placement_options.py
@@ -390,16 +390,11 @@ def get_local_map_placement_option(
     out_placements = local_map_kwargs["out_placements"]
     assert in_placements is not None
     assert out_placements is not None
-    assert (
-        local_map_kwargs.get("in_grad_placements", None) is None
-    ), "Not yet implemented"
     assert local_map_kwargs.get("device_mesh", None) in (
         mesh,
         None,
     ), "Not yet implemented"
-    assert "call_local_map" in str(node.target) or "call_local_map_backward" in str(
-        node.target
-    )
+    assert "local_map" in str(node.target)
     in_specs = []
     num_activation_inputs = len(user_args) - len(in_placements)
     # activations are always replicated

--- a/autoparallel/tracing.py
+++ b/autoparallel/tracing.py
@@ -86,13 +86,67 @@ def move_to_fake(model: torch.nn.Module, mode: FakeTensorMode, device: torch.dev
 
 
 @contextmanager
+def _enable_local_map_in_grad_placements():
+    from torch._higher_order_ops import local_map as local_map_module
+
+    autograd_key = torch._C.DispatchKey.Autograd
+    local_map_hop = local_map_module.local_map_hop
+    orig_autograd_impl = local_map_hop.py_kernels[autograd_key]
+    orig_create_hop_fw_bw = local_map_module.create_hop_fw_bw
+
+    def create_hop_fw_bw_with_in_grad(fw_gm, *args):
+        result = orig_create_hop_fw_bw(fw_gm, *args)
+        _fw_gm, bw_gm, *_rest = result
+        local_map_kwargs = fw_gm.meta["local_map_kwargs"]
+        in_grad_placements = local_map_kwargs.get("in_grad_placements")
+        if in_grad_placements is not None:
+            bw_gm.meta["local_map_kwargs"]["out_placements"] = in_grad_placements
+        return result
+
+    def autograd_impl_with_in_grad(fw_gm, *args, **kwargs):
+        if local_map_module._DEFER_INLINING:
+            (
+                fw_gm,
+                bw_gm,
+                num_fw_ins,
+                num_fw_outs,
+                filtered_grads_idx,
+            ) = local_map_module.create_hop_fw_bw(fw_gm, *args)
+            return local_map_module.LocalMapAutogradOp.apply(
+                fw_gm,
+                bw_gm,
+                num_fw_ins,
+                num_fw_outs,
+                filtered_grads_idx,
+                *args,
+                **kwargs,
+            )
+
+        return torch.fx.Interpreter(fw_gm).run(*args, **kwargs)
+
+    try:
+        local_map_module.create_hop_fw_bw = create_hop_fw_bw_with_in_grad
+        local_map_hop.py_kernels[autograd_key] = autograd_impl_with_in_grad
+        local_map_hop._dispatch_cache.clear()
+        yield
+    finally:
+        local_map_module.create_hop_fw_bw = orig_create_hop_fw_bw
+        local_map_hop.py_kernels[autograd_key] = orig_autograd_impl
+        local_map_hop._dispatch_cache.clear()
+
+
+@contextmanager
 def enable_local_map_wrapping():
     from torch._dynamo.variables.higher_order_ops import (
         LocalMapWrappedHigherOrderVariable as vt_cls,
     )
     from torch._higher_order_ops import local_map as local_map_module
 
-    with vt_cls.enable(), local_map_module.defer_inlining():
+    with (
+        vt_cls.enable(),
+        local_map_module.defer_inlining(),
+        _enable_local_map_in_grad_placements(),
+    ):
         yield
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,8 +20,10 @@ If you're new to the project, use the reading order below.
 
 - [How AutoParallel Chooses a Strategy](how_autoparallel_chooses_a_strategy.md)
 - [Adaptive Sharding: Sequence-Parallel vs Column-Parallel](adaptive_sharding.md)
+- [Context Parallel Local Map Design](context_parallel_design.md)
 
 ## Advanced usage
 
 - [Using `local_map` for MoE and Custom Communication Patterns](local_map_and_moe.md)
+- [Context Parallel Attention](context_parallel.md)
 - [Saving and Loading Optimizer State](save_load.md)

--- a/docs/context_parallel.md
+++ b/docs/context_parallel.md
@@ -1,0 +1,90 @@
+# Context Parallel Attention
+
+Context Parallel (CP) shards the sequence dimension across a mesh axis. Each
+rank computes attention for its local query slice while using full-sequence
+keys and values.
+
+AutoParallel provides helpers for wrapping local attention kernels with the
+placements needed for CP:
+
+```python
+import torch
+
+from autoparallel.context_parallel import make_context_parallel_sdpa
+
+mesh = torch.distributed.device_mesh.init_device_mesh(
+    "cuda",
+    (dp_size, cp_size, tp_size),
+    mesh_dim_names=("dp_shard", "cp", "tp"),
+)
+
+cp_sdpa = make_context_parallel_sdpa(mesh, is_causal=True)
+out = cp_sdpa(q, k, v)
+```
+
+The SDPA helper expects tensors in `(B, H, S, D)` layout by default:
+
+- `B`: batch
+- `H`: attention heads
+- `S`: sequence
+- `D`: head dimension
+
+The default placements are:
+
+| Mesh axis | Q placement | K/V placement | Output placement |
+|---|---|---|---|
+| `dp_shard` | `Shard(B)` | `Shard(B)` | `Shard(B)` |
+| `cp` | `Shard(S)` | `Replicate()` | `Shard(S)` |
+| `tp` | `Shard(H)` | `Shard(H)` | `Shard(H)` |
+
+For Torchtitan-style `(B, L, N, H)` tensors, use:
+
+```python
+from autoparallel.context_parallel import context_parallel_local_map
+
+
+@context_parallel_local_map(mesh=mesh, batch_dim=0, seq_dim=1, head_dim=2)
+def inner_attention(q, k, v):
+    ...
+```
+
+## Supported Meshes
+
+The helpers recognize these mesh axis names:
+
+- DP shard: `dp`, `dp_shard`, `fsdp`, `data`, `data_parallel`
+- DP replicate: `dp_replicate`, `ddp`
+- CP: `cp`, `context`, `context_parallel`
+- TP: `tp`, `tensor`, `tensor_parallel`
+
+Common layouts:
+
+```text
+("dp_shard", "cp")
+("dp_shard", "tp")
+("dp_shard", "cp", "tp")
+("dp_replicate", "dp_shard", "cp", "tp")
+```
+
+For 1D and 2D meshes, pass `mesh_dim_names`. A 2D mesh can mean either
+`("dp_shard", "cp")` or `("dp_shard", "tp")`, and the CP helper needs the
+names to select the correct placements.
+
+## Gradient Placements
+
+CP attention has asymmetric gradient placements on the CP axis:
+
+| Tensor | Forward CP placement | Gradient CP placement |
+|---|---|---|
+| Q | `Shard(sequence)` | `Shard(sequence)` |
+| K | `Replicate()` | `Partial()` |
+| V | `Replicate()` | `Partial()` |
+
+K and V are replicated in forward because each query shard attends to the full
+key/value sequence. In backward, each CP rank computes only the gradient
+contribution from its local query shard. The full K/V gradients are the sum of
+those per-rank contributions, so the local gradients are `Partial()`.
+
+The CP helpers pass these gradient placements through `local_map` so
+AutoParallel can insert the required reductions when gradients leave the local
+attention region.

--- a/docs/context_parallel_design.md
+++ b/docs/context_parallel_design.md
@@ -1,0 +1,114 @@
+# Context Parallel Local Map Design
+
+This note explains the AutoParallel changes that make Context Parallel (CP)
+attention work through `local_map`.
+
+## Background
+
+`local_map` lets a model mark a region that runs on local tensors while the
+surrounding graph still has DTensor placements. AutoParallel traces these
+regions as `local_map_hop` boundaries so the optimizer can reason about the
+region's input and output placements.
+
+CP attention needs one placement distinction that existing AutoParallel support
+did not model:
+
+```text
+K/V forward input placement: Replicate on CP
+K/V input gradient placement: Partial on CP
+```
+
+This differs from MoE Expert Parallel local-map regions, where the backward
+input-gradient placements can follow the forward input placements.
+
+## Previous Unsupported Path
+
+The unsupported path was specific to PyTorch's `local_map_hop` autograd path.
+Ordinary DTensor `local_map` already supports `in_grad_placements` by calling
+`to_local(grad_placements=...)`.
+
+`local_map_hop` did two incompatible things:
+
+1. It rejected any local-map region with `in_grad_placements`.
+2. Its generated backward graph interpreted input gradients using the forward
+   input placements.
+
+The second behavior is wrong for CP K/V gradients. The backward local-map
+outputs are gradients for the forward inputs, so their placements must be the
+declared `in_grad_placements` when present.
+
+AutoParallel also had an optimizer-side assertion that rejected
+`in_grad_placements` metadata before strategy construction.
+
+## Implementation
+
+The support has three pieces.
+
+### HOP Autograd Shim
+
+`autoparallel.tracing._enable_local_map_in_grad_placements()` temporarily
+patches the PyTorch `local_map_hop` autograd implementation while
+AutoParallel is tracing or applying placements.
+
+The shim keeps PyTorch's existing forward/backward graph construction, then
+rewrites the backward local-map metadata:
+
+```text
+backward out_placements = forward in_grad_placements
+```
+
+when `in_grad_placements` is provided.
+
+This is scoped to AutoParallel's tracing/apply-placement contexts and restores
+the original PyTorch functions when the context exits.
+
+### Placement Option Support
+
+`get_local_map_placement_option()` no longer rejects
+`in_grad_placements`. It continues to consume `in_placements` and
+`out_placements` from the HOP metadata. For backward local-map HOPs, the shim
+has already made `out_placements` reflect `in_grad_placements`.
+
+This keeps CP semantics out of the generic placement-option code.
+
+### CP Helper
+
+`autoparallel.context_parallel` provides placement helpers for attention
+regions. For the CP axis:
+
+```text
+Q forward: Shard(sequence)
+Q grad:    Shard(sequence)
+
+K/V forward: Replicate
+K/V grad:    Partial
+```
+
+The helpers support 2D, 3D, and 4D meshes with named DP, CP, and TP axes.
+
+## Why This Matches Torchtitan
+
+Torchtitan full-DTensor CP declares the same local-map contract for attention:
+Q remains sequence-sharded, K/V are gathered for the forward kernel, and K/V
+gradients are partial contributions across CP ranks.
+
+The difference is tracing mode. Torchtitan normally uses ordinary DTensor
+`local_map` semantics. AutoParallel uses `local_map_hop` to preserve a graph
+boundary for placement analysis, so AutoParallel needs the HOP-specific
+metadata fix described above.
+
+## Testing
+
+The CP test is end-to-end. It runs AutoParallel tracing, optimization, and
+placement application, executes the resulting graph under `LocalTensorMode`,
+and compares both forward outputs and Q/K/V gradients against a non-CP SDPA
+reference.
+
+Covered mesh layouts:
+
+```text
+("dp_shard", "cp", "tp")
+("dp_shard", "cp")
+("dp_shard", "tp")
+("dp_replicate", "dp_shard", "cp", "tp")
+```

--- a/tests/test_context_parallel.py
+++ b/tests/test_context_parallel.py
@@ -1,0 +1,115 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from test_correctness import run_correctness_test
+from torch.distributed.tensor.placement_types import Shard
+
+from autoparallel.context_parallel import make_context_parallel_sdpa
+
+
+class AttentionKernel(nn.Module):
+    def __init__(self, mesh):
+        super().__init__()
+        self.cp_sdpa = (
+            make_context_parallel_sdpa(mesh, is_causal=False)
+            if mesh is not None
+            else None
+        )
+
+    def forward(self, q, k, v):
+        if self.cp_sdpa is None:
+            return F.scaled_dot_product_attention(q, k, v, is_causal=False)
+        return self.cp_sdpa(q, k, v)
+
+
+@pytest.mark.parametrize(
+    "mesh_shape,mesh_dim_names,qkv_placements",
+    (
+        (
+            (2, 2, 2),
+            ("dp_shard", "cp", "tp"),
+            (Shard(0), Shard(2), Shard(1)),
+        ),
+        (
+            (2, 2),
+            ("dp_shard", "cp"),
+            (Shard(0), Shard(2)),
+        ),
+        (
+            (2, 2),
+            ("dp_shard", "tp"),
+            (Shard(0), Shard(1)),
+        ),
+        (
+            (2, 2, 2, 2),
+            ("dp_replicate", "dp_shard", "cp", "tp"),
+            (Shard(0), Shard(0), Shard(2), Shard(1)),
+        ),
+    ),
+)
+def test_context_parallel_attention_correctness(
+    mesh_shape,
+    mesh_dim_names,
+    qkv_placements,
+):
+    batch_size = 8
+    nheads = 4
+    seq_len = 8
+    head_dim = 4
+
+    mesh = torch.distributed.device_mesh.init_device_mesh(
+        "cuda", mesh_shape, mesh_dim_names=mesh_dim_names
+    )
+
+    def model_fn():
+        return AttentionKernel(mesh)
+
+    def reference_model_fn():
+        return AttentionKernel(None)
+
+    def input_fn():
+        return (
+            torch.randn(
+                batch_size,
+                nheads,
+                seq_len,
+                head_dim,
+                device="cuda",
+                requires_grad=True,
+            ),
+            torch.randn(
+                batch_size,
+                nheads,
+                seq_len,
+                head_dim,
+                device="cuda",
+                requires_grad=True,
+            ),
+            torch.randn(
+                batch_size,
+                nheads,
+                seq_len,
+                head_dim,
+                device="cuda",
+                requires_grad=True,
+            ),
+        )
+
+    run_correctness_test(
+        model_fn,
+        input_fn,
+        mesh_shape,
+        mesh_dim_names=mesh_dim_names,
+        input_placements=(qkv_placements, qkv_placements, qkv_placements),
+        output_placements=qkv_placements,
+        reference_model_fn=reference_model_fn,
+        parameter_memory_constraint=False,
+        atol=1e-4,
+        rtol=1e-4,
+    )

--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -42,7 +42,7 @@ from torch.distributed._local_tensor import (
 )
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.distributed_c10d import ProcessGroup
-from torch.distributed.tensor.placement_types import Replicate, Shard
+from torch.distributed.tensor.placement_types import Placement, Replicate, Shard
 from torch.testing._internal.distributed.fake_pg import FakeStore
 
 from autoparallel.api import AutoParallel
@@ -215,21 +215,41 @@ def _patch_local_tensor_for_compile_on_one_rank():
 
 
 @apply_cuda_patches
-def _get_parallel_graph_and_placements(model_fn, input_fn, mesh):
+def _get_parallel_graph_and_placements(
+    model_fn,
+    input_fn,
+    mesh,
+    input_placements=None,
+    output_placements=None,
+    parameter_memory_constraint=True,
+):
     """Run AutoParallel and extract the parallel graph + placement info.
 
-    Always uses dynamic=True (required for compile_on_one_rank) and adds
+    Always uses dynamic=True (required for compile_on_one_rank). Tests may add
     a parameter memory constraint to force parameter sharding.
     """
     with torch.device("meta"):
         meta_model = model_fn()
 
-    x_sharding = (Shard(0),) + (Replicate(),) * (mesh.ndim - 1)
+    if input_placements is None:
+        input_constraints = [(Shard(0),) + (Replicate(),) * (mesh.ndim - 1)]
+    elif isinstance(input_placements[0], Placement):
+        input_constraints = [input_placements]
+    else:
+        input_constraints = list(input_placements)
+
+    if output_placements is None:
+        output_constraints = [(Shard(0),) + (Replicate(),) * (mesh.ndim - 1)]
+    elif isinstance(output_placements[0], Placement):
+        output_constraints = [output_placements]
+    else:
+        output_constraints = list(output_placements)
 
     with AutoParallel(meta_model, input_fn, mesh, dynamic=True) as autop:
-        autop.add_input_constraints([x_sharding])
-        autop.add_output_constraints([x_sharding])
-        autop.add_parameter_memory_constraint()
+        autop.add_input_constraints(input_constraints)
+        autop.add_output_constraints(output_constraints)
+        if parameter_memory_constraint:
+            autop.add_parameter_memory_constraint()
         sharding_placement = autop.optimize_placement(verbose=False)
         autop._apply_placement_common(sharding_placement)
 
@@ -268,10 +288,15 @@ def _get_parallel_graph_and_placements(model_fn, input_fn, mesh):
     )
 
 
-def _run_correctness_test(
+def run_correctness_test(
     model_fn,
     input_fn,
     mesh_shape,
+    mesh_dim_names=None,
+    input_placements=None,
+    output_placements=None,
+    reference_model_fn=None,
+    parameter_memory_constraint=True,
     atol=1e-5,
     rtol=1e-5,
 ):
@@ -294,7 +319,11 @@ def _run_correctness_test(
             "fake", store=fake_store, rank=0, world_size=256
         )
 
-    if len(mesh_shape) == 1:
+    if mesh_dim_names is not None:
+        mesh = torch.distributed.device_mesh.init_device_mesh(
+            "cuda", mesh_shape, mesh_dim_names=mesh_dim_names
+        )
+    elif len(mesh_shape) == 1:
         mesh = torch.distributed.device_mesh.init_device_mesh(
             "cuda", mesh_shape, mesh_dim_names=("dp",)
         )
@@ -305,7 +334,8 @@ def _run_correctness_test(
 
     # --- Reference forward + backward on CUDA ---
     torch.manual_seed(42)
-    model = model_fn().cuda()
+    ref_model_fn = reference_model_fn or model_fn
+    model = ref_model_fn().cuda()
     ref_inputs = input_fn()
     if not isinstance(ref_inputs, (tuple, list)):
         ref_inputs = (ref_inputs,)
@@ -331,7 +361,14 @@ def _run_correctness_test(
             param_fqns,
             buffer_fqns,
             num_user_inputs,
-        ) = _get_parallel_graph_and_placements(model_fn, tracing_input_fn, mesh)
+        ) = _get_parallel_graph_and_placements(
+            model_fn,
+            tracing_input_fn,
+            mesh,
+            input_placements=input_placements,
+            output_placements=output_placements,
+            parameter_memory_constraint=parameter_memory_constraint,
+        )
 
     # --- Build LocalTensor primals and tangents ---
     num_params = len(param_fqns)
@@ -361,8 +398,8 @@ def _run_correctness_test(
         local_primals.append(LocalTensor(shards))
 
     # Tangents: the grad_output sharded like the forward output.
-    # The forward output placements match the output constraints (Shard(0) on dp, R on tp).
-    output_placements = (Shard(0),) + (Replicate(),) * (len(mesh_shape) - 1)
+    if output_placements is None:
+        output_placements = (Shard(0),) + (Replicate(),) * (len(mesh_shape) - 1)
 
     # Build tangent LocalTensors — one per forward output.
     # The joint graph may have multiple tangent placeholders; we look at parallel_gm.
@@ -458,7 +495,7 @@ def test_correctness_linear():
     def input_fn():
         return torch.randn(batch, dim, device="cuda")
 
-    _run_correctness_test(model_fn, input_fn, mesh_shape=(4, 2))
+    run_correctness_test(model_fn, input_fn, mesh_shape=(4, 2))
 
 
 def test_correctness_linear_with_bias():
@@ -471,7 +508,7 @@ def test_correctness_linear_with_bias():
     def input_fn():
         return torch.randn(batch, dim, device="cuda")
 
-    _run_correctness_test(model_fn, input_fn, mesh_shape=(4, 2))
+    run_correctness_test(model_fn, input_fn, mesh_shape=(4, 2))
 
 
 def test_correctness_linear_1d_mesh():
@@ -484,7 +521,7 @@ def test_correctness_linear_1d_mesh():
     def input_fn():
         return torch.randn(batch, dim, device="cuda")
 
-    _run_correctness_test(model_fn, input_fn, mesh_shape=(8,))
+    run_correctness_test(model_fn, input_fn, mesh_shape=(8,))
 
 
 def test_correctness_mlp():
@@ -507,7 +544,7 @@ def test_correctness_mlp():
     def input_fn():
         return torch.randn(batch, dim, device="cuda")
 
-    _run_correctness_test(model_fn, input_fn, mesh_shape=(4, 2))
+    run_correctness_test(model_fn, input_fn, mesh_shape=(4, 2))
 
 
 def test_correctness_attention():
@@ -539,4 +576,4 @@ def test_correctness_attention():
     def input_fn():
         return torch.randn(batch, seq_len, dim, device="cuda")
 
-    _run_correctness_test(model_fn, input_fn, mesh_shape=(4, 2))
+    run_correctness_test(model_fn, input_fn, mesh_shape=(4, 2))


### PR DESCRIPTION
Adds Context Parallel attention support through `local_map` and teaches AutoParallel's local_map HOP path to honor `in_grad_placements`.

Context Parallel needs asymmetric placements for attention inputs and their gradients. Q remains sequence-sharded on the CP axis in both forward and backward, while K/V are replicated for the forward attention kernel and produce partial gradients in backward:

- Q forward/grad: `Shard(sequence)` on CP
- K/V forward: `Replicate()` on CP
- K/V grad: `Partial()` on CP

This matches Torchtitan full-DTensor CP semantics. The gap was specific to AutoParallel's tracing path: AutoParallel enables PyTorch's `local_map_hop` wrapping so local_map regions remain explicit placement-aware graph boundaries. That HOP autograd path currently rejects `in_grad_placements`, and its generated backward metadata defaults backward output placements to the forward input placements. That is correct for existing EP/MoE local_map regions with `in_grad_placements=None`, but it is wrong for CP K/V gradients.

This PR adds a scoped AutoParallel shim around local_map HOP autograd:

- bypass the upstream `in_grad_placements` reject while AutoParallel is tracing or applying placements
- keep PyTorch's existing HOP forward/backward graph construction
- rewrite backward local_map `out_placements` to the forward `in_grad_placements` when provided
- restore the original PyTorch HOP implementation when leaving the context

The placement optimizer no longer rejects `in_grad_placements`; it continues to consume local_map `in_placements` and `out_placements`. For backward HOPs, the shim has already made `out_placements` reflect the gradient placements, so CP logic stays out of the generic placement-option path.

Also adds `autoparallel.context_parallel` helpers for CP attention local_map wrapping, including an SDPA convenience wrapper. The helpers support named 2D, 3D, and 4D meshes such as:

- `("dp_shard", "cp")`
- `("dp_shard", "tp")`
- `("dp_shard", "cp", "tp")`
- `("dp_replicate", "dp_shard", "cp", "tp")`

Docs included:

- `docs/context_parallel.md`: user-facing usage and placement semantics
- `docs/context_parallel_design.md`: implementation rationale and unsupported path analysis

Review order:

1. `autoparallel/tracing.py` — local_map HOP autograd shim and scoped enablement
2. `autoparallel/shardings/placement_options.py` — local_map placement option support for in-grad metadata
3. `autoparallel/context_parallel.py` — CP placement helper and SDPA wrapper
4. `tests/test_context_parallel.py` and `tests/test_correctness.py` — end-to-end coverage and shared correctness helper extension
5. `docs/context_parallel.md` and `docs/context_parallel_design.md`

Test plan:

- [x] `pre-commit run --files autoparallel/api.py autoparallel/shardings/placement_options.py autoparallel/tracing.py autoparallel/context_parallel.py tests/test_correctness.py tests/test_context_parallel.py docs/README.md docs/context_parallel.md docs/context_parallel_design.md`
- [x] `git diff --check`
- [x] `python -m py_compile autoparallel/context_parallel.py autoparallel/tracing.py autoparallel/api.py autoparallel/shardings/placement_options.py tests/test_context_parallel.py tests/test_correctness.py`
- [x] `python -m pytest tests/test_context_parallel.py tests/test_correctness.py::test_correctness_attention tests/test_optimize_placement.py::test_local_map_placement_respected tests/test_activation_checkpointing.py::test_local_map_custom_metadata_propagation -q`
