### PR TITLE
Support 3D+ MoE local_map mesh variants

### DIFF
--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -80,4 +80,4 @@ jobs:
         pip install --quiet .
         python -m pytest tests/test_dcp_roundtrip.py -v
         torchrun --standalone --nproc-per-node 4 examples/example_ds3_local_map.py
-        PYTHONPATH=. torchrun --standalone --nproc-per-node 4 tests/test_ds3_local_map_numerics.py --case legacy_2d
+        PYTHONPATH=. torchrun --standalone --nproc-per-node 4 tests/test_ds3_local_map_numerics.py --case legacy_2d --dtype bfloat16

--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -80,3 +80,4 @@ jobs:
         pip install --quiet .
         python -m pytest tests/test_dcp_roundtrip.py -v
         torchrun --standalone --nproc-per-node 4 examples/example_ds3_local_map.py
+        PYTHONPATH=. torchrun --standalone --nproc-per-node 4 tests/test_ds3_local_map_numerics.py --case legacy_2d

--- a/autoparallel/__init__.py
+++ b/autoparallel/__init__.py
@@ -7,11 +7,19 @@ from autoparallel.api import AutoParallel, auto_parallel
 from autoparallel.collectives import with_sharding_constraint
 from autoparallel.compile import autoparallel_backend
 from autoparallel.input_validation import ForwardInputs
+from autoparallel.moe import (
+    MoEMeshRoles,
+    build_moe_local_map_placements,
+    build_moe_mesh,
+)
 
 __all__ = [
     "auto_parallel",
     "AutoParallel",
     "autoparallel_backend",
     "ForwardInputs",
+    "MoEMeshRoles",
+    "build_moe_local_map_placements",
+    "build_moe_mesh",
     "with_sharding_constraint",
 ]

--- a/autoparallel/_testing/models/dsv3.py
+++ b/autoparallel/_testing/models/dsv3.py
@@ -13,19 +13,15 @@ import torch.nn.functional as F
 import triton
 import triton.language as tl
 from torch import nn
-from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import DeviceMesh, DTensor
-from torch.distributed.tensor.placement_types import (
-    Partial,
-    Placement,
-    Replicate,
-    Shard,
-)
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
 from autoparallel.collectives import all_to_all, axis_size, local_map
+from autoparallel.moe import MoEMeshRoles, build_moe_local_map_placements
+from autoparallel.moe import build_moe_mesh as _build_moe_mesh
 
 _MODULE_FQN = "module_fqn"
