### PR TITLE
Avoid logical/physical placement divergence for Partial targets

### DIFF
--- a/autoparallel/apply_sharding.py
+++ b/autoparallel/apply_sharding.py
@@ -140,8 +140,11 @@ class ApplyShardingInterpreter(torch.fx.Interpreter):
         return curr_shard_order, tgt_shard_order
 
     def redistribute_tensor(self, arg, curr_spec, tgt_spec, node):
+        # Preserve Partial -> Partial; only coerce unsupported transitions that
+        # would need to create a Partial value from a non-Partial source.
         tgt_placements = tuple(
-            p if not p.is_partial() else Replicate() for p in tgt_spec.placements
+            tgt_p if not tgt_p.is_partial() or curr_p.is_partial() else Replicate()
+            for curr_p, tgt_p in zip(curr_spec.placements, tgt_spec.placements)
         )
         x = arg
         if node in self.param_placement_order and self.param_placement_order[node][1]:

--- a/tests/test_apply_sharding.py
+++ b/tests/test_apply_sharding.py
@@ -50,13 +50,20 @@ class TestComputeShardOrder:
 
 def _count_collectives(gm):
     """Count collective ops in a traced graph by type."""
-    counts = {"all_gather": 0, "reduce_scatter": 0, "alltoall": 0}
+    counts = {
+        "all_gather": 0,
+        "all_reduce": 0,
+        "reduce_scatter": 0,
+        "alltoall": 0,
+    }
     for n in gm.graph.nodes:
         if n.op != "call_function":
             continue
         name = getattr(n.target, "__name__", "")
         if "all_gather" in name:
             counts["all_gather"] += 1
+        elif "all_reduce" in name:
+            counts["all_reduce"] += 1
         elif "reduce_scatter" in name:
             counts["reduce_scatter"] += 1
         elif "alltoall" in name:
@@ -175,6 +182,40 @@ class TestOrderedRedistributeFusion:
         gm = make_fx(trace_fn, tracing_mode="real")(local)
         counts = _count_collectives(gm)
         assert counts["all_gather"] >= 1
+
+
+class TestPartialRedistribution:
+    def test_partial_to_partial_does_not_reduce(self, device_mesh_2d):
+        """Redistributing another mesh dim must preserve an unchanged Partial.
+
+        This models a CP weight-gradient edge where (R, P) -> (S(1), P).
+        Materializing the CP Partial as Replicate here would insert an early
+        all-reduce, and the planned P -> R transition would reduce it again.
+        """
+        from autoparallel.apply_sharding import ApplyShardingInterpreter
+
+        tm = _make_tensor_meta([512, 128])
+        curr_spec = DTensorSpec(
+            device_mesh_2d, (Replicate(), Partial()), tensor_meta=tm
+        )
+        tgt_spec = DTensorSpec(
+            device_mesh_2d, (Shard(1), Partial()), tensor_meta=tm
+        )
+
+        graph = torch.fx.Graph()
+        node = graph.placeholder("grad")
+        graph.output(node)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        interp = ApplyShardingInterpreter(gm, {}, param_placement_order={})
+
+        local = torch.randn(512, 128, device="meta")
+
+        def trace_fn(x):
+            return interp.redistribute_tensor(x, curr_spec, tgt_spec, node)
+
+        traced = make_fx(trace_fn, tracing_mode="real")(local)
+        counts = _count_collectives(traced)
+        assert counts["all_reduce"] == 0
 
 
 class TestShardOrderSpecIsolation:


### PR DESCRIPTION
## Problem
[`ApplyShardingInterpreter.redistribute_tensor()`](https://github.com/meta-pytorch/autoparallel/blob/a54c2529b1cb10b6b27a585b4a6fc2f84bc1d232/autoparallel/apply_sharding.py#L143-L145) unconditionally converts target `Partial` placements to `Replicate`. This conversion is only applied to a temporary `DTensorSpec`. The corresponding `self.sharding_placement` remains `Partial`, creating a mismatch:
```
Logical metadata: Partial
Physical tensor:  Replicate
```
Downstream redistribution continues using the logical metadata and can insert incorrect collectives.

## Reproduction


In a typical LLM model backward weight-gradient path on a device mesh `("dp_shard", "cp")`:
```
einsum [512,128]
  → permute [128,512]
  → down_proj.weight.grad
```
Planned placements:
```
einsum output:  (Replicate, Partial)
permute input:  (Shard(1), Partial)
permute output: (Shard(0), Partial)
final gradient: (Shard(0), Replicate)
```
The first edge only needs to change the `dp_shard` dimension:
```
(R, P) → (S(1), P)
```
However, the existing implementation rewrites the target to:
```
(R, P) → (S(1), R)
```
This inserts an unintended CP reduction:
```
clone_13 [512,128]
  → all_reduce_2(cp)      # unintended
  → permute_121 [128,512]
  → all_reduce_3(cp)      # planned P → R reduction
  → down_proj.weight.grad
```
The first reduction physically produces `(S(1), R)`, but metadata still describes the permute input as `(S(1), P)`. Consequently, the permute output is logically recorded as `(S(0), P)`, causing the second reduction.

For a CP group of size 2:

```
actual_gradient = 2 * reference_gradient
```
## Why this is easy to miss
For a one-dimensional exact transition:
```
(P) → (P)
```
the source and target tuples are equal, so redistribution is skipped.

The issue appears on multidimensional meshes when another dimension changes:
```
(R, P) → (S(1), P)
```
The difference in the first dimension activates redistribution, after which the unchanged second Partial dimension is also converted to `Replicate`.

## Proposed fix
Preserve a target `Partial` when the current placement is the same, including its reduction operation:
```
tgt_placements = tuple(
            tgt_p if not tgt_p.is_partial() or curr_p.is_partial() else Replicate()
            for curr_p, tgt_p in zip(curr_spec.placements, tgt_spec.placements)
        )
```

## Design concern
Silently substituting `Replicate` for incompatible `Partial` targets still leaves logical and physical placements inconsistent. Mutating only `self.sharding_placement[node].input_specs` is not sufficient because the node’s output and all downstream consumer specs would also need to be recomputed.