+build_moe_mesh = _build_moe_mesh
 
 
 def _to_compute_dtype(
@@ -802,103 +798,9 @@ def _(
 # )
 
 
-@dataclass(frozen=True)
-class MoEMeshRoles:
-    """Which ``DeviceMesh`` axes are expert-parallel inside the MoE ``local_map``.
-
-    ``ep_axis_names``: the axes whose flatten forms the all-to-all (EP) group.
-    ``ep_group_name``: the (possibly flattened) mesh-dim name the region's
-    collectives run over.
-    """
-
-    ep_axis_names: tuple[str, ...]
-    ep_group_name: str
-
-
 def _default_moe_mesh_roles() -> MoEMeshRoles:
     """Backward-compatible 2D default: EP on ``"ep"``."""
     return MoEMeshRoles(ep_axis_names=("ep",), ep_group_name="ep")
-
-
-def build_moe_local_map_placements(
-    mesh_dim_names: tuple[str, ...], roles: MoEMeshRoles
-) -> tuple[tuple[Placement, ...], tuple[Placement, ...], tuple[Placement, ...]]:
-    """Per-axis placements for the region's tokens, expert weights, and counts."""
-    token: list[Placement] = []
-    weight: list[Placement] = []
-    count: list[Placement] = []
-    for name in mesh_dim_names:
-        token.append(Shard(0))
-        count.append(Partial(reduce_op="sum"))
-        weight.append(Shard(0) if name in roles.ep_axis_names else Replicate())
-    return tuple(token), tuple(weight), tuple(count)
-
-
-def build_moe_mesh(
-    *,
-    dp_replicate: int,
-    dp_shard: int,
-    cp: int,
-    tp: int,
-    ep: int,
-    device_type: str = "cuda",
-) -> tuple[DeviceMesh, MoEMeshRoles]:
-    """Build a single AutoParallel mesh + role map for an *aligned* MoE config.
-
-    Only aligned configs are supported: ``ep >= 2`` and ``ep`` must be a multiple of
-    ``cp*tp`` with ``ep/(cp*tp)`` dividing ``dp_shard`` (so no dense axis is split
-    and ``efsdp = dp_shard*cp*tp/ep``, TorchTitan-consistent). Size-1 axes are
-    dropped, so 2D/3D/4D configs yield different atom sets. Returns the mesh and the
-    ``MoEMeshRoles`` naming its EP axes.
-
-    Caller must also ensure ``num_experts`` is divisible by ``ep`` (``MoE.__init__``
-    validates it); this builder cannot see ``num_experts``.
-    """
-    if ep < 2:
-        raise ValueError(
-            f"build_moe_mesh requires ep >= 2 (expert parallelism); got ep={ep}. "
-            "Use the dense path for models without expert parallelism."
-        )
-    if ep % (cp * tp) != 0:
-        raise ValueError(
-            f"Non-aligned MoE config: ep({ep}) must be a multiple of cp*tp "
-            f"({cp}*{tp}); splitting cp/tp across ep is not supported."
-        )
-    dp_shard_in_ep = ep // (cp * tp)
-    if dp_shard % dp_shard_in_ep != 0:
-        raise ValueError(
-            f"Non-aligned MoE config: ep/(cp*tp)={dp_shard_in_ep} must divide "
-            f"dp_shard({dp_shard})."
-        )
-    dp_shard_mod_ep = dp_shard // dp_shard_in_ep  # == efsdp == dp_shard*cp*tp/ep
-
-    # dp outermost, ep-constituents contiguous innermost so the EP group is
-    # contiguous (matches TorchTitan's world unflatten).
-    ordered = [
-        ("dp_replicate", dp_replicate),
-        ("dp_shard_mod_ep", dp_shard_mod_ep),
-        ("dp_shard_in_ep", dp_shard_in_ep),
-        ("cp", cp),
-        ("tp", tp),
-    ]
-    atoms = [(n, d) for n, d in ordered if d > 1]
-    if not atoms:
-        raise ValueError("Degenerate MoE config: all parallelism degrees are 1.")
-    names = tuple(n for n, _ in atoms)
-    mesh = init_device_mesh(
-        device_type, tuple(d for _, d in atoms), mesh_dim_names=names
-    )
-
-    ep_atoms = tuple(n for n in ("dp_shard_in_ep", "cp", "tp") if n in names)
-    assert ep_atoms, "aligned config with ep>1 always keeps >=1 ep atom"
-    if len(ep_atoms) == 1:
-        ep_group_name = ep_atoms[0]
-    else:
-        ep_group_name = "ep"
-        mesh[ep_atoms]._flatten(ep_group_name)
-
-    roles = MoEMeshRoles(ep_axis_names=ep_atoms, ep_group_name=ep_group_name)
-    return mesh, roles
 
 
 def _validate_moe_sharding(mesh, roles, *, num_experts):

--- a/autoparallel/_testing/models/dsv3.py
+++ b/autoparallel/_testing/models/dsv3.py
@@ -290,6 +290,18 @@ def _run_experts_grouped_mm(
     offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)
     # grouped mm between a 2D tensor and a 3D tensor
     assert x.dim() == 2
+    if x.dtype == torch.float32:
+        positions = torch.arange(x.shape[0], dtype=offsets.dtype, device=x.device)
+        out = torch.zeros_like(x)
+        for expert_idx in range(w1.shape[0]):
+            h = F.silu(F.linear(x, w1[expert_idx]))
+            h = h * F.linear(x, w3[expert_idx])
+            expert_out = F.linear(h, w2[expert_idx])
+            mask = positions < offsets[expert_idx]
+            if expert_idx > 0:
+                mask = mask & (positions >= offsets[expert_idx - 1])
+            out = out + expert_out * mask.unsqueeze(-1)
+        return out
 
     h = F.silu(
         torch._grouped_mm(x.bfloat16(), w1.bfloat16().transpose(-2, -1), offs=offsets)

--- a/autoparallel/_testing/models/dsv3.py
+++ b/autoparallel/_testing/models/dsv3.py
@@ -13,8 +13,14 @@ import torch.nn.functional as F
 import triton
 import triton.language as tl
 from torch import nn
+from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import DeviceMesh, DTensor
-from torch.distributed.tensor.placement_types import Partial, Replicate, Shard
+from torch.distributed.tensor.placement_types import (
+    Partial,
+    Placement,
+    Replicate,
+    Shard,
+)
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
 from autoparallel.collectives import all_to_all, axis_size, local_map
@@ -671,6 +677,7 @@ def local_mapped_region(
         output_splits,
     ) = _token_dispatch(routed_input, num_tokens_per_expert, axis_name)
 
+    # Expert weights arrive complete per EP shard; FSDP over them is external.
     routed_output = _run_experts_grouped_mm(
         experts_w1,
         experts_w2,
@@ -795,6 +802,122 @@ def _(
 # )
 
 
+@dataclass(frozen=True)
+class MoEMeshRoles:
+    """Which ``DeviceMesh`` axes are expert-parallel inside the MoE ``local_map``.
+
+    ``ep_axis_names``: the axes whose flatten forms the all-to-all (EP) group.
+    ``ep_group_name``: the (possibly flattened) mesh-dim name the region's
+    collectives run over.
+    """
+
+    ep_axis_names: tuple[str, ...]
+    ep_group_name: str
+
+
+def _default_moe_mesh_roles() -> MoEMeshRoles:
+    """Backward-compatible 2D default: EP on ``"ep"``."""
+    return MoEMeshRoles(ep_axis_names=("ep",), ep_group_name="ep")
+
+
+def build_moe_local_map_placements(
+    mesh_dim_names: tuple[str, ...], roles: MoEMeshRoles
+) -> tuple[tuple[Placement, ...], tuple[Placement, ...], tuple[Placement, ...]]:
+    """Per-axis placements for the region's tokens, expert weights, and counts."""
+    token: list[Placement] = []
+    weight: list[Placement] = []
+    count: list[Placement] = []
+    for name in mesh_dim_names:
+        token.append(Shard(0))
+        count.append(Partial(reduce_op="sum"))
+        weight.append(Shard(0) if name in roles.ep_axis_names else Replicate())
+    return tuple(token), tuple(weight), tuple(count)
+
+
+def build_moe_mesh(
+    *,
+    dp_replicate: int,
+    dp_shard: int,
+    cp: int,
+    tp: int,
+    ep: int,
+    device_type: str = "cuda",
+) -> tuple[DeviceMesh, MoEMeshRoles]:
+    """Build a single AutoParallel mesh + role map for an *aligned* MoE config.
+
+    Only aligned configs are supported: ``ep >= 2`` and ``ep`` must be a multiple of
+    ``cp*tp`` with ``ep/(cp*tp)`` dividing ``dp_shard`` (so no dense axis is split
+    and ``efsdp = dp_shard*cp*tp/ep``, TorchTitan-consistent). Size-1 axes are
+    dropped, so 2D/3D/4D configs yield different atom sets. Returns the mesh and the
+    ``MoEMeshRoles`` naming its EP axes.
+
+    Caller must also ensure ``num_experts`` is divisible by ``ep`` (``MoE.__init__``
+    validates it); this builder cannot see ``num_experts``.
+    """
+    if ep < 2:
+        raise ValueError(
+            f"build_moe_mesh requires ep >= 2 (expert parallelism); got ep={ep}. "
+            "Use the dense path for models without expert parallelism."
+        )
+    if ep % (cp * tp) != 0:
+        raise ValueError(
+            f"Non-aligned MoE config: ep({ep}) must be a multiple of cp*tp "
+            f"({cp}*{tp}); splitting cp/tp across ep is not supported."
+        )
+    dp_shard_in_ep = ep // (cp * tp)
+    if dp_shard % dp_shard_in_ep != 0:
+        raise ValueError(
+            f"Non-aligned MoE config: ep/(cp*tp)={dp_shard_in_ep} must divide "
+            f"dp_shard({dp_shard})."
+        )
+    dp_shard_mod_ep = dp_shard // dp_shard_in_ep  # == efsdp == dp_shard*cp*tp/ep
+
+    # dp outermost, ep-constituents contiguous innermost so the EP group is
+    # contiguous (matches TorchTitan's world unflatten).
+    ordered = [
+        ("dp_replicate", dp_replicate),
+        ("dp_shard_mod_ep", dp_shard_mod_ep),
+        ("dp_shard_in_ep", dp_shard_in_ep),
+        ("cp", cp),
+        ("tp", tp),
+    ]
+    atoms = [(n, d) for n, d in ordered if d > 1]
+    if not atoms:
+        raise ValueError("Degenerate MoE config: all parallelism degrees are 1.")
+    names = tuple(n for n, _ in atoms)
+    mesh = init_device_mesh(
+        device_type, tuple(d for _, d in atoms), mesh_dim_names=names
+    )
+
+    ep_atoms = tuple(n for n in ("dp_shard_in_ep", "cp", "tp") if n in names)
+    assert ep_atoms, "aligned config with ep>1 always keeps >=1 ep atom"
+    if len(ep_atoms) == 1:
+        ep_group_name = ep_atoms[0]
+    else:
+        ep_group_name = "ep"
+        mesh[ep_atoms]._flatten(ep_group_name)
+
+    roles = MoEMeshRoles(ep_axis_names=ep_atoms, ep_group_name=ep_group_name)
+    return mesh, roles
+
+
+def _validate_moe_sharding(mesh, roles, *, num_experts):
+    """Raise unless num_experts is divisible by the EP group size. No-op when the
+    mesh or its axis names are unavailable."""
+    if mesh is None or mesh.mesh_dim_names is None:
+        return
+    dim_names = mesh.mesh_dim_names
+    ep_size = 1
+    for axis in roles.ep_axis_names:
+        if axis in dim_names:
+            ep_size *= mesh.size(dim_names.index(axis))
+    if num_experts % ep_size != 0:
+        raise ValueError(
+            f"num_experts ({num_experts}) must be divisible by the EP group size "
+            f"({ep_size}) over axes {roles.ep_axis_names}."
+        )
+
+
 def _moe_forward(
     x: torch.Tensor,
     router_gate_weight: torch.Tensor,
@@ -808,7 +931,7 @@ def _moe_forward(
     router: TokenChoiceTopKRouter,
     reorderer: TokenReorderer,
     mesh: Optional[DeviceMesh],
-    axis_name: str,
+    roles: MoEMeshRoles,
     score_before_experts: bool,
     compute_dtype: torch.dtype | None = None,
 ):
@@ -855,35 +978,29 @@ def _moe_forward(
     # This is in the local_map region
     ######################################################
 
-    # expert_placements = ((Replicate(), Shard(0)),) * 3
-    # in_placements = (
-    #     (Shard(0), Shard(0)),
-    #     (Shard(0), Shard(0)),
-    #     (Shard(0), Shard(0)),
-    #     (Shard(0), Shard(0)),
-    # )
+    assert mesh is not None and mesh.mesh_dim_names is not None
+    token_p, weight_p, count_p = build_moe_local_map_placements(
+        mesh.mesh_dim_names, roles
+    )
     # Dynamo reorders captured variables (lifted freevars) before explicit
     # arguments, so x must come first in the input order and placements.
     reordered_placements = (
-        (Shard(0), Shard(0)),
-        (Shard(0), Shard(0)),
-        (Shard(0), Shard(0)),
-        (Replicate(), Shard(0)),
-        (Replicate(), Shard(0)),
-        (Replicate(), Shard(0)),
-        (Shard(0), Shard(0)),
-        None,
-        None,
-        None,
-        None,
+        token_p,  # x
+        token_p,  # selected_experts_indices
+        token_p,  # top_scores
+        weight_p,  # experts_w1
+        weight_p,  # experts_w3
+        weight_p,  # experts_w2
+        token_p,  # out
+        None,  # top_k
+        None,  # num_experts
+        None,  # score_before_experts
+        None,  # axis_name (EP group)
     )
 
     out, num_tokens_per_expert = local_map(
         local_mapped_region,
-        out_placements=(
-            (Shard(0), Shard(0)),
-            (Partial(reduce_op="sum"), Partial(reduce_op="sum")),
-        ),
+        out_placements=(token_p, count_p),
         in_placements=reordered_placements,
         redistribute_inputs=True,
         in_grad_placements=None,
@@ -899,7 +1016,7 @@ def _moe_forward(
         router.top_k,
         router.num_experts,
         score_before_experts,
-        axis_name,
+        roles.ep_group_name,
     )
     # assert False, f"there: {out.shape}, {num_tokens_per_expert.shape}"
 
@@ -933,12 +1050,15 @@ class MoE(nn.Module):
         use_grouped_mm: bool = True,
         load_balance_coeff: float | None = 1e-3,
         mesh: DeviceMesh | None = None,
+        roles: MoEMeshRoles | None = None,
         compute_dtype: torch.dtype | None = None,
     ):
         super().__init__()
 
         self.mesh = mesh
-        self.axis_name = "ep"
+        # Default roles: EP on "ep" (the pre-roles 2D behavior).
+        self.roles = roles if roles is not None else _default_moe_mesh_roles()
+        _validate_moe_sharding(mesh, self.roles, num_experts=num_experts)
         self.compute_dtype = compute_dtype
         self.experts = GroupedExperts(
             dim=dim,
@@ -998,7 +1118,7 @@ class MoE(nn.Module):
             self.router,
             self.reorderer,
             self.mesh,
-            self.axis_name,
+            self.roles,
             self.score_before_experts,
             self.compute_dtype,
         )
@@ -1555,6 +1675,7 @@ class TransformerBlock(nn.Module):
         layer_config,
         model_config,
         mesh: DeviceMesh | None = None,
+        roles: MoEMeshRoles | None = None,
         compute_dtype: torch.dtype | None = None,
     ):
         super().__init__()
@@ -1584,6 +1705,7 @@ class TransformerBlock(nn.Module):
                 use_grouped_mm=moe_cfg.experts.use_grouped_mm,
                 load_balance_coeff=moe_cfg.load_balance_coeff,
                 mesh=mesh,
+                roles=roles,
                 compute_dtype=compute_dtype,
             )
         else:
@@ -1639,6 +1761,7 @@ class DeepSeekV3Model(nn.Module):
         self,
         config,
         mesh: DeviceMesh | None = None,
+        roles: MoEMeshRoles | None = None,
         compute_dtype: torch.dtype | None = None,
     ):
         # Explicitly call nn.Module.__init__ to avoid MRO issues when this class
@@ -1658,6 +1781,7 @@ class DeepSeekV3Model(nn.Module):
                 layer_config,
                 config,
                 mesh,
+                roles=roles,
                 compute_dtype=compute_dtype,
             )
 

--- a/autoparallel/collectives.py
+++ b/autoparallel/collectives.py
@@ -76,9 +76,15 @@ def _get_group_name_from_axis_name(mesh_name):
 
 def axis_size(axis_name):
     mesh = get_mesh_from_global()
-    assert axis_name in mesh.mesh_dim_names
-    axis_dim = mesh.mesh_dim_names.index(axis_name)
-    return mesh.size(axis_dim)
+    if mesh.mesh_dim_names is not None and axis_name in mesh.mesh_dim_names:
+        axis_dim = mesh.mesh_dim_names.index(axis_name)
+        return mesh.size(axis_dim)
+    # Flattened sub-mesh axis (e.g. an EP group folded from several root axes via
+    # ``mesh[...]._flatten(axis_name)``). Resolve the size from the process group
+    # rather than ``mesh[axis_name]``: subscripting builds a submesh that Dynamo
+    # lifts into the local_map HOP inputs, while ``get_group`` (also used by the
+    # collectives) constant-folds during tracing.
+    return mesh.get_group(axis_name).size()
 
 
 def axis_index(axis_name):
@@ -218,8 +224,18 @@ class _AllToAll(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx: Any, grad_output: torch.Tensor):  # type: ignore[override]
-        return _all_to_all(
-            grad_output, ctx.input_split_sizes, ctx.output_split_sizes, ctx.group_name
+        # forward has 4 inputs (x, output_split_sizes, input_split_sizes,
+        # axis_name); return one grad per input (None for the non-tensors).
+        return (
+            _all_to_all(
+                grad_output,
+                ctx.input_split_sizes,
+                ctx.output_split_sizes,
+                ctx.group_name,
+            ),
+            None,
+            None,
+            None,
         )
 
 

--- a/autoparallel/moe.py
+++ b/autoparallel/moe.py
@@ -1,0 +1,121 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Public mesh and placement helpers for aligned MoE ``local_map`` regions."""
+
+from dataclasses import dataclass
+
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import DeviceMesh
+from torch.distributed.tensor.placement_types import (
+    Partial,
+    Placement,
+    Replicate,
+    Shard,
+)
+
+__all__ = [
+    "MoEMeshRoles",
+    "build_moe_local_map_placements",
+    "build_moe_mesh",
+]
+
+
+@dataclass(frozen=True)
+class MoEMeshRoles:
+    """Which ``DeviceMesh`` axes are expert-parallel inside an MoE ``local_map``.
+
+    ``ep_axis_names`` names the axes whose flatten forms the all-to-all group.
+    ``ep_group_name`` is the mesh-dimension name used by region collectives.
+    """
+
+    ep_axis_names: tuple[str, ...]
+    ep_group_name: str
+
+
+def build_moe_local_map_placements(
+    mesh_dim_names: tuple[str, ...], roles: MoEMeshRoles
+) -> tuple[tuple[Placement, ...], tuple[Placement, ...], tuple[Placement, ...]]:
+    """Return token, expert-weight, and token-count placements, in that order."""
+    token: list[Placement] = []
+    weight: list[Placement] = []
+    count: list[Placement] = []
+    for name in mesh_dim_names:
+        token.append(Shard(0))
+        count.append(Partial(reduce_op="sum"))
+        weight.append(Shard(0) if name in roles.ep_axis_names else Replicate())
+    return tuple(token), tuple(weight), tuple(count)
+
+
+def build_moe_mesh(
+    *,
+    dp_replicate: int,
+    dp_shard: int,
+    cp: int,
+    tp: int,
+    ep: int,
+    device_type: str = "cuda",
+) -> tuple[DeviceMesh, MoEMeshRoles]:
+    """Build one AutoParallel mesh and role map for an aligned MoE config.
+
+    ``ep`` is formed from axes already contained in ``dp_shard * cp * tp``; it
+    is not an additional world-size factor. The resulting world size is
+    ``dp_replicate * dp_shard * cp * tp``, and the external FSDP degree is
+    ``dp_shard * cp * tp / ep``.
+
+    Only aligned configs are supported: ``ep >= 2``, ``ep`` must be a multiple
+    of ``cp * tp``, and ``ep / (cp * tp)`` must divide ``dp_shard``. Size-one
+    axes are omitted. Callers must also ensure ``num_experts`` is divisible by
+    ``ep``; this builder cannot see the model configuration.
+
+    Returns:
+        The shared ``DeviceMesh`` and the ``MoEMeshRoles`` describing its EP
+        axes and collective group.
+    """
+    if ep < 2:
+        raise ValueError(
+            f"build_moe_mesh requires ep >= 2 (expert parallelism); got ep={ep}. "
+            "Use the dense path for models without expert parallelism."
+        )
+    if ep % (cp * tp) != 0:
+        raise ValueError(
+            f"Non-aligned MoE config: ep({ep}) must be a multiple of cp*tp "
+            f"({cp}*{tp}); splitting cp/tp across ep is not supported."
+        )
+    dp_shard_in_ep = ep // (cp * tp)
+    if dp_shard % dp_shard_in_ep != 0:
+        raise ValueError(
+            f"Non-aligned MoE config: ep/(cp*tp)={dp_shard_in_ep} must divide "
+            f"dp_shard({dp_shard})."
+        )
+    dp_shard_mod_ep = dp_shard // dp_shard_in_ep  # == efsdp == dp_shard*cp*tp/ep
+
+    # dp outermost, ep-constituents contiguous innermost so the EP group is
+    # contiguous (matches TorchTitan's world unflatten).
+    ordered = [
+        ("dp_replicate", dp_replicate),
+        ("dp_shard_mod_ep", dp_shard_mod_ep),
+        ("dp_shard_in_ep", dp_shard_in_ep),
+        ("cp", cp),
+        ("tp", tp),
+    ]
+    atoms = [(n, d) for n, d in ordered if d > 1]
+    if not atoms:
+        raise ValueError("Degenerate MoE config: all parallelism degrees are 1.")
+    names = tuple(n for n, _ in atoms)
+    mesh = init_device_mesh(
+        device_type, tuple(d for _, d in atoms), mesh_dim_names=names
+    )
+
+    ep_atoms = tuple(n for n in ("dp_shard_in_ep", "cp", "tp") if n in names)
+    assert ep_atoms, "aligned config with ep>1 always keeps >=1 ep atom"
+    if len(ep_atoms) == 1:
+        ep_group_name = ep_atoms[0]
+    else:
+        ep_group_name = "ep"
+        mesh[ep_atoms]._flatten(ep_group_name)
+
+    roles = MoEMeshRoles(ep_axis_names=ep_atoms, ep_group_name=ep_group_name)
+    return mesh, roles

--- a/autoparallel/moe.py
+++ b/autoparallel/moe.py
@@ -74,6 +74,20 @@ def build_moe_mesh(
         The shared ``DeviceMesh`` and the ``MoEMeshRoles`` describing its EP
         axes and collective group.
     """
+    degrees = {
+        "dp_replicate": dp_replicate,
+        "dp_shard": dp_shard,
+        "cp": cp,
+        "tp": tp,
+        "ep": ep,
+    }
+    for name, degree in degrees.items():
+        if isinstance(degree, bool) or not isinstance(degree, int) or degree < 1:
+            raise ValueError(
+                f"build_moe_mesh requires {name} to be a positive integer; "
+                f"got {degree!r}."
+            )
+
     if ep < 2:
         raise ValueError(
             f"build_moe_mesh requires ep >= 2 (expert parallelism); got ep={ep}. "

--- a/autoparallel/shardings/placement_options.py
+++ b/autoparallel/shardings/placement_options.py
@@ -13,6 +13,7 @@ from typing import Any, Iterable
 
 import torch
 import torch.utils._pytree as pytree
+from torch._functorch.partitioners import _has_tag_is_backward
 from torch.distributed._tensor.placement_types import Placement, TensorMeta
 from torch.distributed.device_mesh import _get_device_handle
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
@@ -24,7 +25,7 @@ from torch.distributed.tensor._op_schema import (
     TupleStrategy,
 )
 from torch.distributed.tensor._ops.utils import generate_redistribute_costs
-from torch.distributed.tensor.placement_types import Replicate, Shard
+from torch.distributed.tensor.placement_types import Partial, Replicate, Shard
 from torch.utils._pytree import tree_flatten, tree_map_only
 
 from autoparallel.shardings.propagation_rules import generate_dummy_redistribute_costs
@@ -379,6 +380,16 @@ def _concretize_tensor_meta(t: torch.Tensor) -> "TensorMeta | None":
     return TensorMeta(torch.Size(t.shape), tuple(t.stride()), t.dtype)
 
 
+def _grad_placement(p: Placement) -> Placement:
+    """Placement of a local_map input's gradient (autograd duality): Replicate ->
+    Partial(sum), Partial -> Replicate, Shard unchanged."""
+    if isinstance(p, Replicate):
+        return Partial(reduce_op="sum")
+    if isinstance(p, Partial):
+        return Replicate()
+    return p
+
+
 def get_local_map_placement_option(
     mesh,
     specs,
@@ -397,9 +408,10 @@ def get_local_map_placement_option(
         mesh,
         None,
     ), "Not yet implemented"
-    assert "call_local_map" in str(node.target) or "call_local_map_backward" in str(
-        node.target
-    )
+    # Substring match tolerates torch's local_map HOP renames across versions
+    # ("call_local_map"/"call_local_map_backward" pre-2.14, "local_map_hop" in
+    # 2.14+); everything below keys off node.meta["local_map_kwargs"].
+    assert "local_map" in str(node.target)
     in_specs = []
     num_activation_inputs = len(user_args) - len(in_placements)
     # activations are always replicated
@@ -431,6 +443,10 @@ def get_local_map_placement_option(
 
         in_specs.append(DTensorSpec(mesh=mesh, placements=placement, tensor_meta=tm))
 
+    # A backward node's outputs are gradients of the forward inputs, whose
+    # placements the HOP mirrors from the forward in_placements; take their dual.
+    is_backward = _has_tag_is_backward(node)
+
     out_specs = []
     output_val = node.meta["val"]
     assert isinstance(output_val, (torch.Tensor, list, tuple))
@@ -448,6 +464,8 @@ def get_local_map_placement_option(
             placement = [placement]
 
         assert isinstance(placement, (list, tuple)), "Not implemented"
+        if is_backward:
+            placement = [_grad_placement(p) for p in placement]
         tm = _concretize_tensor_meta(example)
         if tm is None:
             out_specs.append(None)

--- a/examples/example_ds3_local_map.py
+++ b/examples/example_ds3_local_map.py
@@ -13,11 +13,8 @@ from torch.distributed.tensor.placement_types import Shard
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.testing._internal.distributed.fake_pg import FakeStore
 
-from autoparallel._testing.models.dsv3 import (
-    DeepSeekV3Model,
-    build_moe_mesh,
-    make_dsv3_config,
-)
+from autoparallel import build_moe_mesh
+from autoparallel._testing.models.dsv3 import DeepSeekV3Model, make_dsv3_config
 from autoparallel.api import AutoParallel
 from autoparallel.shardings.placement_options import NumericsLogger
 

--- a/examples/example_ds3_local_map.py
+++ b/examples/example_ds3_local_map.py
@@ -13,7 +13,11 @@ from torch.distributed.tensor.placement_types import Shard
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.testing._internal.distributed.fake_pg import FakeStore
 
-from autoparallel._testing.models.dsv3 import DeepSeekV3Model, make_dsv3_config
+from autoparallel._testing.models.dsv3 import (
+    DeepSeekV3Model,
+    build_moe_mesh,
+    make_dsv3_config,
+)
 from autoparallel.api import AutoParallel
 from autoparallel.shardings.placement_options import NumericsLogger
 
@@ -24,60 +28,53 @@ def _seed_dtensor_rng(rng_seed: Optional[int]) -> None:
     torch.manual_seed(_DEFAULT_DTENSOR_RNG_SEED if rng_seed is None else rng_seed)
 
 
-def run_test(fake_evaluate: bool, rng_seed: Optional[int], logs_dir: str):
+def run_test(
+    fake_evaluate: bool, rng_seed: Optional[int], logs_dir: str, degrees: dict
+):
     # Match TorchTitan's DeepSeek V3 debug model shape. This example is a
     # regression guard for placement/clustering issues that only appear at the
     # larger debug shape used by TorchTitan GraphTrainer.
     seq_len = 2048
+    # World is dp_replicate*dp_shard*cp*tp; ep is folded into dp_shard*cp*tp
+    # (TorchTitan sparse-mesh semantics), not an independent factor.
+    world_size = (
+        degrees["dp_replicate"] * degrees["dp_shard"] * degrees["cp"] * degrees["tp"]
+    )
     if fake_evaluate:
-        world_size = 256
-
-        fake_store = FakeStore()
         torch.distributed.init_process_group(
-            "fake", store=fake_store, rank=0, world_size=world_size
+            "fake", store=FakeStore(), rank=0, world_size=world_size
         )
         local_rank = torch.distributed.get_rank()
-        device = torch.device(f"cuda:{local_rank}")
-        torch.cuda.set_device(device)
-        _seed_dtensor_rng(rng_seed)
-        mesh = torch.distributed.device_mesh.init_device_mesh(
-            "cuda",
-            (world_size // 64, 64),
-            mesh_dim_names=("dp", "ep"),
-        )
-
-        config = make_dsv3_config(num_experts=64, max_seq_len=seq_len)
+        num_experts = 64
     else:
-        dp_degree = 2
-        ep_degree = 2
-        world_size = dp_degree * ep_degree
-
         assert (
             "WORLD_SIZE" in os.environ
         ), f"run with torchrun --standalone --nproc-per-node {world_size}"
         assert (
             int(os.getenv("WORLD_SIZE")) == world_size
-        ), f"Need at least {world_size} GPUs for real evaluation"
+        ), f"Need {world_size} GPUs for degrees {degrees}"
         local_rank = int(os.getenv("LOCAL_RANK"))
-        device = torch.device(f"cuda:{local_rank}")
-        torch.cuda.set_device(device)
-        _seed_dtensor_rng(rng_seed)
-        torch.distributed.init_process_group(backend="nccl", device_id=device)
-        mesh = torch.distributed.device_mesh.init_device_mesh(
-            "cuda",
-            (dp_degree, ep_degree),
-            mesh_dim_names=("dp", "ep"),
-        )
+        num_experts = 8
 
-        config = make_dsv3_config(max_seq_len=seq_len)
+    device = torch.device(f"cuda:{local_rank}")
+    torch.cuda.set_device(device)
+    _seed_dtensor_rng(rng_seed)
+    if not fake_evaluate:
+        torch.distributed.init_process_group(backend="nccl", device_id=device)
+
+    mesh, roles = build_moe_mesh(**degrees)
+    assert mesh.size() == world_size, (mesh.size(), world_size)
+
+    config = make_dsv3_config(num_experts=num_experts, max_seq_len=seq_len)
 
     local_batch_size = 8
-    global_batch_size = local_batch_size * mesh.shape[0] * mesh.shape[1]
+    global_batch_size = local_batch_size * mesh.size()
 
     with torch.device("meta"):
         model = DeepSeekV3Model(
             config,
             mesh=mesh,
+            roles=roles,
             compute_dtype=torch.bfloat16,
         )
 
@@ -101,7 +98,7 @@ def run_test(fake_evaluate: bool, rng_seed: Optional[int], logs_dir: str):
     ) as autop:
         autop.add_parameter_memory_constraint(low=None, high=None)
 
-        x_sharding = (Shard(0), Shard(0))
+        x_sharding = (Shard(0),) * mesh.ndim
 
         autop.add_input_constraints([x_sharding])
         autop.add_output_constraints([x_sharding])
@@ -185,11 +182,31 @@ if __name__ == "__main__":
         default="out/",
         help="Directory to store logs (default: ./out/).",
     )
+    # Aligned MoE parallelism degrees. Defaults: 4D (dp_shard/cp/tp/ep/efsdp) for
+    # --fake-evaluate; dp_replicate+ep for real 4-GPU runs. ep is folded into
+    # dp_shard*cp*tp, so world = dp_replicate*dp_shard*cp*tp.
+    for name in ("dp-replicate", "dp-shard", "cp", "tp", "ep"):
+        parser.add_argument(f"--{name}", type=int, default=None)
     args = parser.parse_args()
 
     if args.rng_seed is not None:
         torch.use_deterministic_algorithms(True)
 
+    fake_defaults = dict(dp_replicate=1, dp_shard=64, cp=2, tp=2, ep=8)
+    real_defaults = dict(dp_replicate=2, dp_shard=2, cp=1, tp=1, ep=2)
+    defaults = fake_defaults if args.fake_evaluate else real_defaults
+    overrides = {
+        "dp_replicate": args.dp_replicate,
+        "dp_shard": args.dp_shard,
+        "cp": args.cp,
+        "tp": args.tp,
+        "ep": args.ep,
+    }
+    degrees = {k: (v if v is not None else defaults[k]) for k, v in overrides.items()}
+
     run_test(
-        fake_evaluate=args.fake_evaluate, rng_seed=args.rng_seed, logs_dir=args.logs_dir
+        fake_evaluate=args.fake_evaluate,
+        rng_seed=args.rng_seed,
+        logs_dir=args.logs_dir,
+        degrees=degrees,
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -74,6 +74,22 @@ def test_moe_public_mesh_and_placements(
     "degrees, message",
     [
         (
+            {"dp_replicate": 0, "dp_shard": 2, "cp": 1, "tp": 1, "ep": 2},
+            "dp_replicate to be a positive integer",
+        ),
+        (
+            {"dp_replicate": 1, "dp_shard": -1, "cp": 1, "tp": 1, "ep": 2},
+            "dp_shard to be a positive integer",
+        ),
+        (
+            {"dp_replicate": 1, "dp_shard": 2, "cp": 0, "tp": 1, "ep": 2},
+            "cp to be a positive integer",
+        ),
+        (
+            {"dp_replicate": 1, "dp_shard": 2, "cp": 1, "tp": -1, "ep": 2},
+            "tp to be a positive integer",
+        ),
+        (
             {"dp_replicate": 1, "dp_shard": 1, "cp": 1, "tp": 1, "ep": 1},
             "requires ep >= 2",
         ),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,11 +9,87 @@ import torch._inductor.config
 import torch.fx.traceback as fx_traceback
 from torch import nn
 from torch.distributed.tensor import DTensor
-from torch.distributed.tensor.placement_types import Replicate, Shard
+from torch.distributed.tensor.placement_types import Partial, Replicate, Shard
 
+from autoparallel import MoEMeshRoles, build_moe_local_map_placements, build_moe_mesh
 from autoparallel.api import AutoParallel, auto_parallel
 from autoparallel.compile import autoparallel_backend
 from autoparallel.input_validation import ForwardInputs
+
+
+def test_moe_public_exports_preserve_legacy_imports():
+    from autoparallel import moe
+    from autoparallel._testing.models import dsv3
+
+    assert MoEMeshRoles is moe.MoEMeshRoles
+    assert build_moe_mesh is moe.build_moe_mesh
+    assert build_moe_local_map_placements is moe.build_moe_local_map_placements
+    assert dsv3.MoEMeshRoles is MoEMeshRoles
+    assert dsv3.build_moe_mesh is build_moe_mesh
+    assert dsv3.build_moe_local_map_placements is build_moe_local_map_placements
+
+
+@pytest.mark.parametrize(
+    "degrees, expected_shape, expected_names, expected_ep_axes",
+    [
+        (
+            {"dp_replicate": 2, "dp_shard": 2, "cp": 1, "tp": 1, "ep": 2},
+            (2, 2),
+            ("dp_replicate", "dp_shard_in_ep"),
+            ("dp_shard_in_ep",),
+        ),
+        (
+            {"dp_replicate": 1, "dp_shard": 4, "cp": 1, "tp": 2, "ep": 4},
+            (2, 2, 2),
+            ("dp_shard_mod_ep", "dp_shard_in_ep", "tp"),
+            ("dp_shard_in_ep", "tp"),
+        ),
+        (
+            {"dp_replicate": 1, "dp_shard": 64, "cp": 2, "tp": 2, "ep": 8},
+            (32, 2, 2, 2),
+            ("dp_shard_mod_ep", "dp_shard_in_ep", "cp", "tp"),
+            ("dp_shard_in_ep", "cp", "tp"),
+        ),
+    ],
+)
+def test_moe_public_mesh_and_placements(
+    degrees, expected_shape, expected_names, expected_ep_axes
+):
+    mesh, roles = build_moe_mesh(**degrees, device_type="cpu")
+
+    assert tuple(mesh.shape) == expected_shape
+    assert mesh.mesh_dim_names == expected_names
+    ep_group_name = expected_ep_axes[0] if len(expected_ep_axes) == 1 else "ep"
+    assert roles == MoEMeshRoles(expected_ep_axes, ep_group_name)
+
+    token, weight, count = build_moe_local_map_placements(expected_names, roles)
+    assert token == (Shard(0),) * len(expected_names)
+    assert weight == tuple(
+        Shard(0) if name in expected_ep_axes else Replicate() for name in expected_names
+    )
+    assert count == (Partial("sum"),) * len(expected_names)
+
+
+@pytest.mark.parametrize(
+    "degrees, message",
+    [
+        (
+            {"dp_replicate": 1, "dp_shard": 1, "cp": 1, "tp": 1, "ep": 1},
+            "requires ep >= 2",
+        ),
+        (
+            {"dp_replicate": 1, "dp_shard": 2, "cp": 2, "tp": 2, "ep": 2},
+            "must be a multiple of cp\\*tp",
+        ),
+        (
+            {"dp_replicate": 1, "dp_shard": 3, "cp": 1, "tp": 1, "ep": 2},
+            "must divide dp_shard",
+        ),
+    ],
+)
+def test_moe_public_mesh_preserves_validation(degrees, message):
+    with pytest.raises(ValueError, match=message):
+        build_moe_mesh(**degrees, device_type="cpu")
 
 
 def test_from_meta_model(device_mesh_1d):

--- a/tests/test_ds3_local_map_numerics.py
+++ b/tests/test_ds3_local_map_numerics.py
@@ -1,0 +1,286 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Compare 4-GPU AutoParallel DeepSeek-V3 numerics with a single-GPU model."""
+
+import argparse
+import gc
+import json
+import os
+from typing import Any, cast
+
+import torch
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.fsdp import MixedPrecisionPolicy
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor.placement_types import Shard
+
+from autoparallel import AutoParallel, MoEMeshRoles, build_moe_mesh
+from autoparallel._testing.models.dsv3 import DeepSeekV3Model, make_dsv3_config
+
+_WORLD_SIZE = 4
+_SEQ_LEN = 2048
+_LOCAL_BATCH_SIZE = 1
+_SEED = 0
+_OUTPUT_RTOL = 5e-3
+_GRAD_RTOL = 2e-2
+
+_CASES: dict[str, dict[str, int]] = {
+    "efsdp_boundary": dict(dp_replicate=1, dp_shard=4, cp=1, tp=1, ep=2),
+    "legacy_2d": dict(dp_replicate=2, dp_shard=2, cp=1, tp=1, ep=2),
+    "flattened_ep": dict(dp_replicate=1, dp_shard=2, cp=2, tp=1, ep=4),
+}
+
+
+def _relative_error(actual: torch.Tensor, expected: torch.Tensor) -> float:
+    actual = actual.float()
+    expected = expected.float()
+    diff_norm = torch.linalg.vector_norm(actual - expected)
+    expected_norm = torch.linalg.vector_norm(expected)
+    if expected_norm == 0:
+        return diff_norm.item()
+    return (diff_norm / expected_norm).item()
+
+
+def _gather_state_dict(model: torch.nn.Module, rank: int) -> dict[str, torch.Tensor]:
+    state_dict = {}
+    for name, value in model.state_dict().items():
+        full_value = value.full_tensor() if isinstance(value, DTensor) else value
+        if rank == 0:
+            state_dict[name] = full_value.detach().cpu()
+    return state_dict
+
+
+def _run_reference(
+    config,
+    state_dict: dict[str, torch.Tensor],
+    tokens: torch.Tensor,
+    device: torch.device,
+    reference_mesh,
+) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+    roles = MoEMeshRoles(ep_axis_names=("ep",), ep_group_name="ep")
+    with torch.device("meta"):
+        model = DeepSeekV3Model(
+            config,
+            mesh=reference_mesh,
+            roles=roles,
+            compute_dtype=torch.bfloat16,
+        )
+    model.to_empty(device=device)
+    model.init_weights(buffer_device=device, seed=_SEED)
+    model.load_state_dict(state_dict, strict=True)
+
+    with reference_mesh, torch.autograd.set_multithreading_enabled(False):
+        output = model(tokens)
+        output.backward(torch.ones_like(output))
+
+    gradients = {
+        name: parameter.grad.detach().cpu()
+        for name, parameter in model.named_parameters()
+        if parameter.grad is not None
+    }
+    output = output.detach().cpu()
+    del model
+    torch.cuda.empty_cache()
+    return output, gradients
+
+
+def run_numerics_test(case: str):
+    rank = torch.distributed.get_rank()
+    local_rank = int(os.environ["LOCAL_RANK"])
+    device = torch.device("cuda", local_rank)
+    degrees = _CASES[case]
+    mesh, roles = build_moe_mesh(
+        dp_replicate=degrees["dp_replicate"],
+        dp_shard=degrees["dp_shard"],
+        cp=degrees["cp"],
+        tp=degrees["tp"],
+        ep=degrees["ep"],
+    )
+    config = make_dsv3_config(num_experts=8, max_seq_len=_SEQ_LEN)
+    global_batch_size = _LOCAL_BATCH_SIZE * _WORLD_SIZE
+
+    with torch.device("meta"):
+        model = DeepSeekV3Model(
+            config,
+            mesh=mesh,
+            roles=roles,
+            compute_dtype=torch.bfloat16,
+        )
+
+    sample_input = torch.empty(
+        global_batch_size, _SEQ_LEN, dtype=torch.int64, device=device
+    )
+
+    def input_fn():
+        return sample_input
+
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=torch.bfloat16,
+        reduce_dtype=torch.float32,
+    )
+    with AutoParallel(
+        model, input_fn, mesh, mp_policy=mp_policy, dynamic=True
+    ) as autop:
+        autop.add_parameter_memory_constraint(low=None, high=None)
+        input_placements = (Shard(0),) * mesh.ndim
+        autop.add_input_constraints([input_placements])
+        autop.add_output_constraints([input_placements])
+        placement = autop.optimize_placement(verbose=False)
+        parallel_model = autop.apply_placement(placement)
+
+    parallel_model.to_empty(device=device)
+    parallel_model.init_weights(buffer_device=device, seed=_SEED)
+    reference_state = _gather_state_dict(parallel_model, rank)
+
+    if rank == 0:
+        torch.manual_seed(_SEED)
+        global_tokens = torch.randint(
+            0,
+            config.vocab_size,
+            (global_batch_size, _SEQ_LEN),
+            device=device,
+        )
+        scatter_list = list(global_tokens.chunk(_WORLD_SIZE))
+    else:
+        global_tokens = None
+        scatter_list = None
+    local_tokens = torch.empty(
+        _LOCAL_BATCH_SIZE, _SEQ_LEN, dtype=torch.int64, device=device
+    )
+    torch.distributed.scatter(local_tokens, scatter_list, src=0)
+
+    reference_mesh = init_device_mesh("cuda", (1,), mesh_dim_names=("ep",))
+    if rank == 0:
+        assert global_tokens is not None
+        reference_output, reference_gradients = _run_reference(
+            config, reference_state, global_tokens, device, reference_mesh
+        )
+    else:
+        reference_output = None
+        reference_gradients = None
+    torch.distributed.barrier(device_ids=[local_rank])
+
+    with torch.autograd.set_multithreading_enabled(False):
+        output = parallel_model(local_tokens)
+        output.backward(torch.ones_like(output))
+
+    full_output = DTensor.from_local(
+        output.detach(), mesh, input_placements, run_check=False
+    ).full_tensor()
+    output_error = None
+    output_finite = False
+    if rank == 0:
+        assert reference_output is not None
+        output_error = _relative_error(full_output.cpu(), reference_output)
+        output_finite = bool(torch.isfinite(full_output).all()) and bool(
+            torch.isfinite(reference_output).all()
+        )
+
+    parallel_parameters = dict(parallel_model.named_parameters())
+    if rank == 0:
+        assert reference_gradients is not None
+        reference_names = list(reference_gradients)
+    else:
+        reference_names = []
+    objects: list[Any] = [reference_names]
+    torch.distributed.broadcast_object_list(objects, src=0, device=device)
+    reference_names = cast(list[str], objects[0])
+    assert set(parallel_parameters) == set(reference_names)
+    gradient_errors: dict[str, float] = {}
+    nonfinite_gradients: list[str] = []
+    for name in parallel_parameters:
+        gradient = parallel_parameters[name].grad
+        assert gradient is not None, f"Missing parallel gradient for {name}"
+        full_gradient = (
+            gradient.full_tensor() if isinstance(gradient, DTensor) else gradient
+        )
+        if rank == 0:
+            assert reference_gradients is not None
+            error = _relative_error(full_gradient.cpu(), reference_gradients[name])
+            gradient_errors[name] = error
+            if (
+                not torch.isfinite(full_gradient).all()
+                or not torch.isfinite(reference_gradients[name]).all()
+            ):
+                nonfinite_gradients.append(name)
+
+    if rank == 0:
+        assert reference_gradients is not None
+        assert output_error is not None
+        worst_name, worst_error = max(gradient_errors.items(), key=lambda item: item[1])
+        result = {
+            "case": case,
+            "degrees": degrees,
+            "gradient_count": len(reference_gradients),
+            "gradient_relative_errors": gradient_errors,
+            "model": {
+                "global_batch_size": global_batch_size,
+                "layers": len(config.layers),
+                "seed": _SEED,
+                "seq_len": _SEQ_LEN,
+            },
+            "nonfinite_gradients": nonfinite_gradients,
+            "output_finite": output_finite,
+            "output_relative_error": output_error,
+            "thresholds": {
+                "gradient_relative_error": _GRAD_RTOL,
+                "output_relative_error": _OUTPUT_RTOL,
+            },
+            "worst_gradient": {
+                "name": worst_name,
+                "relative_error": worst_error,
+            },
+        }
+        print(f"NUMERICS_RESULT={json.dumps(result, sort_keys=True)}", flush=True)
+        failures = []
+        if not output_finite:
+            failures.append("non-finite output")
+        if nonfinite_gradients:
+            failures.append(f"non-finite gradients: {', '.join(nonfinite_gradients)}")
+        if output_error >= _OUTPUT_RTOL:
+            failures.append(f"output relative error {output_error} >= {_OUTPUT_RTOL}")
+        for name, error in gradient_errors.items():
+            if error >= _GRAD_RTOL:
+                failures.append(
+                    f"gradient {name} relative error {error} >= {_GRAD_RTOL}"
+                )
+        failure = "\n".join(failures) if failures else None
+    else:
+        failure = None
+    status = [failure]
+    torch.distributed.broadcast_object_list(status, src=0, device=device)
+    assert status[0] is None, status[0]
+
+    del parallel_model
+    gc.collect()
+    torch.cuda.empty_cache()
+    torch.distributed.barrier(device_ids=[local_rank])
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--case", required=True, choices=_CASES)
+    args = parser.parse_args()
+
+    if (
+        int(os.environ.get("WORLD_SIZE", "1")) != _WORLD_SIZE
+        or torch.cuda.device_count() < _WORLD_SIZE
+    ):
+        parser.error(f"run with torchrun --standalone --nproc-per-node {_WORLD_SIZE}")
+    local_rank = int(os.environ["LOCAL_RANK"])
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    torch.distributed.init_process_group("nccl", device_id=device)
+    torch.use_deterministic_algorithms(True)
+    try:
+        run_numerics_test(args.case)
+    finally:
+        torch.distributed.barrier(device_ids=[local_rank])
+        torch.distributed.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ds3_local_map_numerics.py
+++ b/tests/test_ds3_local_map_numerics.py
@@ -24,8 +24,8 @@ _WORLD_SIZE = 4
 _SEQ_LEN = 2048
 _LOCAL_BATCH_SIZE = 1
 _SEED = 0
-_OUTPUT_RTOL = 5e-3
-_GRAD_RTOL = 2e-2
+_OUTPUT_ERROR_LIMIT = 5e-3
+_GRADIENT_ERROR_LIMIT = 2e-2
 _DTYPES = {
     "bfloat16": torch.bfloat16,
     "float32": torch.float32,
@@ -99,7 +99,7 @@ def _run_reference(
     return output, gradients
 
 
-def run_numerics_test(case: str, dtype_name: str):
+def run_numerics_test(case: str, dtype_name: str) -> None:
     rank = torch.distributed.get_rank()
     local_rank = int(os.environ["LOCAL_RANK"])
     device = torch.device("cuda", local_rank)
@@ -209,7 +209,6 @@ def run_numerics_test(case: str, dtype_name: str):
     torch.distributed.broadcast_object_list(objects, src=0, device=device)
     reference_names = cast(list[str], objects[0])
     assert set(parallel_parameters) == set(reference_names)
-    gradient_errors: dict[str, float] = {}
     gradient_error_stats: dict[str, dict[str, float]] = {}
     nonfinite_gradients: list[str] = []
     for name in parallel_parameters:
@@ -221,7 +220,6 @@ def run_numerics_test(case: str, dtype_name: str):
         if rank == 0:
             assert reference_gradients is not None
             stats = _error_stats(full_gradient.cpu(), reference_gradients[name])
-            gradient_errors[name] = stats["relative_error"]
             gradient_error_stats[name] = stats
             if (
                 not torch.isfinite(full_gradient).all()
@@ -232,6 +230,10 @@ def run_numerics_test(case: str, dtype_name: str):
     if rank == 0:
         assert reference_gradients is not None
         assert output_error is not None
+        gradient_errors = {
+            name: stats["relative_error"]
+            for name, stats in gradient_error_stats.items()
+        }
         worst_name, worst_error = max(gradient_errors.items(), key=lambda item: item[1])
         result = {
             "case": case,
@@ -251,8 +253,8 @@ def run_numerics_test(case: str, dtype_name: str):
             "output_error_stats": output_stats,
             "output_relative_error": output_error,
             "thresholds": {
-                "gradient_relative_error": _GRAD_RTOL,
-                "output_relative_error": _OUTPUT_RTOL,
+                "gradient_relative_error": _GRADIENT_ERROR_LIMIT,
+                "output_relative_error": _OUTPUT_ERROR_LIMIT,
             },
             "worst_gradient": {
                 "name": worst_name,
@@ -265,12 +267,15 @@ def run_numerics_test(case: str, dtype_name: str):
             failures.append("non-finite output")
         if nonfinite_gradients:
             failures.append(f"non-finite gradients: {', '.join(nonfinite_gradients)}")
-        if output_error >= _OUTPUT_RTOL:
-            failures.append(f"output relative error {output_error} >= {_OUTPUT_RTOL}")
+        if output_error >= _OUTPUT_ERROR_LIMIT:
+            failures.append(
+                f"output relative error {output_error} >= {_OUTPUT_ERROR_LIMIT}"
+            )
         for name, error in gradient_errors.items():
-            if error >= _GRAD_RTOL:
+            if error >= _GRADIENT_ERROR_LIMIT:
                 failures.append(
-                    f"gradient {name} relative error {error} >= {_GRAD_RTOL}"
+                    f"gradient {name} relative error {error} "
+                    f">= {_GRADIENT_ERROR_LIMIT}"
                 )
         failure = "\n".join(failures) if failures else None
     else:

--- a/tests/test_ds3_local_map_numerics.py
+++ b/tests/test_ds3_local_map_numerics.py
@@ -210,6 +210,8 @@ def run_numerics_test(case: str, dtype_name: str) -> None:
     reference_names = cast(list[str], objects[0])
     assert set(parallel_parameters) == set(reference_names)
     gradient_error_stats: dict[str, dict[str, float]] = {}
+    parallel_gradient_dtypes: set[str] = set()
+    reference_gradient_dtypes: set[str] = set()
     nonfinite_gradients: list[str] = []
     for name in parallel_parameters:
         gradient = parallel_parameters[name].grad
@@ -221,6 +223,8 @@ def run_numerics_test(case: str, dtype_name: str) -> None:
             assert reference_gradients is not None
             stats = _error_stats(full_gradient.cpu(), reference_gradients[name])
             gradient_error_stats[name] = stats
+            parallel_gradient_dtypes.add(str(full_gradient.dtype))
+            reference_gradient_dtypes.add(str(reference_gradients[name].dtype))
             if (
                 not torch.isfinite(full_gradient).all()
                 or not torch.isfinite(reference_gradients[name]).all()
@@ -229,6 +233,7 @@ def run_numerics_test(case: str, dtype_name: str) -> None:
 
     if rank == 0:
         assert reference_gradients is not None
+        assert reference_output is not None
         assert output_error is not None
         gradient_errors = {
             name: stats["relative_error"]
@@ -249,6 +254,26 @@ def run_numerics_test(case: str, dtype_name: str) -> None:
                 "seq_len": _SEQ_LEN,
             },
             "nonfinite_gradients": nonfinite_gradients,
+            "observed_dtypes": {
+                "compute": str(compute_dtype),
+                "parallel_gradients": sorted(parallel_gradient_dtypes),
+                "parallel_output": str(full_output.dtype),
+                "parallel_parameters": sorted(
+                    {
+                        str(
+                            parameter.to_local().dtype
+                            if isinstance(parameter, DTensor)
+                            else parameter.dtype
+                        )
+                        for parameter in parallel_parameters.values()
+                    }
+                ),
+                "reference_gradients": sorted(reference_gradient_dtypes),
+                "reference_output": str(reference_output.dtype),
+                "reference_parameters": sorted(
+                    {str(value.dtype) for value in reference_state.values()}
+                ),
+            },
             "output_finite": output_finite,
             "output_error_stats": output_stats,
             "output_relative_error": output_error,

--- a/tests/test_ds3_local_map_numerics.py
+++ b/tests/test_ds3_local_map_numerics.py
@@ -26,6 +26,10 @@ _LOCAL_BATCH_SIZE = 1
 _SEED = 0
 _OUTPUT_RTOL = 5e-3
 _GRAD_RTOL = 2e-2
+_DTYPES = {
+    "bfloat16": torch.bfloat16,
+    "float32": torch.float32,
+}
 
 _CASES: dict[str, dict[str, int]] = {
     "efsdp_boundary": dict(dp_replicate=1, dp_shard=4, cp=1, tp=1, ep=2),
@@ -34,14 +38,21 @@ _CASES: dict[str, dict[str, int]] = {
 }
 
 
-def _relative_error(actual: torch.Tensor, expected: torch.Tensor) -> float:
+def _error_stats(actual: torch.Tensor, expected: torch.Tensor) -> dict[str, float]:
     actual = actual.float()
     expected = expected.float()
-    diff_norm = torch.linalg.vector_norm(actual - expected)
+    diff = actual - expected
+    diff_norm = torch.linalg.vector_norm(diff)
     expected_norm = torch.linalg.vector_norm(expected)
-    if expected_norm == 0:
-        return diff_norm.item()
-    return (diff_norm / expected_norm).item()
+    relative_error = (
+        diff_norm.item() if expected_norm == 0 else (diff_norm / expected_norm).item()
+    )
+    return {
+        "diff_norm": diff_norm.item(),
+        "max_abs": diff.abs().max().item(),
+        "reference_norm": expected_norm.item(),
+        "relative_error": relative_error,
+    }
 
 
 def _gather_state_dict(model: torch.nn.Module, rank: int) -> dict[str, torch.Tensor]:
@@ -59,6 +70,7 @@ def _run_reference(
     tokens: torch.Tensor,
     device: torch.device,
     reference_mesh,
+    compute_dtype: torch.dtype,
 ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
     roles = MoEMeshRoles(ep_axis_names=("ep",), ep_group_name="ep")
     with torch.device("meta"):
@@ -66,7 +78,7 @@ def _run_reference(
             config,
             mesh=reference_mesh,
             roles=roles,
-            compute_dtype=torch.bfloat16,
+            compute_dtype=compute_dtype,
         )
     model.to_empty(device=device)
     model.init_weights(buffer_device=device, seed=_SEED)
@@ -87,10 +99,11 @@ def _run_reference(
     return output, gradients
 
 
-def run_numerics_test(case: str):
+def run_numerics_test(case: str, dtype_name: str):
     rank = torch.distributed.get_rank()
     local_rank = int(os.environ["LOCAL_RANK"])
     device = torch.device("cuda", local_rank)
+    compute_dtype = _DTYPES[dtype_name]
     degrees = _CASES[case]
     mesh, roles = build_moe_mesh(
         dp_replicate=degrees["dp_replicate"],
@@ -107,7 +120,7 @@ def run_numerics_test(case: str):
             config,
             mesh=mesh,
             roles=roles,
-            compute_dtype=torch.bfloat16,
+            compute_dtype=compute_dtype,
         )
 
     sample_input = torch.empty(
@@ -118,7 +131,7 @@ def run_numerics_test(case: str):
         return sample_input
 
     mp_policy = MixedPrecisionPolicy(
-        param_dtype=torch.bfloat16,
+        param_dtype=compute_dtype,
         reduce_dtype=torch.float32,
     )
     with AutoParallel(
@@ -156,7 +169,12 @@ def run_numerics_test(case: str):
     if rank == 0:
         assert global_tokens is not None
         reference_output, reference_gradients = _run_reference(
-            config, reference_state, global_tokens, device, reference_mesh
+            config,
+            reference_state,
+            global_tokens,
+            device,
+            reference_mesh,
+            compute_dtype,
         )
     else:
         reference_output = None
@@ -171,10 +189,12 @@ def run_numerics_test(case: str):
         output.detach(), mesh, input_placements, run_check=False
     ).full_tensor()
     output_error = None
+    output_stats: dict[str, float] = {}
     output_finite = False
     if rank == 0:
         assert reference_output is not None
-        output_error = _relative_error(full_output.cpu(), reference_output)
+        output_stats = _error_stats(full_output.cpu(), reference_output)
+        output_error = output_stats["relative_error"]
         output_finite = bool(torch.isfinite(full_output).all()) and bool(
             torch.isfinite(reference_output).all()
         )
@@ -190,6 +210,7 @@ def run_numerics_test(case: str):
     reference_names = cast(list[str], objects[0])
     assert set(parallel_parameters) == set(reference_names)
     gradient_errors: dict[str, float] = {}
+    gradient_error_stats: dict[str, dict[str, float]] = {}
     nonfinite_gradients: list[str] = []
     for name in parallel_parameters:
         gradient = parallel_parameters[name].grad
@@ -199,8 +220,9 @@ def run_numerics_test(case: str):
         )
         if rank == 0:
             assert reference_gradients is not None
-            error = _relative_error(full_gradient.cpu(), reference_gradients[name])
-            gradient_errors[name] = error
+            stats = _error_stats(full_gradient.cpu(), reference_gradients[name])
+            gradient_errors[name] = stats["relative_error"]
+            gradient_error_stats[name] = stats
             if (
                 not torch.isfinite(full_gradient).all()
                 or not torch.isfinite(reference_gradients[name]).all()
@@ -214,7 +236,9 @@ def run_numerics_test(case: str):
         result = {
             "case": case,
             "degrees": degrees,
+            "dtype": dtype_name,
             "gradient_count": len(reference_gradients),
+            "gradient_error_stats": gradient_error_stats,
             "gradient_relative_errors": gradient_errors,
             "model": {
                 "global_batch_size": global_batch_size,
@@ -224,6 +248,7 @@ def run_numerics_test(case: str):
             },
             "nonfinite_gradients": nonfinite_gradients,
             "output_finite": output_finite,
+            "output_error_stats": output_stats,
             "output_relative_error": output_error,
             "thresholds": {
                 "gradient_relative_error": _GRAD_RTOL,
@@ -263,6 +288,7 @@ def run_numerics_test(case: str):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--case", required=True, choices=_CASES)
+    parser.add_argument("--dtype", required=True, choices=_DTYPES)
     args = parser.parse_args()
 
     if (
@@ -275,8 +301,11 @@ def main():
     torch.cuda.set_device(device)
     torch.distributed.init_process_group("nccl", device_id=device)
     torch.use_deterministic_algorithms(True)
+    torch.set_float32_matmul_precision("highest")
+    torch.backends.cuda.matmul.allow_tf32 = False
+    torch.backends.cudnn.allow_tf32 = False
     try:
-        run_numerics_test(args.case)
+        run_numerics_test(args.case, args.dtype)
     finally:
         torch.distributed.barrier(device_ids=[local_rank])
         torch.distributed.destroy_process_group()

--- a/tests/test_graph_clustering.py
+++ b/tests/test_graph_clustering.py
@@ -9,7 +9,11 @@ import torch
 from torch.distributed.fsdp import MixedPrecisionPolicy
 from torch.distributed.tensor.placement_types import Replicate, Shard
 
-from autoparallel._testing.models.dsv3 import DeepSeekV3Model, make_dsv3_config
+from autoparallel._testing.models.dsv3 import (
+    DeepSeekV3Model,
+    MoEMeshRoles,
+    make_dsv3_config,
+)
 from autoparallel._testing.models.llama3 import Transformer, TransformerModelArgs
 from autoparallel.api import AutoParallel
 from autoparallel.export_json import _get_layer_index
@@ -207,15 +211,17 @@ def _setup_ds3_local_map_autop(device_mesh_2d):
         local_batch_size * device_mesh_2d.shape[0] * device_mesh_2d.shape[1]
     )
     config = make_dsv3_config(max_seq_len=seq_len)
+    # EP on the 2nd mesh axis (matches the pre-roles behavior of setting
+    # MoE.axis_name = mesh_dim_names[1]).
+    ep_name = device_mesh_2d.mesh_dim_names[1]
+    roles = MoEMeshRoles(ep_axis_names=(ep_name,), ep_group_name=ep_name)
     with torch.device("meta"):
         model = DeepSeekV3Model(
             config,
             mesh=device_mesh_2d,
+            roles=roles,
             compute_dtype=torch.bfloat16,
         )
-    for module in model.modules():
-        if hasattr(module, "axis_name"):
-            module.axis_name = device_mesh_2d.mesh_dim_names[1]
 
     def input_fn():
         return torch.randint(

--- a/tests/test_graph_clustering.py
+++ b/tests/test_graph_clustering.py
@@ -9,11 +9,8 @@ import torch
 from torch.distributed.fsdp import MixedPrecisionPolicy
 from torch.distributed.tensor.placement_types import Replicate, Shard
 
-from autoparallel._testing.models.dsv3 import (
-    DeepSeekV3Model,
-    MoEMeshRoles,
-    make_dsv3_config,
-)
+from autoparallel import MoEMeshRoles
+from autoparallel._testing.models.dsv3 import DeepSeekV3Model, make_dsv3_config
 from autoparallel._testing.models.llama3 import Transformer, TransformerModelArgs
 from autoparallel.api import AutoParallel
 from autoparallel.export_json import _get_layer_index

--- a/tests/test_optimize_placement.py
+++ b/tests/test_optimize_placement.py
@@ -460,11 +460,14 @@ def test_local_map_placement_respected(device_mesh_2d, device="cuda"):
     for act_spec in act_specs:
         assert act_spec.placements == (Replicate(), Replicate())
 
-    # Check bw outputs
+    # Check bw outputs. k/v are Replicate on mesh axis 1 in the forward, so their
+    # gradient is Partial(sum) there (autograd duality), reduced at the boundary.
     assert len(bw_spec.output_specs) == 3  # query, key, value
     grad_q_spec, grad_k_spec, grad_v_spec = bw_spec.output_specs
     assert grad_q_spec.placements == (Shard(dim=0), Shard(dim=2))
-    assert grad_k_spec.placements == grad_v_spec.placements == (Shard(0), Replicate())
+    assert (
+        grad_k_spec.placements == grad_v_spec.placements == (Shard(0), Partial("sum"))
+    )
 
 
 @apply_cuda_patches


### PR DESCRIPTION
## Summary
Adds DeepSeek-V3 MoE `local_map` support for N-D aligned meshes on a **single AutoParallel mesh** (config-driven). Supersedes the earlier axis-name-driven draft that previously lived on this branch.

Current head also rejects non-positive and non-integer parallelism degrees before mesh-alignment arithmetic.

## Public interface

```python
from autoparallel import build_moe_local_map_placements, build_moe_mesh

mesh, roles = build_moe_mesh(
    dp_replicate=2,
    dp_shard=2,
    cp=1,
    tp=1,
    ep=2,
)
model = MyMoEModel(..., mesh=mesh, roles=roles)
```

`build_moe_mesh` returns the single `DeviceMesh` used by AutoParallel plus a `MoEMeshRoles` value describing the physical axes and flattened group used for expert parallelism. Pass the returned `roles` through to an N-D/custom MoE model; omitting it only retains the legacy 2-D mesh behavior whose EP axis is named `"ep"`. Size-1 axes are removed, so callers must use `roles` rather than assuming a fixed mesh rank or axis name.

`ep` is the logical expert-parallel group size formed from axes already present in `dp_shard * cp * tp`; it is not another world-size factor:

```text
world_size = dp_replicate * dp_shard * cp * tp
efsdp      = dp_shard * cp * tp / ep
```

All degrees must be positive integers. Aligned configurations additionally require `ep >= 2`, `ep % (cp * tp) == 0`, `dp_shard % (ep / (cp * tp)) == 0`, and `num_experts % ep == 0`.

For custom `local_map` regions, `build_moe_local_map_placements(mesh.mesh_dim_names, roles)` returns `(token_placements, expert_weight_placements, count_placements)`: tokens are `Shard(0)` on every active axis, expert weights are `Shard(0)` on EP axes and `Replicate()` elsewhere, and counts are `Partial(sum)`. Expert weights remain replicated at the eFSDP/data-parallel region boundary; in-region expert tensor parallelism is outside this PR.

## What changed

### Single aligned mesh + role map (`autoparallel/moe.py`)
- Public `MoEMeshRoles`, `build_moe_mesh`, and `build_moe_local_map_placements` build one mesh whose atoms are the common refinement of the dense `{dp_shard, cp, tp}` and sparse `{efsdp, ep}` groupings: `(dp_replicate, dp_shard_mod_ep, dp_shard_in_ep, cp, tp)`, size-1 dropped. `efsdp = dp_shard*cp*tp/ep`; the EP group is `flatten(dp_shard_in_ep, cp, tp)`.
- Tokens are `Shard(0)`, counts are `Partial(sum)`, and expert weights are `Shard(0)` on EP axes and `Replicate()` elsewhere (including eFSDP).
- `_testing.models.dsv3` keeps compatibility aliases for existing internal imports; external callers should import the helpers from `autoparallel`.
- `_validate_moe_sharding` checks `num_experts % ep == 0` after the mesh is available.

### local_map backward gradient placement (`autoparallel/shardings/placement_options.py`)
Because expert weights (and, generally, any `local_map` input that is `Replicate` over a data-parallel axis) are `Replicate` at the boundary, their gradient is `Partial(sum)`—the autograd dual of a `Replicate` input. `get_local_map_placement_option` maps a backward `local_map` node's replicated input-gradients to `Partial(sum)`, so AutoParallel reduce-scatters (FSDP) / all-reduces (DDP) them over eFSDP/DP through the existing `Partial → reduce` path.

### torch-2.14 compatibility (`placement_options.py`, `autoparallel/collectives.py`)
- Accept the renamed `local_map_hop` HOP target.
- `_AllToAll.backward` returns the correct gradient arity for the four-input forward; `axis_size` resolves a flattened EP group through `mesh.get_group(...)`.

### Example & tests
- `examples/example_ds3_local_map.py`: mesh built through the public `build_moe_mesh`; degrees remain exposed on the CLI.
- `tests/test_api.py`: public imports, mesh shapes, role maps, placements, validation, and legacy internal aliases.
- [`tests/test_ds3_local_map_numerics.py`](https://github.com/meta-pytorch/autoparallel/blob/fb62a518481118cb0e151dc835700783e441be94/tests/test_ds3_local_map_numerics.py): real four-GPU NCCL forward/backward compared with a single-GPU reference using identical full weights and input. It supports explicit BF16 and FP32 modes, records the observed dtypes, and emits full output/per-gradient error statistics. The CUDA workflow runs the BF16 `legacy_2d` case as a regression gate.
- [`_run_experts_grouped_mm`](https://github.com/meta-pytorch/autoparallel/blob/fb62a518481118cb0e151dc835700783e441be94/autoparallel/_testing/models/dsv3.py#L276-L314): retains the existing BF16 `_grouped_mm` path. PyTorch's `_grouped_mm` tracing contract only accepts BF16, so the explicit FP32 evidence mode uses ordinary per-expert `F.linear` operations with the same routed tokens, weights, and offsets.

## Numerical validation

Source commit: [`fb62a51`](https://github.com/meta-pytorch/autoparallel/commit/fb62a518481118cb0e151dc835700783e441be94).

Method: existing six-layer DeepSeek-V3 debug config, eight experts, global batch 4, sequence length 2048, seed 0. Rank 0 runs the single-GPU non-AutoParallel reference after strict-loading the full state gathered from the distributed model. The test compares full logits and all 83 parameter gradients using float32 L2 norm-relative error. Acceptance is logits `< 5e-3`, every gradient `< 2e-2`, and all values finite. TF32 is disabled and float32 matmul precision is `highest`.

Environment: 4×NVIDIA H100 (97,871 MiB each), driver 580.126.09, PyTorch `2.14.0.dev20260629+cu130`, CUDA 13.0, NCCL 2.30.7.

```bash
for case in efsdp_boundary legacy_2d flattened_ep; do
  PYTHONPATH=. torchrun --standalone --nproc-per-node 4 \
    tests/test_ds3_local_map_numerics.py --case "$case" --dtype bfloat16
done

PYTHONPATH=. torchrun --standalone --nproc-per-node 4 \
  tests/test_ds3_local_map_numerics.py --case legacy_2d --dtype float32
```

| Mode | Case | `(dp_replicate, dp_shard, cp, tp, ep)` | Logits rel. error | Gradients | Worst grad rel. error | Worst parameter |
| --- | --- | --- | ---: | ---: | ---: | --- |
| BF16 | `efsdp_boundary` | `(1, 4, 1, 1, 2)` | `2.0466943e-3` | 83/83 PASS | `1.8819643e-2` | `layers.3.moe.router.gate.weight` |
| BF16 | `legacy_2d` | `(2, 2, 1, 1, 2)` | `2.0466943e-3` | 83/83 PASS | `1.8819643e-2` | `layers.3.moe.router.gate.weight` |
| BF16 | `flattened_ep` | `(1, 2, 2, 1, 4)` | `2.0466943e-3` | 83/83 PASS | `1.8819643e-2` | `layers.3.moe.router.gate.weight` |
| FP32 | `legacy_2d` | `(2, 2, 1, 1, 2)` | `1.6544281e-7` | 83/83 PASS | `1.1175936e-6` | `layers.0.attention_norm.weight` |

For the original worst parameter, `layers.3.moe.router.gate.weight`, FP32 reduces relative error from `1.8819643e-2` to `7.8102431e-7`. The FP32 result records `torch.float32` for both distributed and reference outputs, parameters, and gradients. The BF16 result records BF16 outputs with FP32 parameter storage and gradients, matching the mixed-precision policy.

Each row is one deterministic run; variance was not estimated. The harness emits a `NUMERICS_RESULT` JSON record with diff norm, reference norm, maximum absolute error, relative error, observed dtypes, and every per-parameter result.

Additional checks: BF16 and FP32 four-GPU E2E passed on `legacy_2d`; current-head MoE public-interface tests `11 passed`; graph-clustering tests `2 passed`; Black, flake8, isort, and mypy passed on the changed Python files.

## Scope / caveats
- The boundary grad-duality applies to all `local_map` backward nodes; full numerics here validate the MoE path. The attention k/v case remains validated at the placement level.
- No full numeric e2e for a three-or-more-atom EP group or an eight-GPU flattened-EP subgroup; the four-GPU `flattened_ep` case validates a two-axis flattened group.
- The true FP32 evidence run covers `legacy_2d`; the other two mesh cases were run in BF16.
- Does not add ETP / in-region expert-weight tensor-parallel sharding.

Authored with Claude Code.
