### PR TITLE
Aggregate: optimizer build, TRW-S, lazy costs, and split-dim seed

### DIFF
--- a/autoparallel/__init__.py
+++ b/autoparallel/__init__.py
@@ -7,6 +7,7 @@ from autoparallel.api import AutoParallel, auto_parallel
 from autoparallel.collectives import with_sharding_constraint
 from autoparallel.compile import autoparallel_backend
 from autoparallel.input_validation import ForwardInputs
+from autoparallel.mesh_search import build_split_dim_seed
 
 __all__ = [
     "auto_parallel",
@@ -14,4 +15,5 @@ __all__ = [
     "autoparallel_backend",
     "ForwardInputs",
     "with_sharding_constraint",
+    "build_split_dim_seed",
 ]

--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -236,6 +236,9 @@ class AutoParallel:
         fast_build: Skip DTensor enumeration costs that AutoParallel recomputes.
     """
 
+    # Selectable solvers over the eagerly built optimizer problem.
+    SOLVER_CHOICES = ("ilp", "lp")
+
     def __init__(
         self,
         model,
@@ -247,8 +250,14 @@ class AutoParallel:
         cost_model: Any = "nccl",
         repeated_subgraphs: bool = True,
         fast_build: bool = True,
+        solver: str = "ilp",
     ):
         self.stack = ExitStack()
+        if solver not in self.SOLVER_CHOICES:
+            raise ValueError(
+                f"Unknown solver={solver!r}; expected one of {self.SOLVER_CHOICES}"
+            )
+        self.solver = solver
         self.fake_mode = (
             FakeTensorMode()
         )  # TODO: maybe need to reuse the model's fake mode
@@ -402,10 +411,49 @@ class AutoParallel:
         self.sharding_optimizer.add_sharded_output_constraint(constraints)
         self.output_constraints = constraints
 
-    def optimize_placement(self, verbose=False):
-        self._assert_entered()
+    def optimize_placement(
+        self,
+        verbose=True,
+        solver=None,
+        optimality_check=False,
+    ):
+        """Solve for the optimal placement.
 
-        self.sharding_placement = self.sharding_optimizer.get_solution(verbose=False)
+        solver selects how the placement is solved (defaults to the solver chosen
+        at AutoParallel construction):
+          - "ilp":    exact PuLP/CBC solve.
+          - "lp":     solve the LP relaxation and use it directly. This problem is
+            empirically integral, so the relaxation optimum equals the ILP optimum
+            while skipping branch-and-bound; raises if it comes out fractional.
+
+        optimality_check: after solving, solve the LP relaxation as a lower bound
+        and log the certified gap of the achieved objective from the optimum.
+        Requires a PuLP problem (i.e. an "ilp"/"lp" build).
+        """
+        self._assert_entered()
+        if solver is None:
+            solver = self.solver
+
+        opt = self.sharding_optimizer
+        if solver == "ilp":
+            self.sharding_placement = opt.get_solution(verbose=False)
+        elif solver in ("lp", "lp_relax", "lp_relaxation"):
+            opt._set_objective()
+            res = opt.solve_lp_relaxation(verbose=verbose, extract=True)
+            if res["solution"] is None:
+                raise RuntimeError(
+                    "solver='lp' requires an integral LP relaxation, but it came "
+                    f"out fractional ({res['n_fractional']}/{res['n_vars']} "
+                    "variables). Use solver='ilp' for an exact integral solve."
+                )
+            self.sharding_placement = res["solution"]
+        else:
+            raise ValueError(
+                f"Unknown solver={solver!r}; expected one of {self.SOLVER_CHOICES}"
+            )
+
+        if optimality_check:
+            self._log_optimality_check(solver, verbose=verbose)
 
         if verbose:
             logger.info(self.sharding_optimizer.get_log(verbose=True))
@@ -421,7 +469,10 @@ class AutoParallel:
             ),
         )
 
-        if self.sharding_optimizer.prob.status == -1:
+        if (
+            self.sharding_optimizer.prob is not None
+            and self.sharding_optimizer.prob.status == -1
+        ):
             raise RuntimeError(
                 "The sharding optimizer could not find a feasible solution. "
                 "This typically means the user-specified constraints are "
@@ -441,6 +492,39 @@ class AutoParallel:
         )
 
         return self.sharding_placement
+
+    def _log_optimality_check(self, solver, verbose=False):
+        """Solve the LP relaxation as a lower bound and log the certified gap of
+        the achieved objective from the optimum. Needs a PuLP problem."""
+        import pulp
+
+        opt = self.sharding_optimizer
+        if opt.prob is None:
+            logger.warning(
+                "optimality_check skipped: solver=%r build has no PuLP problem; "
+                "construct with solver='ilp' or 'lp' to enable it.",
+                self.solver,
+            )
+            return
+        achieved = opt._safe_float(pulp.value(opt.prob.objective))
+        lb_res = opt.get_lower_bound(verbose=verbose)
+        lb = lb_res.objective
+        if not lb or lb <= 0 or achieved is None:
+            logger.warning(
+                "optimality_check inconclusive: lower_bound=%s achieved=%s",
+                lb,
+                achieved,
+            )
+            return
+        gap = (achieved - lb) / lb
+        logger.info(
+            "optimality check (solver=%s): objective=%.4f LP lower bound=%.4f "
+            "=> within %.2f%% of optimum (certified)",
+            solver,
+            achieved,
+            lb,
+            gap * 100,
+        )
 
     def _apply_placement_common(self, sharding_placement):
         t0 = time.perf_counter()

--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -236,7 +236,9 @@ class AutoParallel:
         fast_build: Skip DTensor enumeration costs that AutoParallel recomputes.
     """
 
-    # Selectable solvers over the eagerly built optimizer problem.
+    # Selectable solvers. "ilp": exact PuLP/CBC. "approx": heuristic TRW-S
+    # (light build, no PuLP). "lp": LP relaxation used directly as the solve
+    # (empirically integral for this problem, so much cheaper than CBC).
     SOLVER_CHOICES = ("ilp", "approx", "lp")
 
     def __init__(
@@ -251,8 +253,15 @@ class AutoParallel:
         repeated_subgraphs: bool = True,
         fast_build: bool = True,
         solver: str = "ilp",
+        lazy_costs: Optional[bool] = None,
     ):
         self.stack = ExitStack()
+        # The solver chosen here decides how the optimizer is built: "ilp"/"lp"
+        # build the full PuLP problem (CBC exact solve / LP relaxation solve);
+        # "approx" builds a lighter optimizer (no PuLP variables/constraints),
+        # much faster to construct, solved heuristically. optimize_placement(
+        # solver=...) may override the solve as long as it is compatible with
+        # this build.
         if solver not in self.SOLVER_CHOICES:
             raise ValueError(
                 f"Unknown solver={solver!r}; expected one of {self.SOLVER_CHOICES}"
@@ -269,6 +278,10 @@ class AutoParallel:
         self.cost_model = cost_model
         self.repeated_subgraphs = repeated_subgraphs
         self.fast_build = fast_build
+        # None => default per solver: approx builds lazy (no eager per-edge cost
+        # estimation; the TRW-S solver computes costs on demand), ilp/lp build
+        # eager (a PuLP objective needs the costs). True/False forces lazy/eager.
+        self.lazy_costs = lazy_costs
         # copy user model to avoid modifying it in-place
         # in dtype casting and move_to_fake
         model = copy.deepcopy(model)
@@ -336,6 +349,12 @@ class AutoParallel:
                 force_grad_reduce_in_higher_precision,
                 repeated_subgraphs=self.repeated_subgraphs,
                 fast_build=self.fast_build,
+                build_pulp=self.solver in ("ilp", "lp"),
+                build_costs=(
+                    (self.solver != "approx")
+                    if self.lazy_costs is None
+                    else (not self.lazy_costs)
+                ),
             )
 
             self.sharding_optimizer = sharding_optimizer
@@ -423,12 +442,15 @@ class AutoParallel:
         solver selects how the placement is solved (defaults to the solver chosen
         at AutoParallel construction):
           - "ilp":    exact PuLP/CBC solve.
-          - "approx": heuristic TRW-S ApproximateShardingSolver.
+          - "approx": heuristic TRW-S ApproximateShardingSolver — trades a small
+            objective gap for a much faster solve.
           - "lp":     solve the LP relaxation and use it directly. This problem is
             empirically integral, so the relaxation optimum equals the ILP optimum
             while skipping branch-and-bound; raises if it comes out fractional.
         approximate_options is forwarded as kwargs to the approximate solver
-        (e.g. candidate_limit, max_sweeps).
+        (e.g. candidate_limit, max_sweeps). The requested solver must be
+        compatible with how the optimizer was built: "ilp"/"lp" need a PuLP
+        problem (build with solver="ilp" or "lp").
 
         optimality_check: after solving, solve the LP relaxation as a lower bound
         and log the certified gap of the achieved objective from the optimum.
@@ -445,8 +467,20 @@ class AutoParallel:
             approx = ApproximateShardingSolver(opt, **(approximate_options or {}))
             self.sharding_placement = approx.get_solution(verbose=verbose)
         elif solver == "ilp":
+            if opt.prob is None:
+                raise RuntimeError(
+                    "solver='ilp' requires a PuLP problem, but this AutoParallel "
+                    "was constructed without one (e.g. solver='approx'). "
+                    "Construct with solver='ilp' to use the exact solver."
+                )
             self.sharding_placement = opt.get_solution(verbose=False)
         elif solver in ("lp", "lp_relax", "lp_relaxation"):
+            if opt.prob is None:
+                raise RuntimeError(
+                    "solver='lp' requires a PuLP problem, but this AutoParallel "
+                    "was constructed without one (e.g. solver='approx'). "
+                    "Construct with solver='lp' or 'ilp' to use the LP solver."
+                )
             opt._set_objective()
             res = opt.solve_lp_relaxation(verbose=verbose, extract=True)
             if res["solution"] is None:

--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -237,7 +237,7 @@ class AutoParallel:
     """
 
     # Selectable solvers over the eagerly built optimizer problem.
-    SOLVER_CHOICES = ("ilp", "lp")
+    SOLVER_CHOICES = ("ilp", "approx", "lp")
 
     def __init__(
         self,
@@ -415,6 +415,7 @@ class AutoParallel:
         self,
         verbose=True,
         solver=None,
+        approximate_options=None,
         optimality_check=False,
     ):
         """Solve for the optimal placement.
@@ -422,9 +423,12 @@ class AutoParallel:
         solver selects how the placement is solved (defaults to the solver chosen
         at AutoParallel construction):
           - "ilp":    exact PuLP/CBC solve.
+          - "approx": heuristic TRW-S ApproximateShardingSolver.
           - "lp":     solve the LP relaxation and use it directly. This problem is
             empirically integral, so the relaxation optimum equals the ILP optimum
             while skipping branch-and-bound; raises if it comes out fractional.
+        approximate_options is forwarded as kwargs to the approximate solver
+        (e.g. candidate_limit, max_sweeps).
 
         optimality_check: after solving, solve the LP relaxation as a lower bound
         and log the certified gap of the achieved objective from the optimum.
@@ -435,7 +439,12 @@ class AutoParallel:
             solver = self.solver
 
         opt = self.sharding_optimizer
-        if solver == "ilp":
+        if solver in ("approx", "approximate"):
+            from .approximate_sharding import ApproximateShardingSolver
+
+            approx = ApproximateShardingSolver(opt, **(approximate_options or {}))
+            self.sharding_placement = approx.get_solution(verbose=verbose)
+        elif solver == "ilp":
             self.sharding_placement = opt.get_solution(verbose=False)
         elif solver in ("lp", "lp_relax", "lp_relaxation"):
             opt._set_objective()

--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -23,6 +23,7 @@ from torch._logging import trace_structured
 from torch._subclasses import FakeTensorMode
 from torch.distributed.fsdp import MixedPrecisionPolicy
 from torch.distributed.tensor import DeviceMesh
+from torch.distributed.tensor.placement_types import Placement
 from torch.export._trace import _restore_state_dict
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
@@ -253,6 +254,8 @@ class AutoParallel:
         repeated_subgraphs: bool = True,
         fast_build: bool = True,
         solver: str = "ilp",
+        strategy_radius: Optional[int] = None,
+        seed_input_placements: Optional[tuple[Placement, ...]] = None,
         lazy_costs: Optional[bool] = None,
     ):
         self.stack = ExitStack()
@@ -278,6 +281,8 @@ class AutoParallel:
         self.cost_model = cost_model
         self.repeated_subgraphs = repeated_subgraphs
         self.fast_build = fast_build
+        self.strategy_radius = strategy_radius
+        self.seed_input_placements = seed_input_placements
         # None => default per solver: approx builds lazy (no eager per-edge cost
         # estimation; the TRW-S solver computes costs on demand), ilp/lp build
         # eager (a PuLP objective needs the costs). True/False forces lazy/eager.
@@ -343,6 +348,23 @@ class AutoParallel:
                 and self.mp_policy.reduce_dtype.itemsize
                 > self.mp_policy.param_dtype.itemsize
             )
+            strategy_seed = None
+            if self.strategy_radius is not None:
+                assert self.seed_input_placements is not None, (
+                    "strategy_radius requires seed_input_placements "
+                    "(one input placement per mesh dim)"
+                )
+                from .mesh_search import build_split_dim_seed
+
+                strategy_seed = build_split_dim_seed(
+                    self.gm,
+                    tuple(self.mesh.shape),
+                    self.seed_input_placements,
+                    cost_model=self.cost_model,
+                    force_grad_reduce_in_higher_precision=force_grad_reduce_in_higher_precision,
+                    repeated_subgraphs=self.repeated_subgraphs,
+                    fast_build=self.fast_build,
+                )
             sharding_optimizer = ShardingOptimizer(
                 self.gm,
                 self.mesh,
@@ -355,6 +377,8 @@ class AutoParallel:
                     if self.lazy_costs is None
                     else (not self.lazy_costs)
                 ),
+                strategy_seed=strategy_seed,
+                strategy_radius=self.strategy_radius,
             )
 
             self.sharding_optimizer = sharding_optimizer

--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -233,6 +233,7 @@ class AutoParallel:
     Args:
         mesh: Defines placement options.
         The meta model is moved to a fake device based on mesh.device_type.
+        fast_build: Skip DTensor enumeration costs that AutoParallel recomputes.
     """
 
     def __init__(
@@ -245,6 +246,7 @@ class AutoParallel:
         dynamic: bool = False,
         cost_model: Any = "nccl",
         repeated_subgraphs: bool = True,
+        fast_build: bool = True,
     ):
         self.stack = ExitStack()
         self.fake_mode = (
@@ -257,6 +259,7 @@ class AutoParallel:
         self.mp_policy = mp_policy
         self.cost_model = cost_model
         self.repeated_subgraphs = repeated_subgraphs
+        self.fast_build = fast_build
         # copy user model to avoid modifying it in-place
         # in dtype casting and move_to_fake
         model = copy.deepcopy(model)
@@ -323,6 +326,7 @@ class AutoParallel:
                 self.mesh,
                 force_grad_reduce_in_higher_precision,
                 repeated_subgraphs=self.repeated_subgraphs,
+                fast_build=self.fast_build,
             )
 
             self.sharding_optimizer = sharding_optimizer

--- a/autoparallel/approximate_sharding.py
+++ b/autoparallel/approximate_sharding.py
@@ -21,8 +21,14 @@ from typing import Any, Optional
 
 import numpy as np
 import pulp
+import torch
+from torch.distributed.tensor._dtensor_spec import DTensorSpec
+from torch.distributed.tensor.placement_types import Replicate, Shard
 
-from .cost_models.compute_estimation import _get_sharded_shape_stride
+from .cost_models.compute_estimation import (
+    _get_sharded_shape_stride,
+    estimate_strategy_runtime_cost,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -114,6 +120,18 @@ class ApproximateShardingSolver:
         self.max_star_children = max_star_children
         self.group_domain_limit = group_domain_limit
 
+        # Lazy build: the optimizer was built with build_costs=False, so no
+        # DecisionVars / edge costs exist. We compute the comm/compute costs that
+        # TRW-S touches on demand (memoized) instead of reading opt.decision_vars.
+        self._lazy = not getattr(optimizer, "build_costs", True)
+        # (root v, argi, out_v, out_p) -> (comm_cost, transition_cost)
+        self._edge_cache: dict[tuple, tuple] = {}
+        self._compute_cache: dict[tuple, float] = {}  # (root v, out) -> per-arg compute
+        # Nodes whose redistribution must be forbidden because they precede a
+        # downcasting dtype_cast (the lazy analogue of the per-key dtype forbidden
+        # the eager build stamps); populated in _topology_direct.
+        self._pre_cast_nodes: set[int] = set()
+
         # Populated by _build_problem().
         self.cost_bearing: list[int] = []
         self.node_mult: dict[int, int] = {}
@@ -171,9 +189,16 @@ class ApproximateShardingSolver:
                 max((g.domain for g in self.groups), default=0),
             )
 
-        # max_time_s bounds TRW-S and polish, not factor construction.
+        # max_time_s bounds the *solve* (TRW-S + polish), so start the clock after
+        # the build. In the lazy build the per-edge costs are computed during
+        # _build_factors (not up front), which can exceed max_time_s on large
+        # meshes; measuring the deadline from t0 would then starve TRW-S of any
+        # sweeps and decode a near-random assignment.
         deadline = t_bf + self.max_time_s
-        # Initialize with TRW-S, then polish the assignment with local search.
+        # TRW-S init, then local-search polish. TRW-S reaches the exact MAP on the
+        # (integral) sharding problem, so the old greedy second candidate it used
+        # to be compared against is strictly dominated and has been dropped; the
+        # polish remains for the memory budget and as a local-search safety net.
         t_bp0 = time.perf_counter()
         mem = self._memory
         if mem is not None and not mem.get("tight"):
@@ -275,7 +300,11 @@ class ApproximateShardingSolver:
             self.allowed_out[opt.node_map[node]] = list(range(len(strat.strategies)))
 
         t = time.perf_counter()
-        paired_edges, authoritative = self._parse_constraints()
+        if opt.prob is None:
+            # Lite build: no PuLP problem was constructed, derive topology directly.
+            paired_edges, authoritative = self._topology_direct()
+        else:
+            paired_edges, authoritative = self._parse_constraints()
         # Flow edges are taken from the ILP's output_input_consistent constraints
         # (the authoritative producer per consumer-arg), NOT from _all_input_nodes:
         # the two disagree for some ops (einsum list-args, alias/backward nodes),
@@ -412,8 +441,214 @@ class ApproximateShardingSolver:
                 self.allowed_out[n] = [o for o in self.allowed_out[n] if o in out_set]
         return paired_edges, authoritative
 
+    def _topology_direct(self):
+        """Compute the same topology (forbidden / out_idx restrictions / paired
+        edges / flow producers) that _parse_constraints extracts, but directly
+        from the graph + cluster_links + _constraint_log, WITHOUT a PuLP problem.
+        This lets the optimizer skip building millions of PuLP variables and
+        constraints when only the approximate solver is used.
+
+        Mirrors ShardingOptimizer.add_inf_cost_constraint /
+        add_grad_reduce_dtype_constraints / add_forward_backward_consistency_constraints /
+        _add_paired_output_constraint / add_node_constraint /
+        add_output_input_consistent_constraint. Verified byte-identical to
+        _parse_constraints on a full build (see tests)."""
+        from torch._functorch._aot_autograd.fx_utils import (
+            get_param_and_grad_nodes,
+            get_plain_input_and_grad_nodes,
+            get_plain_output_and_tangent_nodes,
+        )
+
+        opt = self.opt
+        cl = opt.cluster_links  # node-level: copy node idx -> root node idx
+
+        def rootkey(k):
+            return opt._cluster_root_key(k)
+
+        cluster_linked = set(cl)
+        node_root = dict(cl)
+
+        def nroot(idx):
+            return node_root.get(idx, idx)
+
+        # 1. inf-cost forbidden (== add_inf_cost_constraint).
+        for key, dv in opt.decision_vars.items():
+            if not math.isfinite(dv.cost) or dv.cost == 10000.0:
+                self.forbidden.add(key)
+
+        # 2a. forward param-dtype forbidden (== add_grad_reduce_dtype_constraints
+        #     forward part, unconditional). Force the FSDP allgather to run after
+        #     a downcasting param dtype_cast (in the smaller param_dtype) by
+        #     forbidding any pre-cast redistribution.
+        cast_op = torch.ops.autoparallel.dtype_cast.default
+        fwd_pre_cast: set[int] = set()
+        for param, _grad in get_param_and_grad_nodes(opt.graph).values():
+            n = param
+            while True:
+                if n.target == cast_op:
+                    break
+                users = list(n.users.keys())
+                if len(users) != 1:
+                    break
+                child = users[0]
+                if len(child.all_input_nodes) != 1:
+                    break
+                n = child
+            if n.target != cast_op:
+                continue
+            if n.meta["val"].dtype.itemsize >= param.meta["val"].dtype.itemsize:
+                continue  # only constrain downcasts
+            node = n
+            while node != param:
+                if node in opt.node_map:
+                    fwd_pre_cast.add(opt.node_map[node])
+                node = node.all_input_nodes[0]
+        # In the lazy build there are no decision_vars to stamp, so record the
+        # pre-cast nodes; the lazy edge provider forbids their redistributions.
+        self._pre_cast_nodes.update(fwd_pre_cast)
+        for key, dv in opt.decision_vars.items():
+            if key[0] in fwd_pre_cast and dv.comm_cost > 0:
+                self.forbidden.add(key)
+
+        # 2. grad-reduce-dtype (backward) forbidden
+        #    (== add_grad_reduce_dtype_constraints backward part).
+        if getattr(opt, "force_grad_reduce_in_higher_precision", False):
+            cast_op = torch.ops.autoparallel.dtype_cast.default
+            pre_cast: set[int] = set()
+            for param, grad in get_param_and_grad_nodes(opt.graph).values():
+                if grad is None:
+                    continue
+                chain = [grad]
+                n = grad
+                while len(n.all_input_nodes) == 1:
+                    parent = n.all_input_nodes[0]
+                    if len(parent.all_input_nodes) != 1:
+                        break
+                    chain.append(parent)
+                    n = parent
+                cast_idx = next(
+                    (i for i, nd in enumerate(chain) if nd.target == cast_op), None
+                )
+                if cast_idx is None:
+                    continue
+                for nd in chain[cast_idx:]:
+                    if nd in opt.node_map:
+                        pre_cast.add(opt.node_map[nd])
+            self._pre_cast_nodes.update(pre_cast)
+            for key, dv in opt.decision_vars.items():
+                if key[0] in pre_cast and dv.comm_cost > 0:
+                    self.forbidden.add(key)
+
+        # 3. forward/backward paired output constraints + disables
+        #    (== add_forward_backward_consistency_constraints / _add_paired_output_constraint).
+        paired_edges: list[tuple[int, int, frozenset]] = []
+
+        def add_paired(node_a, node_b):
+            idx_a, idx_b = opt.node_map[node_a], opt.node_map[node_b]
+            strat_a = [str(s.output_specs) for s in opt.strats[node_a].strategies]
+            strat_b = [str(s.output_specs) for s in opt.strats[node_b].strategies]
+            num_inp_a = len(opt.strats[node_a].strategies[0].redistribute_cost[0])
+            for out_idx, sp in enumerate(strat_a):
+                if sp not in strat_b:
+                    for inp in range(num_inp_a):
+                        self.forbidden.add(rootkey((idx_a, 0, out_idx, inp)))
+                    continue
+                out_idx_b = strat_b.index(sp)
+                ra = rootkey((idx_a, 0, out_idx, 0))[0]
+                rb = rootkey((idx_b, 0, out_idx_b, 0))[0]
+                paired_edges.append((ra, rb, frozenset({(out_idx, out_idx_b)})))
+
+        for param, grad in get_param_and_grad_nodes(opt.graph).values():
+            if grad is not None:
+                add_paired(param, grad)
+        for node, gnode in get_plain_input_and_grad_nodes(opt.graph).values():
+            if gnode is not None:
+                add_paired(node, gnode)
+        for node, tnode in get_plain_output_and_tangent_nodes(opt.graph).values():
+            if tnode is not None:
+                add_paired(node, tnode)
+
+        # 4. user node/input/output placement restrictions (== add_node_constraint),
+        #    replayed from _constraint_log.
+        restrict: dict[int, set] = {}
+        for fname, kwargs in getattr(opt, "_constraint_log", []):
+            if fname != "add_node_constraint":
+                continue
+            node = next(
+                (nd for nd in opt.nodes if nd.name == kwargs["node_name"]), None
+            )
+            if node is None or node not in opt.strats:
+                continue
+            placement = kwargs["placement"]
+            if placement is None:
+                placement = (Shard(0),) + (Replicate(),) * (opt.mesh.ndim - 1)
+            out_set = set()
+            for i, s in enumerate(opt.strats[node].strategies):
+                specs = s.output_specs
+                if isinstance(specs, DTensorSpec):
+                    if specs.placements == placement:
+                        out_set.add(i)
+                elif isinstance(specs, (list, tuple)):
+                    for spec in specs:
+                        if isinstance(spec, DTensorSpec):
+                            if spec.placements == placement:
+                                out_set.add(i)
+                            break
+            r = nroot(opt.node_map[node])
+            restrict[r] = restrict.get(r, out_set) & out_set
+        for n_idx, out_set in restrict.items():
+            if n_idx in self.allowed_out:
+                self.allowed_out[n_idx] = [
+                    o for o in self.allowed_out[n_idx] if o in out_set
+                ]
+
+        # 5. flow producers (== add_output_input_consistent_constraint): for each
+        #    consumer-arg, the set of (cluster-resolved) producers feeding it.
+        authoritative: dict[tuple[int, int], set] = {}
+        for node in opt.graph.nodes:
+            if node.op == "output" or node not in opt.node_map:
+                continue
+            p_idx = opt.node_map[node]
+            p_linked = p_idx in cluster_linked
+            p_root = nroot(p_idx)
+            for user in node.users:
+                if user.op == "output" or user not in opt.node_map:
+                    continue
+                u_idx = opt.node_map[user]
+                if p_linked and u_idx in cluster_linked:
+                    continue
+                ain = opt._all_input_nodes(user)
+                argi = next((i for i, x in enumerate(ain) if x is node), None)
+                if argi is None:
+                    continue
+                ispecs = opt.strats[user].strategies[0].input_specs
+                if argi < len(ispecs) and ispecs[argi] is None:
+                    continue
+                authoritative.setdefault((nroot(u_idx), argi), set()).add(p_root)
+
+        return paired_edges, authoritative
+
     def _is_forbidden(self, key) -> bool:
-        """Return whether constraints or invalid-cost pruning removed an edge."""
+        """A strategy edge is forbidden if a constraint ruled it out OR it was
+        pruned for infinite cost. Pruning removes such keys from decision_vars
+        entirely (see ShardingOptimizer._build_decision_vars), so a key missing
+        from decision_vars is just as forbidden as one in ``self.forbidden``.
+
+        In the lazy build there are no decision_vars, so an infinite-cost edge
+        (an invalid redistribution, which the eager build prunes out of
+        decision_vars) is discovered by computing the edge cost on demand and
+        checking finiteness — same notion of forbidden, just learned lazily.
+        Keeping this in sync with the eager pruning is what lets _out_fully_
+        forbidden and candidate pruning drop the same infeasible strategies."""
+        if self._lazy:
+            if key in self.forbidden:
+                return True
+            v, argi, ov, op = key
+            p = self._arg_prod.get(v, {}).get(argi)
+            if p is None:
+                return False  # producer-less arg: 0-cost dummy, never infinite
+            comm, _trans = self._edge_cost(v, argi, ov, op, p)
+            return not math.isfinite(comm)
         return key in self.forbidden or key not in self.opt.decision_vars
 
     def _surviving_dv(self, v, argi, o):
@@ -582,6 +817,8 @@ class ApproximateShardingSolver:
             group.choices = [group.choices[ci] for ci in sorted(keep)]
 
     def _choice_lower_bound(self, v, node, o):
+        if self._lazy:
+            return self._choice_lower_bound_lazy(v, node, o)
         opt = self.opt
         strat = opt.strats[node].strategies[o]
         mult = self.node_mult[v]
@@ -650,7 +887,12 @@ class ApproximateShardingSolver:
         }
 
     def _param_ratio(self, v, node, o):
-        spec = self._surviving_dv(v, 0, o).input_spec
+        if self._lazy:
+            # input_specs[0] is the param's own (redistributed) spec, identical to
+            # the eager _surviving_dv(v, 0, o).input_spec but without decision_vars.
+            spec = self.opt.strats[node].strategies[o].input_specs[0]
+        else:
+            spec = self._surviving_dv(v, 0, o).input_spec
         new_shape, _ = _get_sharded_shape_stride(spec)
         return math.prod(new_shape) / math.prod(spec.tensor_meta.shape)
 
@@ -703,9 +945,125 @@ class ApproximateShardingSolver:
         self.nbrs = [sorted(s) for s in nbr_set]
 
     # ------------------------------------------------------------------ #
+    # Lazy cost provider (build_costs=False): compute on demand, memoized.
+    # These mirror the eager readers below but call the cost estimators
+    # directly instead of reading opt.decision_vars (which is empty).
+    # ------------------------------------------------------------------ #
+    def _compute_cost(self, m, o):
+        """Per-arg compute cost of node m at output strategy o, matching the
+        eager per_arg_compute = estimate_strategy_runtime_cost / num_args."""
+        ck = (m, o)
+        c = self._compute_cache.get(ck)
+        if c is not None:
+            return c
+        node = self.opt.nodes[m]
+        strats = self.opt.strats[node].strategies
+        num_args = max(len(strats[0].input_specs), 1)
+        c = estimate_strategy_runtime_cost(node, strats[o]) / num_args
+        self._compute_cache[ck] = c
+        return c
+
+    def _edge_cost(self, v, argi, ov, op, p):
+        """(comm_cost, transition_cost) for the edge feeding consumer v's arg
+        argi from producer p, with v at output ov and p at output op. Computed
+        via the same estimator the eager build uses (opt._compute_edge_costs) and
+        memoized. comm is INF for an infeasible redistribution or one forbidden
+        because v precedes a downcasting dtype_cast (lazy analogue of the eager
+        per-key dtype/inf pruning)."""
+        ck = (v, argi, ov, op)
+        cached = self._edge_cache.get(ck)
+        if cached is not None:
+            return cached
+        opt = self.opt
+        node = opt.nodes[v]
+        strat = opt.strats[node].strategies[ov]
+        redist = strat.redistribute_cost[argi]
+        default = redist[op] if op < len(redist) else 0.0
+        prod_strat = opt.strats[opt.nodes[p]]
+        comm, trans = opt._compute_edge_costs(
+            node, strat, argi, op, default, prod_strat
+        )
+        if comm > 0 and v in self._pre_cast_nodes:
+            comm = INF
+        result = (comm, trans)
+        self._edge_cache[ck] = result
+        return result
+
+    def _self_cost_vec_lazy(self, m, out_indices):
+        node = self.opt.nodes[m]
+        strats = self.opt.strats[node].strategies
+        out = np.empty(len(out_indices))
+        for i, o in enumerate(out_indices):
+            # Producer-less args contribute 0 comm/transition in the fast build
+            # (their redistribute_cost is the 0.0 enumeration dummy), so the self
+            # cost is just the per-strategy compute over all args.
+            out[i] = self._compute_cost(m, o) * len(strats[o].redistribute_cost)
+        return out
+
+    def _edge_matrix_lazy(self, v, argi, p):
+        opt = self.opt
+        Kv = len(opt.strats[opt.nodes[v]].strategies)
+        Kp = len(opt.strats[opt.nodes[p]].strategies)
+        R = np.full((Kv, Kp), BIG)
+        gv = self.node_to_group[v]
+        gp = self.node_to_group[p]
+        ov_vals = sorted({c[v] for c in self.groups[gv].choices})
+        op_vals = sorted({c[p] for c in self.groups[gp].choices})
+        for ov in ov_vals:
+            for op in op_vals:
+                if (v, argi, ov, op) in self.forbidden:
+                    continue  # constraint-forbidden; infinite-cost => finite check
+                comm, trans = self._edge_cost(v, argi, ov, op, p)
+                if math.isfinite(comm):
+                    R[ov, op] = comm + trans
+        return R
+
+    def _choice_lower_bound_lazy(self, v, node, o):
+        strat = self.opt.strats[node].strategies[o]
+        mult = self.node_mult[v]
+        lb = self._compute_cost(v, o) * len(strat.redistribute_cost) * mult
+        # Include the cheapest feasible comm+transition per producer arg so lazy
+        # candidate ranking is identical to eager ranking.
+        for argi, p in self.input_edges.get(v, []):
+            best = INF
+            for op in range(len(strat.redistribute_cost[argi])):
+                if self._is_forbidden((v, argi, o, op)):
+                    continue
+                comm, trans = self._edge_cost(v, argi, o, op, p)
+                if math.isfinite(comm):
+                    best = min(best, comm + trans)
+            if math.isfinite(best):
+                lb += mult * best
+        return lb
+
+    def _total_objective_lazy(self):
+        total = 0.0
+        for v in self.cost_bearing:
+            node = self.opt.nodes[v]
+            o = self.cur_out[v]
+            strat = self.opt.strats[node].strategies[o]
+            prod = self._arg_prod.get(v, {})
+            n_args = len(strat.redistribute_cost)
+            c = self._compute_cost(v, o) * n_args
+            for argi in range(n_args):
+                p = prod.get(argi)
+                if p is None:
+                    continue  # producer-less arg: 0 comm/transition (fast build)
+                inp = self.cur_out[p]
+                if self._is_forbidden((v, argi, o, inp)):
+                    return INF
+                comm, trans = self._edge_cost(v, argi, o, inp, p)
+                if not math.isfinite(comm):
+                    return INF
+                c += comm + trans
+            total += self.node_mult[v] * c
+        return total
+
     def _self_cost_vec(self, m, out_indices):
         """Vectorized self-cost (compute + producer-less arg costs) for node m
         over an array of out_idx."""
+        if self._lazy:
+            return self._self_cost_vec_lazy(m, out_indices)
         opt = self.opt
         node = opt.nodes[m]
         prod = self._arg_prod.get(m, {})
@@ -736,6 +1094,8 @@ class ApproximateShardingSolver:
         """Raw (Kv, Kp) edge cost matrix R[o_v][o_p] = comm + transition, BIG when
         the (o_v, o_p) combination is forbidden. Only entries that can actually be
         indexed by the group choices are filled; the rest are BIG."""
+        if self._lazy:
+            return self._edge_matrix_lazy(v, argi, p)
         opt = self.opt
         Kv = len(opt.strats[opt.nodes[v]].strategies)
         Kp = len(opt.strats[opt.nodes[p]].strategies)
@@ -1225,6 +1585,8 @@ class ApproximateShardingSolver:
     def total_objective(self):
         """Exact objective of the current assignment via decision_vars (for
         verification); equals pulp.value(prob.objective) after write-back."""
+        if self._lazy:
+            return self._total_objective_lazy()
         total = 0.0
         for v in self.cost_bearing:
             node = self.opt.nodes[v]
@@ -1245,8 +1607,10 @@ class ApproximateShardingSolver:
 
     def _write_back(self):
         opt = self.opt
-        for var in opt.pulp_variables.values():
-            var.varValue = 0
+        has_pulp = bool(opt.pulp_variables)
+        if has_pulp:
+            for var in opt.pulp_variables.values():
+                var.varValue = 0
         selected = []
         feasible = True
         for v in self.cost_bearing:
@@ -1260,13 +1624,20 @@ class ApproximateShardingSolver:
                 key = (v, argi, o, inp)
                 if self._is_forbidden(key):
                     feasible = False
-                if key in opt.pulp_variables:
+                # A pruned key has no PuLP variable; the infeasible flag above
+                # already records it (and raises in _solve).
+                if has_pulp and key in opt.pulp_variables:
                     opt.pulp_variables[key].varValue = 1
                 selected.append(key)
         opt.selected_keys = list(selected)
         for rk in selected:
             opt.selected_keys.extend(opt._linked_option_keys(rk))
-        opt.prob.status = pulp.LpStatusOptimal
-        opt.prob.sol_status = pulp.LpSolutionOptimal
-        opt._set_objective()
+        # Populate prob.objective (when a PuLP problem exists) so callers can also
+        # score via pulp.value(prob.objective); the returned value uses the
+        # equivalent but cheaper total_objective(). In the lite (no-PuLP) build,
+        # there is no problem to populate.
+        if opt.prob is not None:
+            opt.prob.status = pulp.LpStatusOptimal
+            opt.prob.sol_status = pulp.LpSolutionOptimal
+            opt._set_objective()
         return INF if not feasible else self.total_objective()

--- a/autoparallel/approximate_sharding.py
+++ b/autoparallel/approximate_sharding.py
@@ -1,0 +1,1272 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Approximate sharding solver.
+
+Reduces the sharding ILP (see :mod:`optimize_sharding`) to a pairwise MRF over the
+per-node output-strategy indices and solves it with tree-reweighted message passing
+(TRW-S) plus local-search polish, replacing only the CBC/ILP *solve*. It reuses the
+strategies / decision variables / constraints built by ``ShardingOptimizer`` and writes
+its assignment back into the PuLP variables, so it is scored by ``pulp.value(prob.objective)``.
+"""
+
+import logging
+import math
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import numpy as np
+import pulp
+
+from .cost_models.compute_estimation import _get_sharded_shape_stride
+
+logger = logging.getLogger(__name__)
+
+INF = float("inf")
+BIG = 1e12  # finite stand-in for forbidden combinations (avoids NaN in min-sum)
+
+# Paired forward/backward constraints couple two nodes to the *same output
+# placement* (the strategy index may differ between the two strategy lists).
+_PAIRED_PREFIXES = (
+    "grad_param_constraint",
+    "grad_input_constraint",
+    "grad_output_constraint",
+)
+
+
+@dataclass
+class ApproximateSolveResult:
+    objective: float
+    status: str
+    build_s: float
+    solve_s: float
+    total_s: float
+    num_groups: int
+    num_nodes: int
+
+
+@dataclass
+class _Group:
+    """A set of node indices chosen jointly (cluster copies share a strategy
+    index; forward/backward pairs share an output placement)."""
+
+    members: list[int]
+    cost_bearing: list[int] = field(default_factory=list)
+    choices: list[dict[int, int]] = field(default_factory=list)  # member -> out_idx
+    current: int = 0
+
+    @property
+    def domain(self) -> int:
+        return len(self.choices)
+
+
+class _UnionFind:
+    def __init__(self, n: int):
+        self.parent = list(range(n))
+
+    def find(self, x: int) -> int:
+        root = x
+        while self.parent[root] != root:
+            root = self.parent[root]
+        while self.parent[x] != root:
+            self.parent[x], x = root, self.parent[x]
+        return root
+
+    def union(self, a: int, b: int) -> None:
+        ra, rb = self.find(a), self.find(b)
+        if ra != rb:
+            self.parent[rb] = ra
+
+
+class ApproximateShardingSolver:
+    """Approximate solver for the sharding placement problem on an already-built
+    :class:`ShardingOptimizer`.
+
+    Call :meth:`get_solution` for a ``{node: OpSpec}`` dict (same format as
+    ``ShardingOptimizer.get_solution``); it also fills the PuLP variables and
+    ``optimizer.selected_keys`` so the assignment can be scored/inspected exactly
+    like an ILP solution.
+    """
+
+    def __init__(
+        self,
+        optimizer,
+        candidate_limit: Optional[int] = 64,
+        bp_iters: int = 400,
+        bp_tol: float = 1e-3,
+        max_sweeps: int = 12,
+        max_time_s: float = 60.0,
+        star_passes: int = 2,
+        max_star_children: int = 32,
+        group_domain_limit: int = 512,
+    ):
+        self.opt = optimizer
+        self.candidate_limit = candidate_limit
+        self.bp_iters = bp_iters
+        self.bp_tol = bp_tol
+        self.max_sweeps = max_sweeps
+        self.max_time_s = max_time_s
+        self.star_passes = star_passes
+        self.max_star_children = max_star_children
+        self.group_domain_limit = group_domain_limit
+
+        # Populated by _build_problem().
+        self.cost_bearing: list[int] = []
+        self.node_mult: dict[int, int] = {}
+        self.forbidden: set[tuple] = set()
+        self.allowed_out: dict[int, list[int]] = {}
+        self.groups: list[_Group] = []
+        self.node_to_group: dict[int, int] = {}
+        self.input_edges: dict[int, list[tuple[int, int]]] = {}
+        self._arg_prod: dict[int, dict[int, int]] = {}
+        self.consumers: dict[int, list[tuple[int, int]]] = defaultdict(list)
+        self.cur_out: dict[int, int] = {}
+        self._memory: Optional[dict[str, Any]] = None
+        # When False, the hard memory-budget checks in local search are skipped
+        # (used by the Lagrangian solve, which enforces the budget softly via a
+        # penalty folded into the unaries instead).
+        self._mem_enforce: bool = True
+        self._mem_unary: list[np.ndarray] = []
+
+        # Populated by _build_factors().
+        self.g_unary: list[np.ndarray] = []
+        self.C: dict[tuple, np.ndarray] = {}
+        self.nbrs: list[list[int]] = []
+
+    # ------------------------------------------------------------------ #
+    # Public entry point
+    # ------------------------------------------------------------------ #
+    def get_solution(self, verbose: bool = False):
+        result, solution = self._solve(verbose=verbose)
+        self.result = result
+        return solution
+
+    def _solve(self, verbose: bool = False):
+        opt = self.opt
+        if getattr(opt, "solver_backend", "ilp") != "ilp":
+            raise RuntimeError(
+                "ApproximateShardingSolver requires an ILP-built optimizer "
+                "(decision_vars / pulp_variables / constraints)."
+            )
+        t0 = time.perf_counter()
+        self._build_problem()
+        t_bp = time.perf_counter()
+        self._build_factors()
+        t_bf = time.perf_counter()
+        t_build = t_bf - t0
+        if verbose:
+            logger.info(
+                "approx build: problem=%.2fs %s factors=%.2fs groups=%d "
+                "cost_bearing=%d edges=%d max_domain=%d",
+                t_bp - t0,
+                getattr(self, "_build_times", {}),
+                t_bf - t_bp,
+                len(self.groups),
+                len(self.cost_bearing),
+                sum(len(v) for v in self.input_edges.values()),
+                max((g.domain for g in self.groups), default=0),
+            )
+
+        # max_time_s bounds TRW-S and polish, not factor construction.
+        deadline = t_bf + self.max_time_s
+        # Initialize with TRW-S, then polish the assignment with local search.
+        t_bp0 = time.perf_counter()
+        mem = self._memory
+        if mem is not None and not mem.get("tight"):
+            # A non-tight budget can bind the runtime-optimal placement; solve it
+            # exactly via Lagrangian relaxation (folds λ·ratio into the unaries).
+            # A tight budget is already handled by build-time param pinning, and
+            # the no-memory case has nothing to relax, so both take the plain path.
+            res = self.solve_lagrangian(
+                mem["budget_low"],
+                mem["budget_high"],
+                deadline=deadline,
+                verbose=verbose,
+            )
+            if verbose:
+                logger.info(
+                    "approx phase: lagrangian lam=%.4g memory=%.4f feasible=%s",
+                    res["lam"],
+                    res["memory"],
+                    res["feasible"],
+                )
+        else:
+            self._belief_propagation(deadline)
+            if verbose:
+                logger.info(
+                    "approx phase: trws iter=%s delta=%.4g in %.2fs; "
+                    "decode energy=%.1f",
+                    getattr(self, "_bp_last_iter", None),
+                    getattr(self, "_bp_last_delta", float("nan")),
+                    time.perf_counter() - t_bp0,
+                    self._fast_total_energy(),
+                )
+            self._memory_repair()
+            self._coordinate_descent(deadline)
+            self._star_block_search(deadline)
+        bp_energy = self._fast_total_energy()
+        if verbose:
+            logger.info("approx phase: polished energy=%.1f", bp_energy)
+        t_solve = time.perf_counter() - t0 - t_build
+
+        objective = self._write_back()
+        total_s = time.perf_counter() - t0
+        infeasible = not math.isfinite(objective)
+        status = "Infeasible" if infeasible else "Heuristic"
+        result = ApproximateSolveResult(
+            objective=objective,
+            status=status,
+            build_s=t_build,
+            solve_s=t_solve,
+            total_s=total_s,
+            num_groups=len(self.groups),
+            num_nodes=len(self.cost_bearing),
+        )
+        logger.info(
+            "ApproximateShardingSolver: status=%s objective=%.4f "
+            "(trws+polish=%.1f) groups=%d nodes=%d "
+            "timings={build=%.3fs,solve=%.3fs,total=%.3fs}",
+            status,
+            objective,
+            bp_energy,
+            len(self.groups),
+            len(self.cost_bearing),
+            t_build,
+            t_solve,
+            total_s,
+        )
+        opt.profile["approximate"] = {"objective": objective}
+        if infeasible:
+            raise RuntimeError(
+                "ApproximateShardingSolver could not find a feasible assignment. "
+                "User constraints may be contradictory or the mesh too small."
+            )
+        solution = opt._to_orig_solution(opt._extract_and_validate_solution())
+        return result, solution
+
+    # ------------------------------------------------------------------ #
+    # Problem construction
+    # ------------------------------------------------------------------ #
+    def _build_problem(self):
+        opt = self.opt
+        # cluster_links is node-level: copy node idx -> root node idx.
+        cluster_linked = set(opt.cluster_links)
+        self.cost_bearing = [
+            opt.node_map[node]
+            for node in opt.strats
+            if node.op != "output" and opt.node_map[node] not in cluster_linked
+        ]
+
+        root_to_copies: dict[int, set] = defaultdict(set)
+        for copy_idx, root_idx in opt.cluster_links.items():
+            root_to_copies[root_idx].add(copy_idx)
+        self.node_mult = {
+            v: 1 + len(root_to_copies.get(v, ())) for v in self.cost_bearing
+        }
+
+        self.allowed_out = {}
+        for node, strat in opt.strats.items():
+            if node.op == "output":
+                continue
+            self.allowed_out[opt.node_map[node]] = list(range(len(strat.strategies)))
+
+        t = time.perf_counter()
+        paired_edges, authoritative = self._parse_constraints()
+        # Flow edges are taken from the ILP's output_input_consistent constraints
+        # (the authoritative producer per consumer-arg), NOT from _all_input_nodes:
+        # the two disagree for some ops (einsum list-args, alias/backward nodes),
+        # and trusting _all_input_nodes yields flow-infeasible assignments. The
+        # producer here is the (possibly cluster-resolved) node carrying the
+        # producer's pulp variable; the ILP guarantees its out_idx range matches
+        # the consumer's inp_idx range for that arg.
+        self._arg_prod: dict[int, dict[int, int]] = defaultdict(dict)
+        flow_couplings = []  # producer sets forced to share an out_idx
+        for (c_idx, argi), producers in authoritative.items():
+            rep = min(producers)  # all coupled -> same out, any representative
+            self._arg_prod[c_idx][argi] = rep
+            if len(producers) > 1:
+                flow_couplings.append(producers)
+        self.input_edges = {}
+        self.consumers = defaultdict(list)
+        for v in self.cost_bearing:
+            edges = sorted(self._arg_prod.get(v, {}).items())
+            self.input_edges[v] = edges
+            for argi, p in edges:
+                self.consumers[p].append((v, argi))
+        t_parse = time.perf_counter()
+
+        # Remove fully-forbidden out_idx for cost-bearing nodes.
+        for v in self.cost_bearing:
+            node = opt.nodes[v]
+            self.allowed_out[v] = [
+                o
+                for o in self.allowed_out[v]
+                if not self._out_fully_forbidden(v, node, o)
+            ]
+        t_forbid = time.perf_counter()
+
+        self._build_memory_info()  # also pins params when the budget is tight
+        t_mem = time.perf_counter()
+        self._build_groups(paired_edges, flow_couplings)
+        t_groups = time.perf_counter()
+        self._prune_candidates()
+        self._build_times = {
+            "parse": t_parse - t,
+            "forbid": t_forbid - t_parse,
+            "memory": t_mem - t_forbid,
+            "groups": t_groups - t_mem,
+            "prune": time.perf_counter() - t_groups,
+        }
+
+    # Constraint families that never restrict the per-node out_idx domain and
+    # are handled structurally (flow/uniqueness) or via the cost sentinel below.
+    # Skipping them by name avoids materializing items() for the ~majority of the
+    # (often >100k) constraints.
+    _SKIP_PREFIXES = (
+        "unique_decision",
+        "same_across_args",
+        "inf_cases",
+        "memory_constraint",
+    )
+
+    def _parse_constraints(self):
+        opt = self.opt
+        # inf-cost keys are forced to 0 by add_inf_cost_constraint, which also
+        # stamps dv.cost = 10000.0. Detect them directly instead of parsing the
+        # (very numerous) inf_cases constraints.
+        for key, dv in opt.decision_vars.items():
+            if dv.cost == 10000.0:
+                self.forbidden.add(key)
+
+        var_to_key = {var: key for key, var in opt.pulp_variables.items()}
+        restrict: dict[int, set] = {}
+        paired_edges: list[tuple[int, int, frozenset]] = []
+        # (consumer_idx, argi) -> set of producer_idx, from flow constraints. A
+        # clustered consumer's single inp variable is shared across all its
+        # copies, so the ILP couples one producer per copy (resolved to its root)
+        # to that inp, forcing them all equal; we collect the whole set.
+        authoritative: dict[tuple[int, int], set] = {}
+        for name, c in opt.prob.constraints.items():
+            if name.startswith("output_input_consistent"):
+                # +side = producer (grouped by out), -side = consumer (grouped by
+                # inp at a fixed arg). One +var and one -var pin down the edge.
+                pos_key = neg_key = None
+                for var, coeff in c.items():
+                    k = var_to_key.get(var)
+                    if k is None:
+                        continue
+                    if coeff > 0:
+                        pos_key = pos_key or k
+                    else:
+                        neg_key = neg_key or k
+                    if pos_key is not None and neg_key is not None:
+                        break
+                if pos_key is not None and neg_key is not None:
+                    authoritative.setdefault((neg_key[0], neg_key[1]), set()).add(
+                        pos_key[0]
+                    )
+                continue
+            if name.startswith(self._SKIP_PREFIXES):
+                continue
+            items = list(c.items())
+            if not items:
+                continue
+            rhs = -c.constant
+            coeffs = [coeff for _, coeff in items]
+            keys = [var_to_key.get(var) for var, _ in items]
+            if any(k is None for k in keys):
+                continue
+            all_pos = all(coeff > 0 for coeff in coeffs)
+            if c.sense == pulp.LpConstraintEQ and rhs == 0 and all_pos:
+                self.forbidden.update(keys)  # Σ vars == 0  (inf / dtype / disable)
+            elif c.sense == pulp.LpConstraintEQ and rhs == 1 and all_pos:
+                nodes = {k[0] for k in keys}
+                if len(nodes) == 1:
+                    n = next(iter(nodes))
+                    out_set = {k[2] for k in keys}
+                    restrict[n] = restrict.get(n, out_set) & out_set
+            elif (
+                c.sense == pulp.LpConstraintEQ
+                and rhs == 0
+                and any(name.startswith(p) for p in _PAIRED_PREFIXES)
+                and "disable" not in name
+            ):
+                pos = {k for k, coeff in zip(keys, coeffs) if coeff > 0}
+                neg = {k for k, coeff in zip(keys, coeffs) if coeff < 0}
+                na, nb = {k[0] for k in neg}, {k[0] for k in pos}
+                oa, ob = {k[2] for k in neg}, {k[2] for k in pos}
+                if len(na) == 1 and len(nb) == 1 and len(oa) == 1 and len(ob) == 1:
+                    paired_edges.append(
+                        (
+                            next(iter(na)),
+                            next(iter(nb)),
+                            frozenset({(next(iter(oa)), next(iter(ob)))}),
+                        )
+                    )
+        for n, out_set in restrict.items():
+            if n in self.allowed_out:
+                self.allowed_out[n] = [o for o in self.allowed_out[n] if o in out_set]
+        return paired_edges, authoritative
+
+    def _is_forbidden(self, key) -> bool:
+        """Return whether constraints or invalid-cost pruning removed an edge."""
+        return key in self.forbidden or key not in self.opt.decision_vars
+
+    def _surviving_dv(self, v, argi, o):
+        """A DecisionVar for (v, argi, o, *) using any inp_idx that survived
+        pruning, or None if every edge for that (arg, out) was pruned.
+        compute_cost / input_spec are identical across inp_idx for a fixed out."""
+        strat = self.opt.strats[self.opt.nodes[v]].strategies[o]
+        n_inp = (
+            len(strat.redistribute_cost[argi])
+            if argi < len(strat.redistribute_cost)
+            else 1
+        )
+        for inp in range(n_inp):
+            dv = self.opt.decision_vars.get((v, argi, o, inp))
+            if dv is not None:
+                return dv
+        return None
+
+    def _out_fully_forbidden(self, v, node, o):
+        strat = self.opt.strats[node].strategies[o]
+        for argi, costs in enumerate(strat.redistribute_cost):
+            if all(self._is_forbidden((v, argi, o, inp)) for inp in range(len(costs))):
+                return True
+        return False
+
+    def _build_groups(self, paired_edges, flow_couplings):
+        opt = self.opt
+        n = len(opt.nodes)
+        uf = _UnionFind(n)
+        # cluster_links is node-level: (copy node idx, root node idx) pairs.
+        cluster_pairs = set(opt.cluster_links.items())
+        for li, ri in cluster_pairs:
+            uf.union(li, ri)
+        for a, b, _ in paired_edges:
+            uf.union(a, b)
+
+        allow: dict[tuple, dict[int, set]] = defaultdict(lambda: defaultdict(set))
+        adj: dict[int, set] = defaultdict(set)
+        for li, ri in cluster_pairs:
+            for o in self.allowed_out.get(ri, []):
+                allow[(ri, li)][o].add(o)
+            for o in self.allowed_out.get(li, []):
+                allow[(li, ri)][o].add(o)
+            adj[li].add(ri)
+            adj[ri].add(li)
+        for a, b, pairs in paired_edges:
+            for oa, ob in pairs:
+                allow[(a, b)][oa].add(ob)
+                allow[(b, a)][ob].add(oa)
+            adj[a].add(b)
+            adj[b].add(a)
+        # Flow couplings: producers feeding a clustered consumer's shared inp are
+        # forced to the same out_idx (same-index coupling, star to the rep).
+        for producers in flow_couplings:
+            ps = sorted(producers)
+            rep = ps[0]
+            for q in ps[1:]:
+                uf.union(rep, q)
+                for o in self.allowed_out.get(rep, []):
+                    allow[(rep, q)][o].add(o)
+                for o in self.allowed_out.get(q, []):
+                    allow[(q, rep)][o].add(o)
+                adj[rep].add(q)
+                adj[q].add(rep)
+
+        comps: dict[int, list[int]] = defaultdict(list)
+        for node in opt.strats:
+            if node.op == "output":
+                continue
+            v = opt.node_map[node]
+            comps[uf.find(v)].append(v)
+
+        cost_bearing_set = set(self.cost_bearing)
+        self.groups = []
+        self.node_to_group = {}
+        for members in comps.values():
+            members.sort()
+            group = _Group(members=members)
+            group.cost_bearing = [m for m in members if m in cost_bearing_set]
+            group.choices = self._enumerate_choices(members, allow, adj)
+            if not group.choices:
+                raise RuntimeError(
+                    f"No feasible joint choice for group {members}; "
+                    "constraints are contradictory."
+                )
+            gid = len(self.groups)
+            self.groups.append(group)
+            for m in members:
+                self.node_to_group[m] = gid
+
+    def _enumerate_choices(self, members, allow, adj):
+        if len(members) == 1:
+            v = members[0]
+            return [{v: o} for o in self.allowed_out.get(v, [])]
+        member_set = set(members)
+        # BFS order from a representative so every member after the first is
+        # adjacent to an already-assigned one; coupling then propagates
+        # deterministically (no spurious K-way branching that explodes the
+        # domain for large cluster+paired groups).
+        order = []
+        seen = set()
+        for start in members:
+            if start in seen:
+                continue
+            queue = [start]
+            seen.add(start)
+            while queue:
+                m = queue.pop(0)
+                order.append(m)
+                for nb in adj[m]:
+                    if nb in member_set and nb not in seen:
+                        seen.add(nb)
+                        queue.append(nb)
+        results: list[dict[int, int]] = []
+        limit = self.group_domain_limit
+
+        def candidates(m, assign):
+            cand = None
+            for nb in adj[m]:
+                if nb in assign and nb in member_set:
+                    allowed = allow[(nb, m)].get(assign[nb], set())
+                    cand = allowed if cand is None else (cand & allowed)
+            cand = (
+                set(self.allowed_out.get(m, []))
+                if cand is None
+                else (cand & set(self.allowed_out.get(m, [])))
+            )
+            return cand
+
+        def dfs(i, assign):
+            if len(results) >= limit:
+                return
+            if i == len(order):
+                results.append(dict(assign))
+                return
+            m = order[i]
+            for val in sorted(candidates(m, assign)):
+                assign[m] = val
+                dfs(i + 1, assign)
+                del assign[m]
+                if len(results) >= limit:
+                    return
+
+        dfs(0, {})
+        if len(results) >= limit:
+            logger.warning(
+                "Approximate solver: group of %d nodes hit group_domain_limit=%d.",
+                len(members),
+                limit,
+            )
+        return results
+
+    def _prune_candidates(self):
+        if self.candidate_limit is None:
+            return
+        for group in self.groups:
+            if len(group.members) != 1 or len(group.choices) <= self.candidate_limit:
+                continue
+            v = group.members[0]
+            node = self.opt.nodes[v]
+            lbs = sorted(
+                (self._choice_lower_bound(v, node, c[v]), ci)
+                for ci, c in enumerate(group.choices)
+            )
+            keep = {ci for _, ci in lbs[: self.candidate_limit]}
+            group.choices = [group.choices[ci] for ci in sorted(keep)]
+
+    def _choice_lower_bound(self, v, node, o):
+        opt = self.opt
+        strat = opt.strats[node].strategies[o]
+        mult = self.node_mult[v]
+        dv0 = self._surviving_dv(v, 0, o)
+        if dv0 is None:
+            return INF  # every edge for this output strategy was pruned
+        lb = dv0.compute_cost * len(strat.redistribute_cost)
+        lb *= mult
+        for argi, _p in self.input_edges.get(v, []):
+            best = INF
+            for inp in range(len(strat.redistribute_cost[argi])):
+                key = (v, argi, o, inp)
+                if self._is_forbidden(key):
+                    continue
+                dv = opt.decision_vars[key]
+                best = min(best, dv.comm_cost + dv.sharding_transition_cost)
+            if math.isfinite(best):
+                lb += mult * best
+        return lb
+
+    # ------------------------------------------------------------------ #
+    # Memory constraint (ratios, budget, tight-budget param pinning)
+    # ------------------------------------------------------------------ #
+    def _build_memory_info(self):
+        opt = self.opt
+        factors = None
+        for fname, kwargs in getattr(opt, "_constraint_log", []):
+            if fname == "add_parameter_memory_constraint":
+                factors = kwargs
+        if factors is None:
+            return
+        try:
+            from torch._functorch._aot_autograd.fx_utils import get_param_nodes
+
+            param_nodes = get_param_nodes(opt.graph)
+        except Exception:
+            return
+
+        low_f, high_f = factors["memory_factor_low"], factors["memory_factor_high"]
+        budget_low = budget_high = 0.0
+        param_idxs, ratios = [], {}
+        for node in param_nodes:
+            v = opt.node_map[node]
+            param_idxs.append(v)
+            r = {o: self._param_ratio(v, node, o) for o in self.allowed_out.get(v, [])}
+            ratios[v] = r
+            best = min(r.values())
+            budget_low += max(best, low_f)
+            budget_high += max(best, high_f)
+
+        tight = abs(budget_high - budget_low) < 1e-9
+        if tight:
+            # Σ ratio == Σ min(ratio) forces every param to a min-ratio choice.
+            for v in param_idxs:
+                r = ratios[v]
+                mn = min(r.values())
+                self.allowed_out[v] = [
+                    o for o in self.allowed_out[v] if r[o] <= mn + 1e-12
+                ]
+        self._memory = {
+            "param_idxs": param_idxs,
+            "ratios": ratios,
+            "budget_low": budget_low,
+            "budget_high": budget_high,
+            "tight": tight,
+        }
+
+    def _param_ratio(self, v, node, o):
+        spec = self._surviving_dv(v, 0, o).input_spec
+        new_shape, _ = _get_sharded_shape_stride(spec)
+        return math.prod(new_shape) / math.prod(spec.tensor_meta.shape)
+
+    # ------------------------------------------------------------------ #
+    # Factor graph (numpy unary + pairwise matrices over groups)
+    # ------------------------------------------------------------------ #
+    def _build_factors(self):
+        G = len(self.groups)
+        # per member, its out_idx across its group's choices
+        member_vals = []
+        for group in self.groups:
+            mv = {}
+            for m in group.cost_bearing:
+                mv[m] = np.array([c[m] for c in group.choices], dtype=np.int64)
+            # also predecessors that are non-cost-bearing but in this group
+            for m in group.members:
+                if m not in mv:
+                    mv[m] = np.array([c[m] for c in group.choices], dtype=np.int64)
+            member_vals.append(mv)
+
+        self.g_unary = [np.zeros(g.domain) for g in self.groups]
+        for gid, group in enumerate(self.groups):
+            for m in group.cost_bearing:
+                vals = member_vals[gid][m]
+                self.g_unary[gid] += self.node_mult[m] * self._self_cost_vec(m, vals)
+
+        C: dict[tuple, np.ndarray] = {}
+        nbr_set: list[set] = [set() for _ in range(G)]
+        for v in self.cost_bearing:
+            gv = self.node_to_group[v]
+            mult = self.node_mult[v]
+            for argi, p in self.input_edges[v]:
+                gp = self.node_to_group[p]
+                R = self._edge_matrix(v, argi, p)  # (Kv, Kp) raw, BIG if forbidden
+                av = member_vals[gv][v]
+                bp = member_vals[gp][p]
+                contrib = mult * R[np.ix_(av, bp)]  # (D_gv, D_gp)
+                if gv == gp:
+                    self.g_unary[gv] += np.diagonal(contrib)
+                else:
+                    a, b = (gv, gp) if gv < gp else (gp, gv)
+                    mat = contrib if gv < gp else contrib.T
+                    if (a, b) in C:
+                        C[(a, b)] += mat
+                    else:
+                        C[(a, b)] = mat.copy()
+                    nbr_set[a].add(b)
+                    nbr_set[b].add(a)
+        self.C = C
+        self.nbrs = [sorted(s) for s in nbr_set]
+
+    # ------------------------------------------------------------------ #
+    def _self_cost_vec(self, m, out_indices):
+        """Vectorized self-cost (compute + producer-less arg costs) for node m
+        over an array of out_idx."""
+        opt = self.opt
+        node = opt.nodes[m]
+        prod = self._arg_prod.get(m, {})
+        out = np.empty(len(out_indices))
+        for i, o in enumerate(out_indices):
+            strat = opt.strats[node].strategies[o]
+            n_args = len(strat.redistribute_cost)
+            dv0 = self._surviving_dv(m, 0, o)
+            if dv0 is None:  # whole output strategy pruned
+                out[i] = BIG
+                continue
+            c = dv0.compute_cost * n_args
+            # Args with no flow edge (constructors / None-spec) are scored at
+            # inp=0 here; args with a producer are charged via the pairwise edges.
+            for argi in range(n_args):
+                if argi in prod:
+                    continue
+                key = (m, argi, o, 0)
+                if self._is_forbidden(key):
+                    c = BIG
+                    break
+                dv = opt.decision_vars[key]
+                c += dv.comm_cost + dv.sharding_transition_cost
+            out[i] = c
+        return out
+
+    def _edge_matrix(self, v, argi, p):
+        """Raw (Kv, Kp) edge cost matrix R[o_v][o_p] = comm + transition, BIG when
+        the (o_v, o_p) combination is forbidden. Only entries that can actually be
+        indexed by the group choices are filled; the rest are BIG."""
+        opt = self.opt
+        Kv = len(opt.strats[opt.nodes[v]].strategies)
+        Kp = len(opt.strats[opt.nodes[p]].strategies)
+        R = np.full((Kv, Kp), BIG)
+        gv = self.node_to_group[v]
+        gp = self.node_to_group[p]
+        ov_vals = sorted({c[v] for c in self.groups[gv].choices})
+        op_vals = sorted({c[p] for c in self.groups[gp].choices})
+        for ov in ov_vals:
+            for op in op_vals:
+                key = (v, argi, ov, op)
+                if self._is_forbidden(key):
+                    continue
+                dv = opt.decision_vars[key]
+                R[ov, op] = dv.comm_cost + dv.sharding_transition_cost
+        return R
+
+    def _pair_matrix(self, g, h):
+        """Pairwise cost oriented as (x_g, x_h)."""
+        if g < h:
+            return self.C[(g, h)]
+        return self.C[(h, g)].T
+
+    # ------------------------------------------------------------------ #
+    # Energy (fast, numpy)
+    # ------------------------------------------------------------------ #
+    def _fast_group_energy(self, gid, ci):
+        e = self.g_unary[gid][ci]
+        for h in self.nbrs[gid]:
+            ch = self.groups[h].current
+            e += self.C[(gid, h)][ci, ch] if gid < h else self.C[(h, gid)][ch, ci]
+        return e
+
+    def _fast_total_energy(self):
+        total = 0.0
+        for gid, g in enumerate(self.groups):
+            total += self.g_unary[gid][g.current]
+        for (a, b), mat in self.C.items():
+            total += mat[self.groups[a].current, self.groups[b].current]
+        return total
+
+    # ------------------------------------------------------------------ #
+    # Belief propagation (min-sum) + decode
+    # ------------------------------------------------------------------ #
+    def _belief_propagation(self, deadline=None):
+        """Sequential tree-reweighted message passing (TRW-S).
+
+        Plain loopy min-sum BP settles into globally-inconsistent fixed points on
+        this MRF (empirically 5-16% above the optimum). TRW-S optimizes a convex
+        upper bound over a tree decomposition (here: monotonic chains induced by a
+        node ordering), so on the integral sharding problem it converges to the
+        exact MAP. Node g is reweighted by 1/(chains through g) = 1/max(in,out)deg
+        under the ordering; forward and backward half-sweeps send only along edges
+        oriented with the pass. We decode each sweep and keep the best assignment."""
+        G = len(self.groups)
+        if G == 0:
+            return
+        unary = self.g_unary
+        nbrs = self.nbrs
+
+        order = sorted(range(G), key=lambda g: min(self.groups[g].members))
+        pos = [0] * G
+        for i, g in enumerate(order):
+            pos[g] = i
+        gamma = np.ones(G)
+        for g in range(G):
+            indeg = sum(1 for h in nbrs[g] if pos[h] < pos[g])
+            outdeg = sum(1 for h in nbrs[g] if pos[h] > pos[g])
+            gamma[g] = 1.0 / max(indeg, outdeg, 1)
+
+        msg: dict[tuple, np.ndarray] = {}
+        for g in range(G):
+            for h in nbrs[g]:
+                msg[(g, h)] = np.zeros(len(unary[h]))
+
+        # We decode every sweep and keep the best assignment. The decoded energy
+        # converges in long, irregular plateaus (it can sit at a high value for
+        # ~100 sweeps, drop, plateau again, then drop to the optimum), so neither
+        # an energy-plateau counter nor a message-delta threshold detects true
+        # convergence without stopping on a false plateau. We therefore run a
+        # fixed sweep budget (bounded by the time deadline), which is enough for
+        # the slowest converger observed, and an exact fixed point ends early.
+        best_e = INF
+        best_snap = None
+        for sweep in range(self.bp_iters):
+            max_delta = 0.0
+            for forward in (True, False):
+                for g in order if forward else order[::-1]:
+                    if not nbrs[g]:
+                        continue
+                    wp = unary[g].copy()
+                    for r in nbrs[g]:
+                        wp += msg[(r, g)]
+                    wp *= gamma[g]
+                    for h in nbrs[g]:
+                        if (pos[h] > pos[g]) != forward:
+                            continue
+                        P = self._pair_matrix(g, h)  # (D_g, D_h)
+                        m = ((wp - msg[(h, g)])[:, None] + P).min(axis=0)
+                        m -= m.min()
+                        d = np.abs(m - msg[(g, h)]).max()
+                        if d > max_delta:
+                            max_delta = d
+                        msg[(g, h)] = m
+            self._decode(msg)
+            e = self._fast_total_energy()
+            if e < best_e:
+                best_e, best_snap = e, [grp.current for grp in self.groups]
+            self._bp_last_iter = sweep + 1
+            self._bp_last_delta = max_delta
+            if max_delta == 0.0 or (
+                deadline is not None and time.perf_counter() > deadline
+            ):
+                break
+
+        if best_snap is not None:
+            for gid, ci in enumerate(best_snap):
+                self._set_group(gid, ci)
+
+    def _decode(self, msg):
+        """Sequential topological decode: fix each group to the argmin of its
+        belief conditioned on already-decoded neighbors (exact pairwise cost) and
+        BP messages for the rest. Produces a consistent, forbidden-avoiding
+        assignment, unlike independent argmin on a loopy graph."""
+        G = len(self.groups)
+        order = sorted(range(G), key=lambda g: min(self.groups[g].members))
+        decided: dict[int, int] = {}
+        for g in order:
+            b = self.g_unary[g].copy()
+            for h in self.nbrs[g]:
+                if h in decided:
+                    b = b + self._pair_matrix(g, h)[:, decided[h]]
+                else:
+                    b = b + msg[(h, g)]
+            ci = int(np.argmin(b))
+            decided[g] = ci
+            self._set_group(g, ci)
+
+    # ------------------------------------------------------------------ #
+    # Local search
+    # ------------------------------------------------------------------ #
+    def _set_group(self, gid, ci):
+        group = self.groups[gid]
+        group.current = ci
+        for m, o in group.choices[ci].items():
+            self.cur_out[m] = o
+
+    def _coordinate_descent(self, deadline):
+        for _ in range(self.max_sweeps):
+            if time.perf_counter() > deadline:
+                break
+            improved = False
+            for gid in range(len(self.groups)):
+                if self.groups[gid].domain <= 1:
+                    continue
+                cur = self.groups[gid].current
+                best_i, best_e = cur, self._fast_group_energy(gid, cur)
+                for ci in range(self.groups[gid].domain):
+                    if ci == cur:
+                        continue
+                    e = self._fast_group_energy(gid, ci)
+                    if e < best_e - 1e-6 and self._memory_ok_after(gid, ci):
+                        best_i, best_e = ci, e
+                if best_i != cur:
+                    self._set_group(gid, best_i)
+                    improved = True
+            if not improved:
+                break
+
+    def _star_block_search(self, deadline):
+        ranked = sorted(
+            (
+                (len(self.nbrs[g]), g)
+                for g in range(len(self.groups))
+                if len(self.nbrs[g]) >= 2 and self.groups[g].domain > 1
+            ),
+            reverse=True,
+        )
+        for _ in range(self.star_passes):
+            if time.perf_counter() > deadline:
+                break
+            improved = False
+            for _deg, gid in ranked:
+                if time.perf_counter() > deadline:
+                    break
+                if self._optimize_star(gid):
+                    improved = True
+            if not improved:
+                break
+
+    def _optimize_star(self, gid):
+        children = [h for h in self.nbrs[gid] if self.groups[h].domain > 1]
+        child_costs = sorted(
+            ((self._fast_group_energy(h, self.groups[h].current), h) for h in children),
+            reverse=True,
+        )
+        child_ids = [h for _e, h in child_costs[: self.max_star_children]]
+        if not child_ids:
+            return False
+        block = [gid, *child_ids]
+        base = self._block_energy(block)
+        best_energy = base
+        best_center = self.groups[gid].current
+        best_children = {h: self.groups[h].current for h in child_ids}
+        for ci in range(self.groups[gid].domain):
+            self._set_group(gid, ci)
+            if not self._memory_ok_after(gid, ci):
+                continue
+            chosen = {}
+            for h in child_ids:
+                b_i, b_e = self.groups[h].current, INF
+                for hi in range(self.groups[h].domain):
+                    e = self._fast_group_energy(h, hi)
+                    if e < b_e:
+                        b_i, b_e = hi, e
+                self._set_group(h, b_i)
+                chosen[h] = b_i
+            energy = self._block_energy(block)
+            if energy < best_energy - 1e-6 and self._block_memory_ok():
+                best_energy = energy
+                best_center = ci
+                best_children = dict(chosen)
+        self._set_group(gid, best_center)
+        for h, hi in best_children.items():
+            self._set_group(h, hi)
+        return best_energy < base - 1e-6
+
+    def _block_energy(self, gids):
+        total = 0.0
+        seen_edges = set()
+        for g in gids:
+            total += self.g_unary[g][self.groups[g].current]
+            for h in self.nbrs[g]:
+                key = (g, h) if g < h else (h, g)
+                if key in seen_edges:
+                    continue
+                seen_edges.add(key)
+                a, b = key
+                total += self.C[key][self.groups[a].current, self.groups[b].current]
+        return total
+
+    # ------------------------------------------------------------------ #
+    # Memory repair
+    # ------------------------------------------------------------------ #
+    def _current_memory(self):
+        if self._memory is None:
+            return 0.0
+        return sum(
+            self._memory["ratios"][v][self.cur_out[v]]
+            for v in self._memory["param_idxs"]
+        )
+
+    def _memory_ok_after(self, gid, ci):
+        if self._memory is None or self._memory.get("tight") or not self._mem_enforce:
+            return True
+        ratios = self._memory["ratios"]
+        choice = self.groups[gid].choices[ci]
+        delta = sum(
+            ratios[m][o] - ratios[m][self.cur_out[m]]
+            for m, o in choice.items()
+            if m in ratios
+        )
+        mem = self._current_memory() + delta
+        return (
+            self._memory["budget_low"] - 1e-6
+            <= mem
+            <= self._memory["budget_high"] + 1e-6
+        )
+
+    def _block_memory_ok(self):
+        if self._memory is None or self._memory.get("tight") or not self._mem_enforce:
+            return True
+        mem = self._current_memory()
+        return (
+            self._memory["budget_low"] - 1e-6
+            <= mem
+            <= self._memory["budget_high"] + 1e-6
+        )
+
+    def _memory_repair(self):
+        if self._memory is None or self._memory.get("tight"):
+            return
+        low, high = self._memory["budget_low"], self._memory["budget_high"]
+        ratios = self._memory["ratios"]
+        param_groups = {
+            self.node_to_group[v]
+            for v in self._memory["param_idxs"]
+            if v in self.node_to_group
+        }
+        for _ in range(2 * max(1, len(param_groups))):
+            mem = self._current_memory()
+            if low - 1e-6 <= mem <= high + 1e-6:
+                return
+            over = mem > high
+            best = None
+            for gid in param_groups:
+                group = self.groups[gid]
+                cur_e = self._fast_group_energy(gid, group.current)
+                for ci in range(group.domain):
+                    if ci == group.current:
+                        continue
+                    choice = group.choices[ci]
+                    dmem = sum(
+                        ratios[m][choice[m]] - ratios[m][self.cur_out[m]]
+                        for m in choice
+                        if m in ratios
+                    )
+                    if (dmem < -1e-9) != over and abs(dmem) > 1e-9:
+                        continue
+                    if abs(dmem) <= 1e-9:
+                        continue
+                    score = (self._fast_group_energy(gid, ci) - cur_e) / abs(dmem)
+                    if best is None or score < best[0]:
+                        best = (score, gid, ci)
+            if best is None:
+                logger.warning(
+                    "Approximate solver: memory repair stuck at %.4f "
+                    "(budget=[%.4f,%.4f]).",
+                    mem,
+                    low,
+                    high,
+                )
+                return
+            self._set_group(best[1], best[2])
+
+    # ------------------------------------------------------------------ #
+    # Lagrangian memory-constrained solve
+    # ------------------------------------------------------------------ #
+    def _build_mem_unary(self):
+        """Per-group vector mem_unary[gid][ci] = Σ_{param member} ratio[member][ci],
+        i.e. the memory term as a node-separable unary so it folds into the
+        Lagrangian objective with no change to the pairwise structure."""
+        self._mem_unary = [np.zeros(g.domain) for g in self.groups]
+        if self._memory is None:
+            return
+        ratios = self._memory["ratios"]
+        for v in self._memory["param_idxs"]:
+            gid = self.node_to_group.get(v)
+            if gid is None:
+                continue
+            r = ratios[v]
+            self._mem_unary[gid] += np.array(
+                [r[c[v]] for c in self.groups[gid].choices]
+            )
+
+    def _run_search(self, deadline):
+        self._belief_propagation(deadline)
+        self._coordinate_descent(deadline)
+        self._star_block_search(deadline)
+
+    def solve_lagrangian(
+        self,
+        budget_low,
+        budget_high,
+        deadline=None,
+        max_iter=30,
+        lam_tol=1e-9,
+        verbose=False,
+    ):
+        """Memory-constrained solve via Lagrangian relaxation.
+
+        The budget Σ_param ratio[v][x_v] ∈ [low, high] is a single linear,
+        node-separable coupling. Penalizing it by λ folds λ·ratio into each param
+        node's unary and leaves the pairwise MRF untouched, so TRW-S + polish
+        solves the penalized problem directly. a(λ) := Σ ratio at the optimum is
+        monotone non-increasing in λ (larger λ ⇒ more sharding ⇒ less memory), so
+        a scalar bisection on λ ≥ 0 drives a(λ) into the budget. The cheapest
+        feasible assignment seen is kept; the existing greedy repair only closes
+        any small residual from integrality.
+
+        Leaves the solver at the chosen assignment (does not write back) and
+        returns a dict: objective (true), memory (achieved a), lam, feasible,
+        iters."""
+        if not self._mem_unary:
+            self._build_mem_unary()
+        t_start = time.perf_counter()
+        if deadline is None:
+            deadline = t_start + self.max_time_s
+        # Reserve the tail of the budget for the constrained polish below.
+        bisect_deadline = t_start + 0.6 * (deadline - t_start)
+        base = [u.copy() for u in self.g_unary]
+        prev_enforce = self._mem_enforce
+        self._mem_enforce = False
+        eps = 1e-6
+
+        best = {"objective": INF, "snapshot": None, "memory": None, "lam": None}
+        # Closest over-budget assignment (smallest excess memory) — the seed the
+        # repair step nudges down into the budget to recover integer solutions
+        # that lie inside the (memory, cost) hull and so no lambda can reach.
+        seed = {"memory": INF, "snapshot": None}
+
+        def evaluate(lam):
+            for gid in range(len(self.groups)):
+                self.g_unary[gid] = base[gid] + lam * self._mem_unary[gid]
+            self._run_search(bisect_deadline)
+            a = self._current_memory()
+            obj = self.total_objective()
+            feasible = budget_low - eps <= a <= budget_high + eps
+            if feasible and obj < best["objective"]:
+                best.update(
+                    objective=obj,
+                    snapshot=[g.current for g in self.groups],
+                    memory=a,
+                    lam=lam,
+                )
+            if budget_high + eps < a < seed["memory"]:
+                seed.update(memory=a, snapshot=[g.current for g in self.groups])
+            if verbose:
+                logger.info(
+                    "lagrangian: lam=%.6g memory=%.5f obj=%.2f feasible=%s",
+                    lam,
+                    a,
+                    obj,
+                    feasible,
+                )
+            return a
+
+        a0 = evaluate(0.0)
+        iters = 1
+        if a0 <= budget_high + eps:
+            lam = 0.0  # unconstrained optimum already fits the budget
+        else:
+            lo_lam, hi_lam = 0.0, 1.0
+            while evaluate(hi_lam) > budget_high + eps and iters < max_iter:
+                lo_lam, hi_lam = hi_lam, hi_lam * 2.0
+                iters += 1
+            while iters < max_iter and hi_lam - lo_lam > lam_tol:
+                mid = 0.5 * (lo_lam + hi_lam)
+                a = evaluate(mid)
+                iters += 1
+                if a > budget_high + eps:
+                    lo_lam = mid  # still over budget, penalize harder
+                else:
+                    hi_lam = mid  # feasible, try to relax toward the cheaper side
+            lam = hi_lam
+
+        for gid in range(len(self.groups)):
+            self.g_unary[gid] = base[gid]
+        self._mem_enforce = prev_enforce
+
+        # Constrained polish (under the base unary, budget enforced). No single λ
+        # recovers integer solutions inside the (memory, cost) hull; coordinate +
+        # star search restricted to the budget can climb from an over-sharded
+        # point back up to a cheaper intermediate-memory one. We polish both the
+        # bisection's feasible point and the repaired closest-over-budget seed and
+        # keep the cheapest feasible result.
+        def polish(snapshot):
+            for gid, ci in enumerate(snapshot):
+                self._set_group(gid, ci)
+            self._memory_repair()
+            self._coordinate_descent(deadline)
+            self._star_block_search(deadline)
+            a = self._current_memory()
+            if budget_low - eps <= a <= budget_high + eps:
+                obj = self.total_objective()
+                if obj < best["objective"]:
+                    best.update(
+                        objective=obj,
+                        snapshot=[g.current for g in self.groups],
+                        memory=a,
+                        lam=lam,
+                    )
+
+        for snap in (best["snapshot"], seed["snapshot"]):
+            if snap is not None:
+                polish(snap)
+
+        if best["snapshot"] is not None:
+            for gid, ci in enumerate(best["snapshot"]):
+                self._set_group(gid, ci)
+        else:
+            # Nothing landed in [low, high]; repair the last assignment in place.
+            self._memory_repair()
+
+        a = self._current_memory()
+        return {
+            "objective": self.total_objective(),
+            "memory": a,
+            "lam": lam,
+            "feasible": budget_low - eps <= a <= budget_high + eps,
+            "iters": iters,
+        }
+
+    # ------------------------------------------------------------------ #
+    # Write-back
+    # ------------------------------------------------------------------ #
+    def total_objective(self):
+        """Exact objective of the current assignment via decision_vars (for
+        verification); equals pulp.value(prob.objective) after write-back."""
+        total = 0.0
+        for v in self.cost_bearing:
+            node = self.opt.nodes[v]
+            o = self.cur_out[v]
+            strat = self.opt.strats[node].strategies[o]
+            prod = self._arg_prod.get(v, {})
+            n_args = len(strat.redistribute_cost)
+            c = 0.0
+            for argi in range(n_args):
+                p = prod.get(argi)
+                inp = self.cur_out[p] if p is not None else 0
+                key = (v, argi, o, inp)
+                if self._is_forbidden(key):
+                    return INF
+                c += self.opt.decision_vars[key].cost
+            total += self.node_mult[v] * c
+        return total
+
+    def _write_back(self):
+        opt = self.opt
+        for var in opt.pulp_variables.values():
+            var.varValue = 0
+        selected = []
+        feasible = True
+        for v in self.cost_bearing:
+            node = opt.nodes[v]
+            o = self.cur_out[v]
+            strat = opt.strats[node].strategies[o]
+            prod = self._arg_prod.get(v, {})
+            for argi in range(len(strat.redistribute_cost)):
+                p = prod.get(argi)
+                inp = self.cur_out[p] if p is not None else 0
+                key = (v, argi, o, inp)
+                if self._is_forbidden(key):
+                    feasible = False
+                if key in opt.pulp_variables:
+                    opt.pulp_variables[key].varValue = 1
+                selected.append(key)
+        opt.selected_keys = list(selected)
+        for rk in selected:
+            opt.selected_keys.extend(opt._linked_option_keys(rk))
+        opt.prob.status = pulp.LpStatusOptimal
+        opt.prob.sol_status = pulp.LpSolutionOptimal
+        opt._set_objective()
+        return INF if not feasible else self.total_objective()

--- a/autoparallel/cost_models/nccl_cost_model.py
+++ b/autoparallel/cost_models/nccl_cost_model.py
@@ -80,6 +80,7 @@ class NCCLTopoConfig:
     has_collnet: bool = False  # Enables CollNet Direct/Chain (SHARP)
     # Additional network latency beyond base hw latency (us)
     net_latency: float = 0.0
+    mesh_dim_topo_override: "MeshDimTopo | None" = None
 
 
 @dataclass
@@ -1005,6 +1006,15 @@ def derive_mesh_dim_topo(
 ) -> MeshDimTopo:
     """Derive per-mesh-dimension NCCL topology parameters."""
     dim_size = mesh_shape[dim_idx]
+    if config.mesh_dim_topo_override is not None:
+        if len(mesh_shape) != 1 or dim_idx != 0:
+            raise ValueError("mesh_dim_topo_override can only be used for 1D dim0")
+        if config.mesh_dim_topo_override.n_ranks != dim_size:
+            raise ValueError(
+                "mesh_dim_topo_override.n_ranks must match the 1D mesh size"
+            )
+        return config.mesh_dim_topo_override
+
     inner_product = math.prod(mesh_shape[dim_idx + 1 :])
     ppn = max(1, min(config.gpus_per_node // inner_product, dim_size))
     n_nodes = dim_size // ppn

--- a/autoparallel/graph_passes/graph_clustering.py
+++ b/autoparallel/graph_passes/graph_clustering.py
@@ -65,18 +65,17 @@ def _prepare_op_strategy(op_strategy):
     return str(op_strategy)
 
 
-def _hash_node(node, strategies, input_pickler):
+def _hash_node(node, strategies, input_pickler, op_str):
+    # op_str caches _prepare_op_strategy(strategies[n]) per node: each node's
+    # (large, 3D-mesh) strategy string is otherwise rebuilt once as self plus
+    # once per consumer, dominating clustering time on deep models.
     key = (
         str(node.target),
         node.meta.get("partitioner_tag"),
         node.meta.get("stack_trace"),
         _normalize_args(node),
-        _prepare_op_strategy(strategies[node]),
-        tuple(
-            _prepare_op_strategy(strategies[s])
-            for s in node.all_input_nodes
-            if s in strategies
-        ),
+        op_str[node],
+        tuple(op_str[s] for s in node.all_input_nodes if s in strategies),
     )
     return sha256_hash(input_pickler.dumps(key))
 
@@ -107,6 +106,7 @@ def get_identical_regions(
     hash_to_duplicates: dict[str, IdenticalNodes] = defaultdict(list)
     node_to_duplicates: dict[Node, IdenticalNodes] = {}
     t = time.time()
+    op_str = {n: _prepare_op_strategy(s) for n, s in strategies.items()}
     for node in graph.nodes:
         if node.op == "placeholder":
             continue
@@ -115,7 +115,9 @@ def get_identical_regions(
             # HOP submodule get_attr nodes are not in strategies.
             continue
 
-        duplicates = hash_to_duplicates[_hash_node(node, strategies, input_pickler)]
+        duplicates = hash_to_duplicates[
+            _hash_node(node, strategies, input_pickler, op_str)
+        ]
         duplicates.append(node)
         node_to_duplicates[node] = duplicates
     logger.debug(f"Hashed nodes in {time.time() - t} s")

--- a/autoparallel/mesh_search.py
+++ b/autoparallel/mesh_search.py
@@ -1,0 +1,295 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import replace
+from typing import Any, Callable, Iterator, cast
+
+import torch
+from torch._subclasses.fake_tensor import unset_fake_temporarily
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor._dtensor_spec import DTensorSpec
+from torch.distributed.tensor.placement_types import Placement, Replicate, Shard
+
+from .cost_models.collective_runtime_estimation import (
+    get_nccl_topo_config,
+    reset_comms_cost_cache,
+    set_nccl_topo_config,
+)
+from .cost_models.compute_estimation import reset_compute_cost_cache
+from .cost_models.nccl_cost_model import (
+    NCCLTopoConfig,
+    derive_mesh_dim_topo,
+    detect_nccl_topo_config,
+)
+from .optimize_sharding import ShardingOptimizer
+from .shardings.placement_options import reset_placement_options_cache
+
+
+def reset_mesh_search_caches() -> None:
+    """Clear mesh-dependent strategy and cost caches."""
+
+    reset_placement_options_cache()
+    reset_comms_cost_cache()
+    reset_compute_cost_cache()
+
+
+def _set_cost_model_for_mesh(mesh, cost_model: Any) -> None:
+    if isinstance(cost_model, NCCLTopoConfig):
+        set_nccl_topo_config(cost_model)
+    elif cost_model == "nccl":
+        set_nccl_topo_config(detect_nccl_topo_config(mesh))
+    else:
+        set_nccl_topo_config(None)
+
+
+def _placement_code(p: Placement) -> str:
+    if isinstance(p, Shard):
+        return f"S{p.dim}"
+    if isinstance(p, Replicate):
+        return "R"
+    return type(p).__name__
+
+
+def _split_dim_seed_dim_cost_model(
+    cost_model: Any,
+    mesh_shape: tuple[int, ...],
+    dim_idx: int,
+    *,
+    fabric_aware: bool,
+) -> Any:
+    if not fabric_aware or not isinstance(cost_model, NCCLTopoConfig):
+        return cost_model
+
+    topo = derive_mesh_dim_topo(cost_model, mesh_shape, dim_idx)
+    return replace(cost_model, mesh_dim_topo_override=topo)
+
+
+def _split_dim_seed_cache_key(
+    size: int,
+    input_placement: Placement,
+    cost_model: Any,
+    mesh_shape: tuple[int, ...],
+    dim_idx: int,
+    *,
+    fabric_aware: bool,
+) -> tuple[Any, ...]:
+    placement = _placement_code(input_placement)
+    if isinstance(cost_model, NCCLTopoConfig):
+        dim_cost_model = _split_dim_seed_dim_cost_model(
+            cost_model, mesh_shape, dim_idx, fabric_aware=fabric_aware
+        )
+        topo = derive_mesh_dim_topo(dim_cost_model, (int(size),), 0)
+        return (
+            "nccl",
+            int(size),
+            placement,
+            tuple(mesh_shape),
+            dim_idx,
+            cost_model.arch.name,
+            cost_model.num_nodes,
+            cost_model.gpus_per_node,
+            cost_model.bw_intra,
+            cost_model.bw_inter,
+            cost_model.num_channels,
+            topo.n_nodes,
+            topo.ppn,
+            topo.bw_intra,
+            topo.bw_inter,
+            topo.n_channels,
+            dim_cost_model.has_nvswitch,
+            dim_cost_model.has_collnet,
+            dim_cost_model.net_latency,
+        )
+    return (str(cost_model), int(size), placement, tuple(mesh_shape), dim_idx)
+
+
+def _first_output_placements(output_specs) -> tuple[Placement, ...] | None:
+    if isinstance(output_specs, DTensorSpec):
+        return output_specs.placements
+    if isinstance(output_specs, (tuple, list)):
+        for output_spec in output_specs:
+            if isinstance(output_spec, DTensorSpec):
+                return output_spec.placements
+    return None
+
+
+def _project_placements_to_dim(
+    placements, dim_idx: int, ndim: int
+) -> tuple[tuple[Placement, ...] | None, ...]:
+    projected: list[tuple[Placement, ...] | None] = []
+    for placement in placements:
+        if placement is None:
+            projected.append(None)
+            continue
+        if isinstance(placement, Placement):
+            if ndim != 1:
+                raise ValueError(
+                    "A scalar local_map placement is only valid for a 1D mesh"
+                )
+            projected.append((placement,))
+            continue
+        if len(placement) != ndim:
+            raise ValueError(
+                f"local_map placement has {len(placement)} entries, expected {ndim}"
+            )
+        projected.append((placement[dim_idx],))
+    return tuple(projected)
+
+
+@contextmanager
+def _project_local_map_to_dim(
+    gm: torch.fx.GraphModule, mesh_1d, dim_idx: int, ndim: int
+) -> Iterator[None]:
+    originals = []
+    try:
+        for node in gm.graph.nodes:
+            local_map_kwargs = node.meta.get("local_map_kwargs")
+            if local_map_kwargs is None:
+                continue
+            projected = dict(local_map_kwargs)
+            projected["in_placements"] = _project_placements_to_dim(
+                local_map_kwargs["in_placements"], dim_idx, ndim
+            )
+            projected["out_placements"] = _project_placements_to_dim(
+                local_map_kwargs["out_placements"], dim_idx, ndim
+            )
+            projected["device_mesh"] = mesh_1d
+            originals.append((node, local_map_kwargs))
+            node.meta["local_map_kwargs"] = projected
+        yield
+    finally:
+        for node, local_map_kwargs in originals:
+            node.meta["local_map_kwargs"] = local_map_kwargs
+
+
+def build_split_dim_seed(
+    gm: torch.fx.GraphModule,
+    mesh_shape: tuple[int, ...],
+    input_placements: tuple[Placement, ...],
+    *,
+    cost_model: Any = "nccl",
+    force_grad_reduce_in_higher_precision: bool = False,
+    repeated_subgraphs: bool = True,
+    fast_build: bool = True,
+    memory_high_fn: Callable[[int], float] | None = None,
+    one_d_cache: dict[tuple[Any, ...], dict[str, Placement]] | None = None,
+    device_type: str = "cuda",
+    fabric_aware: bool = True,
+) -> dict[str, tuple[Placement, ...]]:
+    """Return a per-node placement seed for a target mesh shape.
+
+    Args:
+        gm: Joint graph to optimize.
+        mesh_shape: Target mesh shape.
+        input_placements: Required input placement for each target mesh dim.
+        cost_model: Cost model identifier or NCCL topology config.
+        force_grad_reduce_in_higher_precision: Whether gradient reductions use
+            higher precision costs.
+        repeated_subgraphs: Whether repeated graph regions share decisions.
+        fast_build: Whether one-dimensional solves skip redundant enumeration costs.
+        memory_high_fn: Function returning the parameter memory upper bound for
+            a one-dimensional solve size.
+        one_d_cache: Optional cache reused across calls.
+        device_type: Device mesh type.
+        fabric_aware: Whether one-dimensional solves use per-dim fabric topology.
+
+    Returns:
+        A mapping from FX node name to placement tuple.
+    """
+
+    ndim = len(mesh_shape)
+    if len(input_placements) != ndim:
+        raise ValueError(
+            f"input_placements has {len(input_placements)} entries, expected {ndim}"
+        )
+    if memory_high_fn is None:
+        memory_high_fn = lambda size: 1.0 / size  # noqa: E731
+
+    cache = one_d_cache if one_d_cache is not None else {}
+    seed_cost_model = cost_model
+    if fabric_aware and cost_model == "nccl":
+        with unset_fake_temporarily():
+            full_mesh = init_device_mesh(
+                device_type,
+                mesh_shape,
+                mesh_dim_names=tuple(f"d{i}" for i in range(ndim)),
+            )
+        seed_cost_model = detect_nccl_topo_config(full_mesh)
+
+    per_dim: list[dict[str, Placement]] = []
+    for dim_idx, size in enumerate(mesh_shape):
+        input_placement = input_placements[dim_idx]
+        key = _split_dim_seed_cache_key(
+            int(size),
+            input_placement,
+            seed_cost_model,
+            mesh_shape,
+            dim_idx,
+            fabric_aware=fabric_aware,
+        )
+        if key not in cache:
+            with unset_fake_temporarily():
+                mesh_1d = init_device_mesh(
+                    device_type,
+                    (int(size),),
+                    mesh_dim_names=("d",),
+                )
+            prev = get_nccl_topo_config()
+            try:
+                dim_cost_model = _split_dim_seed_dim_cost_model(
+                    seed_cost_model,
+                    mesh_shape,
+                    dim_idx,
+                    fabric_aware=fabric_aware,
+                )
+                _set_cost_model_for_mesh(mesh_1d, dim_cost_model)
+                reset_mesh_search_caches()
+                with _project_local_map_to_dim(gm, mesh_1d, dim_idx, ndim):
+                    opt = ShardingOptimizer(
+                        gm,
+                        mesh_1d,
+                        force_grad_reduce_in_higher_precision,
+                        repeated_subgraphs=repeated_subgraphs,
+                        fast_build=fast_build,
+                    )
+                    opt.add_sharded_input_constraint([(input_placement,)])
+                    opt.add_sharded_output_constraint([(input_placement,)])
+                    opt.add_parameter_memory_constraint(0.0, memory_high_fn(int(size)))
+                    solution = opt.get_solution()
+            finally:
+                set_nccl_topo_config(prev)
+
+            node_placements: dict[str, Placement] = {}
+            for node, strategy in solution.items():
+                placements = _first_output_placements(strategy.output_specs)
+                if placements is not None:
+                    node_placements[node.name] = placements[0]
+            cache[key] = node_placements
+        per_dim.append(cache[key])
+
+    seed: dict[str, tuple[Placement, ...]] = {}
+    for node in gm.graph.nodes:
+        if node.op == "output":
+            continue
+        seed[node.name] = tuple(
+            per_dim[i].get(node.name, Replicate()) for i in range(ndim)
+        )
+
+    from torch._functorch._aot_autograd.fx_utils import (
+        get_plain_input_and_grad_nodes,
+        get_plain_output_and_tangent_nodes,
+    )
+
+    input_tuple = tuple(input_placements)
+    for getter in (get_plain_input_and_grad_nodes, get_plain_output_and_tangent_nodes):
+        for _desc, (node, companion) in cast(Any, getter(gm.graph)).items():
+            seed[node.name] = input_tuple
+            if companion is not None:
+                seed[companion.name] = input_tuple
+
+    return seed

--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -41,10 +41,10 @@ subject to the following constraint categories:
 
    → Implemented in: add_output_input_consistent_constraint()
 
-4. COST CONSTRAINTS: Variables with infinite cost (invalid configurations) are
-   forced to zero. Efficiency penalties for inefficient collective operations
-   (e.g., non-batch-dim shard-to-replicate) are embedded in the cost coefficients
-   computed by the cost model (see cost_models/collective_runtime_estimation.py).
+4. COST CONSTRAINTS: Invalid configurations are excluded. Efficiency penalties
+   for inefficient collective operations (e.g., non-batch-dim
+   shard-to-replicate) are embedded in the cost coefficients computed by the
+   cost model (see cost_models/collective_runtime_estimation.py).
 
    ∀i,a,o,j: c_{i,a,o,j} = ∞ ⟹ x_{i,a,o,j} = 0
 
@@ -69,6 +69,7 @@ The solver finds the globally optimal sharding strategy that minimizes total
 runtime cost while satisfying all constraints.
 """
 
+import contextlib
 import logging
 import math
 import operator
@@ -106,6 +107,22 @@ from .shardings.placement_options import get_placement_options_for_node
 from .shardings.propagation_rules import _create_all_options
 
 logger = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def _skip_enumeration_redistribute_cost(enabled):
+    if not enabled:
+        yield
+        return
+
+    import torch.distributed.tensor._ops.utils as dt_utils
+
+    orig = dt_utils.redistribute_cost
+    dt_utils.redistribute_cost = lambda *args, **kwargs: 0.0
+    try:
+        yield
+    finally:
+        dt_utils.redistribute_cost = orig
 
 
 def concretize_symint(val):
@@ -188,7 +205,7 @@ def concretize_gm(gm):
     return concrete_gm, orig_to_concrete, concrete_to_orig
 
 
-@dataclass
+@dataclass(slots=True)
 class DecisionVar:
     """A decision variable in the ILP, representing one (node, arg, output_placement,
     input_placement) choice with its associated costs and strategy metadata."""
@@ -224,8 +241,10 @@ class ShardingOptimizer:
         mesh,
         force_grad_reduce_in_higher_precision=False,
         repeated_subgraphs=False,
+        fast_build=True,
     ):
         self.orig_gm = gm
+        self.fast_build = fast_build
         # The optimizer works on a concretized copy of the graph where all
         # symbolic shapes are replaced with their concrete hint values. This
         # centralizes dynamic-shape handling: the optimization pipeline
@@ -246,6 +265,7 @@ class ShardingOptimizer:
         # remove_constraints can keep this in sync.
         self._node_constraint_names: dict[str, str] = {}
         self._name_counters: dict[str, int] = {}
+        self._valid_keys: set[tuple] | None = None
         t0 = time.perf_counter()
         self.strats = self.build_sharding_metadata()
         # nodes/node_map are derived from strats (not graph.nodes) so that
@@ -258,7 +278,8 @@ class ShardingOptimizer:
 
         get_placement_options_timer().report()
 
-        self.cluster_links: dict[tuple, tuple] = {}
+        self.cluster_links: dict[int, int] = {}
+        self._root_to_copies: dict[int, list[int]] = defaultdict(list)
         if repeated_subgraphs:
             t = time.time()
             clusters = get_identical_regions(self.gm.graph, self.strats)
@@ -305,58 +326,59 @@ class ShardingOptimizer:
 
     def build_sharding_metadata(self):
         strats = {}
-        for node in self.graph.nodes:
-            if node.op in ("placeholder", "get_attr"):
-                val = node.meta.get("val")
-                if isinstance(val, torch.Tensor):
-                    strats[node] = _create_all_options(self.mesh, val.shape, tensor=val)
-                elif node.op == "placeholder":
-                    # Non-tensor placeholders (e.g. baked-in booleans/strings):
-                    # keep them in strats with empty-shape replicate options
-                    # so the constraint system can reference them.
-                    strats[node] = _create_all_options(self.mesh, ())
+        with _skip_enumeration_redistribute_cost(self.fast_build):
+            for node in self.graph.nodes:
+                if node.op in ("placeholder", "get_attr"):
+                    val = node.meta.get("val")
+                    if isinstance(val, torch.Tensor):
+                        strats[node] = _create_all_options(
+                            self.mesh, val.shape, tensor=val
+                        )
+                    elif node.op == "placeholder":
+                        # Non-tensor placeholders (e.g. baked-in booleans/strings):
+                        # keep them in strats with empty-shape replicate options
+                        # so the constraint system can reference them.
+                        strats[node] = _create_all_options(self.mesh, ())
+                    else:
+                        # Non-tensor get_attr: GraphModule submodules used by
+                        # HOPs — not added to strats, invisible to the ILP.
+                        # _all_input_nodes filters them.
+                        assert node.op == "get_attr"
+                        assert any(
+                            isinstance(u.target, torch._ops.HigherOrderOperator)
+                            or "local_map" in u.name
+                            for u in node.users
+                        ), f"Non-tensor get_attr {node} is not used by a HOP"
+                elif node.op == "call_function":
+                    if not _produces_tensor(node.meta.get("val")):
+                        # Shape-computation nodes (sym_size, operator.mul, etc.)
+                        # produce scalars, not tensors — skip sharding.
+                        continue
+                    user_strats = tree_map_only(
+                        torch.fx.Node,
+                        lambda x: strats.get(x, x.meta.get("val")),
+                        node.args,
+                    )
+                    user_args = tree_map_only(
+                        torch.fx.Node, lambda x: x.meta.get("val"), node.args
+                    )
+                    user_kwargs = tree_map_only(
+                        torch.fx.Node, lambda x: x.meta.get("val"), node.kwargs
+                    )
+                    strats[node] = get_placement_options_for_node(
+                        self.mesh, node, user_strats, user_args, user_kwargs
+                    )
+                elif node.op == "output":
+                    user_strats = tree_map_only(
+                        torch.fx.Node, lambda x: strats[x], node.args
+                    )
+                    strats[node] = user_strats
                 else:
-                    # Non-tensor get_attr: GraphModule submodules used by
-                    # HOPs — not added to strats, invisible to the ILP.
-                    # _all_input_nodes filters them.
-                    assert node.op == "get_attr"
-                    assert any(
-                        isinstance(u.target, torch._ops.HigherOrderOperator)
-                        or "local_map" in u.name
-                        for u in node.users
-                    ), f"Non-tensor get_attr {node} is not used by a HOP"
-            elif node.op == "call_function":
-                if not _produces_tensor(node.meta.get("val")):
-                    # Shape-computation nodes (sym_size, operator.mul, etc.)
-                    # produce scalars, not tensors — skip sharding.
-                    continue
-                user_strats = tree_map_only(
-                    torch.fx.Node,
-                    lambda x: strats.get(x, x.meta.get("val")),
-                    node.args,
-                )
-                user_args = tree_map_only(
-                    torch.fx.Node, lambda x: x.meta.get("val"), node.args
-                )
-                user_kwargs = tree_map_only(
-                    torch.fx.Node, lambda x: x.meta.get("val"), node.kwargs
-                )
-                strats[node] = get_placement_options_for_node(
-                    self.mesh, node, user_strats, user_args, user_kwargs
-                )
-            elif node.op == "output":
-                user_strats = tree_map_only(
-                    torch.fx.Node, lambda x: strats[x], node.args
-                )
-                strats[node] = user_strats
-            else:
-                raise ValueError(f"Unexpected node op: {node.op}")
+                    raise ValueError(f"Unexpected node op: {node.op}")
         return strats
 
     def create_cluster_links(self, clusters):
-        """Create a mapping between identical optimization nodes to reduce the
-        optimization space. If cluster_links[key1] == key2, the optimization
-        problem uses key2's variable in place of key1."""
+        """Create a node-level mapping between identical optimization nodes."""
         for cluster_group in clusters:
             cluster0 = cluster_group[0]
             for cluster_i in cluster_group[1:]:
@@ -369,13 +391,15 @@ class ShardingOptimizer:
                         f"Problem with graph clustering: {n0} and {ni} don't have the same number "
                         "of input/output placements. Please report a bug"
                     )
-                    for argi, out_idx, inp_idx in options_n0:
-                        self.cluster_links[(idx1, argi, out_idx, inp_idx)] = (
-                            idx0,
-                            argi,
-                            out_idx,
-                            inp_idx,
-                        )
+                    self.cluster_links[idx1] = idx0
+
+    def _cluster_root_key(self, key):
+        root_idx = self.cluster_links.get(key[0])
+        return key if root_idx is None else (root_idx, key[1], key[2], key[3])
+
+    def _linked_option_keys(self, root_key):
+        for copy_idx in self._root_to_copies.get(root_key[0], ()):
+            yield (copy_idx, root_key[1], root_key[2], root_key[3])
 
     def _all_input_nodes(self, node):
         """Variant of node.all_input_nodes that preserves duplicate nodes.
@@ -417,7 +441,7 @@ class ShardingOptimizer:
         to their PuLP variables. Linked keys are not stored; use
         _get_pulp_variable() to resolve them through cluster_links.
         """
-        cluster_linked_node_idxs = {key[0] for key in self.cluster_links}
+        cluster_linked_node_idxs = set(self.cluster_links)
 
         pulp_variables = {}
         for node, _ in self.strats.items():
@@ -428,6 +452,8 @@ class ShardingOptimizer:
                 continue
             for argi, out_idx, inp_idx in self.walk_over_options(node):
                 key = (node_idx, argi, out_idx, inp_idx)
+                if self._valid_keys is not None and key not in self._valid_keys:
+                    continue
                 root_node = self.nodes[node_idx]
                 pulp_variables[key] = pulp.LpVariable(
                     f"n={root_node},s={node_idx},arg={argi},"
@@ -440,8 +466,8 @@ class ShardingOptimizer:
     def _get_pulp_variable(self, key):
         """Look up the PuLP variable for a key, resolving through
         cluster_links if the key belongs to a linked node."""
-        root_key = self.cluster_links.get(key, key)
-        return self.pulp_variables[root_key]
+        root_key = self._cluster_root_key(key)
+        return self.pulp_variables.get(root_key)
 
     def _compute_edge_costs(
         self,
@@ -482,16 +508,17 @@ class ShardingOptimizer:
         """Build DecisionVar entries for every (node_idx, argi, out_idx, inp_idx)
         combination in the strategy space."""
         t_pulp_start = time.perf_counter()
-        self.pulp_variables = self._create_pulp_variables()
-        t_pulp_end = time.perf_counter()
+        self.pulp_variables = {}
+        self._valid_keys = set()
 
         # Precompute which node indices are cluster-linked so we can
         # copy costs from the root instead of recomputing them.
-        self._cluster_linked_node_idxs = {key[0] for key in self.cluster_links}
+        self._cluster_linked_node_idxs = set(self.cluster_links)
 
         t_compute = 0.0
         t_edge = 0.0
         n_vars = 0
+        n_pruned = 0
         n_cluster_copied = 0
 
         decision_vars = {}
@@ -499,49 +526,43 @@ class ShardingOptimizer:
             (self.node_map[node], node, strat) for node, strat in self.strats.items()
         ]
 
-        # Build DVs for root nodes only (not cluster-linked).
-        for node_idx, node, op_strategy in strats_items:
-            if node.op == "output":
-                continue
-            if node_idx in self._cluster_linked_node_idxs:
-                continue
+        root_idxs = [
+            node_idx
+            for node_idx, node, _ in strats_items
+            if node.op != "output" and node_idx not in self._cluster_linked_node_idxs
+        ]
+        tc0 = time.perf_counter()
+        node_results = [self._compute_node_edge_costs(idx) for idx in root_idxs]
+        t_edge = time.perf_counter() - tc0
 
-            num_args = len(op_strategy.strategies[0].input_specs)
-
-            for out_idx, output_strategy in enumerate(op_strategy.strategies):
-                tc0 = time.perf_counter()
-                compute_cost = estimate_strategy_runtime_cost(node, output_strategy)
-                tc1 = time.perf_counter()
-                t_compute += tc1 - tc0
-                per_arg_compute = compute_cost / num_args
-
+        for node_idx, out_data in node_results:
+            node = self.nodes[node_idx]
+            op_strategy = self.strats[node]
+            for out_idx, (per_arg_compute, arg_rows) in enumerate(out_data):
+                output_strategy = op_strategy.strategies[out_idx]
                 for argi, redist_costs in enumerate(output_strategy.redistribute_cost):
-                    for inp_idx, default_comm_cost in enumerate(redist_costs):
+                    for inp_idx, (comm_cost, transition_cost) in enumerate(
+                        arg_rows[argi]
+                    ):
                         key = (node_idx, argi, out_idx, inp_idx)
-
-                        all_input_nodes = self._all_input_nodes(node)
-                        producer_strategy = (
-                            self.strats[all_input_nodes[argi]]
-                            if all_input_nodes
-                            else None
-                        )
-                        te0 = time.perf_counter()
-                        comm_cost, transition_cost = self._compute_edge_costs(
-                            node,
-                            output_strategy,
-                            argi,
-                            inp_idx,
-                            default_comm_cost,
-                            producer_strategy,
-                        )
-                        te1 = time.perf_counter()
-                        t_edge += te1 - te0
-
                         redist_costs[inp_idx] = comm_cost
+                        cost = comm_cost + per_arg_compute + transition_cost
+                        if not math.isfinite(cost):
+                            n_pruned += 1
+                            continue
+
+                        var = pulp.LpVariable(
+                            f"n={node},s={node_idx},arg={argi},"
+                            f"output_p={out_idx},input_p={inp_idx}",
+                            cat=pulp.LpBinary,
+                        )
+                        self.pulp_variables[key] = var
+                        self._valid_keys.add(key)
+                        n_vars += 1
 
                         decision_vars[key] = DecisionVar(
-                            var=self.pulp_variables[key],
-                            cost=comm_cost + per_arg_compute + transition_cost,
+                            var=var,
+                            cost=cost,
                             compute_cost=per_arg_compute,
                             comm_cost=comm_cost,
                             sharding_transition_cost=transition_cost,
@@ -549,16 +570,12 @@ class ShardingOptimizer:
                             output_spec=output_strategy.output_specs,
                             input_spec=output_strategy.input_specs[argi],
                         )
-                        n_vars += 1
 
         # Batch-copy redistribute_cost from root strats to linked strats.
         # The root pass above updated redistribute_cost in place with
         # edge-computed costs; linked strats need the same values for
         # _compute_solution_cost and other readers.
-        linked_node_to_root_node: dict[int, int] = {}
-        for linked_key, root_key in self.cluster_links.items():
-            linked_node_to_root_node[linked_key[0]] = root_key[0]
-        for linked_node_idx, root_node_idx in linked_node_to_root_node.items():
+        for linked_node_idx, root_node_idx in self.cluster_links.items():
             linked_node = self.nodes[linked_node_idx]
             root_node = self.nodes[root_node_idx]
             linked_op = self.strats[linked_node]
@@ -570,16 +587,17 @@ class ShardingOptimizer:
                     list(costs) for costs in root_spec.redistribute_cost
                 ]
         n_cluster_copied = len(self.cluster_links)
-        n_vars += n_cluster_copied
 
-        self._root_to_linked: dict[tuple, list[tuple]] = defaultdict(list)
-        for linked_key, root_key in self.cluster_links.items():
-            self._root_to_linked[root_key].append(linked_key)
+        self._root_to_copies = defaultdict(list)
+        for copy_idx, root_idx in self.cluster_links.items():
+            self._root_to_copies[root_idx].append(copy_idx)
 
+        t_pulp_end = time.perf_counter()
         logger.debug(
-            "_build_decision_vars breakdown (%d vars, %d cluster-copied): "
+            "_build_decision_vars breakdown (%d vars, %d pruned-inf, %d cluster-copied): "
             "pulp_vars=%.3fs, compute_cost=%.3fs, edge_cost=%.3fs",
             n_vars,
+            n_pruned,
             n_cluster_copied,
             t_pulp_end - t_pulp_start,
             t_compute,
@@ -587,12 +605,47 @@ class ShardingOptimizer:
         )
         return decision_vars
 
+    def _compute_node_edge_costs(self, node_idx):
+        """Compute per-edge costs for one cluster-root node."""
+        node = self.nodes[node_idx]
+        op_strategy = self.strats[node]
+        num_args = len(op_strategy.strategies[0].input_specs)
+        input_nodes = self._all_input_nodes(node)
+        producer_strategies = [self.strats[n] for n in input_nodes]
+        out_data = []
+        for output_strategy in op_strategy.strategies:
+            per_arg_compute = (
+                estimate_strategy_runtime_cost(node, output_strategy) / num_args
+            )
+            arg_rows = []
+            for argi, redist_costs in enumerate(output_strategy.redistribute_cost):
+                producer_strategy = (
+                    producer_strategies[argi]
+                    if argi < len(producer_strategies)
+                    else None
+                )
+                arg_rows.append(
+                    [
+                        self._compute_edge_costs(
+                            node,
+                            output_strategy,
+                            argi,
+                            inp_idx,
+                            default_comm_cost,
+                            producer_strategy,
+                        )
+                        for inp_idx, default_comm_cost in enumerate(redist_costs)
+                    ]
+                )
+            out_data.append((per_arg_compute, arg_rows))
+        return node_idx, out_data
+
     def _resolve_decision_var(self, key):
         """Return a DecisionVar for key, reconstructing on the fly for linked keys."""
         dv = self.decision_vars.get(key)
         if dv is not None:
             return dv
-        root_key = self.cluster_links[key]
+        root_key = self._cluster_root_key(key)
         root_dv = self.decision_vars[root_key]
         node_idx, argi, out_idx, _ = key
         strategy = self.strats[self.nodes[node_idx]].strategies[out_idx]
@@ -607,6 +660,15 @@ class ShardingOptimizer:
             input_spec=strategy.input_specs[argi],
         )
 
+    def _find_decision_var(self, node_idx, argi, out_idx):
+        node = self.nodes[node_idx]
+        for _, _, inp_idx in self.walk_over_options(node, argi):
+            key = (node_idx, argi, out_idx, inp_idx)
+            root_key = self._cluster_root_key(key)
+            if root_key in self.decision_vars:
+                return self._resolve_decision_var(key)
+        return None
+
     def _collect_vars(self, node, node_idx, argi, group_by, resolve_clusters=False):
         """Collect PuLP variables for a node's options, grouped by strategy index.
 
@@ -619,12 +681,14 @@ class ShardingOptimizer:
         result = {}
         for _, out_idx, inp_idx in self.walk_over_options(node, argi):
             key = (node_idx, argi, out_idx, inp_idx)
-            if key in self.cluster_links:
+            if key[0] in self.cluster_links:
                 if not resolve_clusters:
                     continue
-                var = self.pulp_variables[self.cluster_links[key]]
+                var = self._get_pulp_variable(key)
             else:
-                var = self.pulp_variables[key]
+                var = self.pulp_variables.get(key)
+            if var is None:
+                continue
             group_key = out_idx if group_by == "out_idx" else inp_idx
             result.setdefault(group_key, []).append(var)
         return result
@@ -677,13 +741,16 @@ class ShardingOptimizer:
             if node_idx in self._cluster_linked_node_idxs:
                 continue
             arg_vars = {}
+            num_args = len(self.strats[node].strategies[0].input_specs)
             for argi, out_idx, inp_idx in self.walk_over_options(node):
                 key = (node_idx, argi, out_idx, inp_idx)
-                var = self.pulp_variables[key]
+                var = self.pulp_variables.get(key)
+                if var is None:
+                    continue
                 arg_vars.setdefault(argi, []).append(var)
-            for eqs in arg_vars.values():
+            for argi in range(num_args):
                 self.prob += (
-                    pulp.lpSum(eqs) == 1,
+                    pulp.lpSum(arg_vars.get(argi, [])) == 1,
                     self._get_next_name("unique_decision"),
                 )
 
@@ -703,17 +770,24 @@ class ShardingOptimizer:
                 continue
             if len(self._all_input_nodes(node)) <= 1:
                 continue
+            num_args = len(self._all_input_nodes(node))
+            num_outputs = len(self.strats[node].strategies)
             vars_per_output = {}
             for argi, out_idx, inp_idx in self.walk_over_options(node):
                 key = (node_idx, argi, out_idx, inp_idx)
-                var = self.pulp_variables[key]
+                var = self.pulp_variables.get(key)
+                if var is None:
+                    continue
                 vars_per_output.setdefault((argi, out_idx), []).append(var)
-            eqs_per_arg = [[] for _ in self._all_input_nodes(node)]
-            for (argi, out_idx), value in vars_per_output.items():
-                eqs_per_arg[argi].append(pulp.lpSum(value))
+            eqs_per_arg = [
+                [
+                    pulp.lpSum(vars_per_output.get((argi, out_idx), []))
+                    for out_idx in range(num_outputs)
+                ]
+                for argi in range(num_args)
+            ]
             arg0 = eqs_per_arg[0]
             for arg_eqs in eqs_per_arg[1:]:
-                assert len(arg0) == len(arg_eqs)
                 for i in range(len(arg0)):
                     self.prob += (
                         arg0[i] == arg_eqs[i],
@@ -790,22 +864,15 @@ class ShardingOptimizer:
                     )
                     continue
 
-                assert (
-                    vars_producer.keys() == vars_consumer.keys()
-                ), f"{vars_producer}, {vars_consumer}"
-
-                for k in vars_producer:
+                for k in vars_producer.keys() | vars_consumer.keys():
                     self.prob += (
-                        pulp.lpSum(vars_producer[k]) == pulp.lpSum(vars_consumer[k]),
+                        pulp.lpSum(vars_producer.get(k, []))
+                        == pulp.lpSum(vars_consumer.get(k, [])),
                         self._get_next_name("output_input_consistent"),
                     )
 
     def add_inf_cost_constraint(self):
-        """COST (Category 4): Variables with infinite cost (invalid configurations)
-        are forced to zero.
-
-        ∀i,a,o,j: c_{i,a,o,j} = ∞ ⟹ x_{i,a,o,j} = 0
-        """
+        """COST (Category 4): Invalid configurations are excluded."""
         for key, dv in self.decision_vars.items():
             if not math.isfinite(dv.cost):
                 dv.cost = 10000.0
@@ -880,7 +947,7 @@ class ShardingOptimizer:
         """Add the cost minimization objective to the ILP."""
         terms = []
         for key, dv in self.decision_vars.items():
-            multiplier = 1 + len(self._root_to_linked.get(key, []))
+            multiplier = 1 + len(self._root_to_copies.get(key[0], ()))
             terms.append(dv.var * dv.cost * multiplier)
         self.prob += pulp.lpSum(terms)
 
@@ -898,7 +965,7 @@ class ShardingOptimizer:
             key for key, dv in self.decision_vars.items() if dv.var.value() == 1
         ]
         for root_key in list(self.selected_keys):
-            self.selected_keys.extend(self._root_to_linked.get(root_key, []))
+            self.selected_keys.extend(self._linked_option_keys(root_key))
 
         if self.prob.status == -1:
             logger.warning(self.get_violated_constraints_log())
@@ -1073,7 +1140,9 @@ class ShardingOptimizer:
             # Use pre-computed costs from decision vars instead of
             # estimate_strategy_runtime_cost, which needs node.meta["val"]
             # (absent on loaded optimizers).
-            dv = self._resolve_decision_var((node_idx, 0, out_idx, 0))
+            dv = self._find_decision_var(node_idx, 0, out_idx)
+            if dv is None:
+                continue
             num_args = max(len(strategy.input_specs), 1)
             total_compute += dv.compute_cost * num_args
 
@@ -1158,9 +1227,9 @@ class ShardingOptimizer:
 
         # Build node-level cluster mapping: linked_node -> root_node
         cluster_roots: dict[torch.fx.Node, torch.fx.Node] = {}
-        for linked_key, root_key in self.cluster_links.items():
-            linked_node = self.nodes[linked_key[0]]
-            root_node = self.nodes[root_key[0]]
+        for linked_idx, root_idx in self.cluster_links.items():
+            linked_node = self.nodes[linked_idx]
+            root_node = self.nodes[root_idx]
             cluster_roots[linked_node] = root_node
 
         _normalize_cluster_layer(cluster_roots)
@@ -1404,11 +1473,13 @@ class ShardingOptimizer:
         if constraint_name is None:
             constraint_name = "user_constraint"
         node_idx = self.node_map[node]
-        vars_per_arg = {}
+        num_args = len(self.strats[node].strategies[0].input_specs)
+        vars_per_arg = {argi: [] for argi in range(num_args)}
         for argi, out_idx, inp_idx in self.walk_over_options(node):
             if out_idx in output_constraint_indices:
                 var = self._get_pulp_variable((node_idx, argi, out_idx, inp_idx))
-                vars_per_arg.setdefault(argi, []).append(var)
+                if var is not None:
+                    vars_per_arg[argi].append(var)
         names = []
         for eqs in vars_per_arg.values():
             name = self._get_next_name(constraint_name)
@@ -1435,8 +1506,10 @@ class ShardingOptimizer:
                 # This placement exists in node_a but not in node_b.
                 # Disable it: force sum of its decision variables to 0.
                 v_a = [
-                    self._get_pulp_variable((idx_a, 0, out_idx, inp_idx))
+                    var
                     for inp_idx in range(num_inp_a)
+                    if (var := self._get_pulp_variable((idx_a, 0, out_idx, inp_idx)))
+                    is not None
                 ]
                 self.prob += (
                     pulp.lpSum(v_a) == 0,
@@ -1445,12 +1518,16 @@ class ShardingOptimizer:
                 continue
             out_idx_b = strat_b.index(sp)
             v_a = [
-                self._get_pulp_variable((idx_a, 0, out_idx, inp_idx))
+                var
                 for inp_idx in range(num_inp_a)
+                if (var := self._get_pulp_variable((idx_a, 0, out_idx, inp_idx)))
+                is not None
             ]
             v_b = [
-                self._get_pulp_variable((idx_b, 0, out_idx_b, inp_idx))
+                var
                 for inp_idx in range(num_inp_b)
+                if (var := self._get_pulp_variable((idx_b, 0, out_idx_b, inp_idx)))
+                is not None
             ]
             self.prob += (
                 pulp.lpSum(v_b) == pulp.lpSum(v_a),
@@ -1653,7 +1730,9 @@ class ShardingOptimizer:
             num_out_strat = len(self.strats[node].strategies)
             ratios: list[float] = []
             for out_idx in range(num_out_strat):
-                dv = self._resolve_decision_var((node_idx, 0, out_idx, 0))
+                dv = self._find_decision_var(node_idx, 0, out_idx)
+                if dv is None:
+                    continue
                 spec: DTensorSpec = dv.input_spec
                 assert spec.tensor_meta is not None
                 tensor_shape: torch.Size = spec.tensor_meta.shape
@@ -1663,6 +1742,8 @@ class ShardingOptimizer:
                 ratio = new_size / old_size
                 ratios.append(ratio)
                 elms.append(dv.var * ratio)
+            if not ratios:
+                continue
             best_ratio: float = min(ratios)
             budget_low += max(best_ratio, memory_factor_low)
             budget_high += max(best_ratio, memory_factor_high)

--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -41,10 +41,10 @@ subject to the following constraint categories:
 
    → Implemented in: add_output_input_consistent_constraint()
 
-4. COST CONSTRAINTS: Invalid configurations are excluded. Efficiency penalties
-   for inefficient collective operations (e.g., non-batch-dim
-   shard-to-replicate) are embedded in the cost coefficients computed by the
-   cost model (see cost_models/collective_runtime_estimation.py).
+4. COST CONSTRAINTS: Variables with infinite cost (invalid configurations) are
+   forced to zero. Efficiency penalties for inefficient collective operations
+   (e.g., non-batch-dim shard-to-replicate) are embedded in the cost coefficients
+   computed by the cost model (see cost_models/collective_runtime_estimation.py).
 
    ∀i,a,o,j: c_{i,a,o,j} = ∞ ⟹ x_{i,a,o,j} = 0
 
@@ -108,21 +108,31 @@ from .shardings.propagation_rules import _create_all_options
 
 logger = logging.getLogger(__name__)
 
+# Strategy enumeration fills each OpSpec's redistribute_cost via torch's
+# generate_redistribute_costs (an expensive per-strategy redistribute-plan
+# computation, the dominant cost of build on large/3D meshes). But
+# _build_decision_vars overwrites every edge with the NCCL-aware
+# estimate_strategy_comms_cost, and nothing reads the enumeration costs in
+# between (remove_invalid_configs / keep_unique_configs select on placements/
+# shapes only). So during enumeration we replace torch's redistribute_cost with
+# a structure-preserving dummy to skip the wasted work; the final decision_vars
+# are byte-identical. Autoparallel's own cost model uses a separate
+# redistribute_cost (collective_runtime_estimation) and is unaffected.
+
 
 @contextlib.contextmanager
 def _skip_enumeration_redistribute_cost(enabled):
     if not enabled:
         yield
         return
+    import torch.distributed.tensor._ops.utils as _dt_utils
 
-    import torch.distributed.tensor._ops.utils as dt_utils
-
-    orig = dt_utils.redistribute_cost
-    dt_utils.redistribute_cost = lambda *args, **kwargs: 0.0
+    orig = _dt_utils.redistribute_cost
+    _dt_utils.redistribute_cost = lambda *args, **kwargs: 0.0
     try:
         yield
     finally:
-        dt_utils.redistribute_cost = orig
+        _dt_utils.redistribute_cost = orig
 
 
 def concretize_symint(val):
@@ -208,7 +218,10 @@ def concretize_gm(gm):
 @dataclass(slots=True)
 class DecisionVar:
     """A decision variable in the ILP, representing one (node, arg, output_placement,
-    input_placement) choice with its associated costs and strategy metadata."""
+    input_placement) choice with its associated costs and strategy metadata.
+
+    slots=True: there are millions of these on large/3D meshes, so dropping the
+    per-instance __dict__ materially cuts both build time and memory."""
 
     var: Any  # pulp.LpVariable
     cost: float
@@ -218,6 +231,14 @@ class DecisionVar:
     strategy: Any  # OpSpec
     output_spec: Any  # DTensorSpec or tuple[DTensorSpec | None, ...]
     input_spec: Any  # DTensorSpec
+
+
+@dataclass
+class LPRelaxationResult:
+    objective: float
+    status: str
+    solve_s: float
+    total_s: float
 
 
 def _assert_has_tensor_meta(spec_or_specs, node, label):
@@ -265,21 +286,33 @@ class ShardingOptimizer:
         # remove_constraints can keep this in sync.
         self._node_constraint_names: dict[str, str] = {}
         self._name_counters: dict[str, int] = {}
+        # Set by _build_decision_vars: the (node, arg, out, inp) keys whose
+        # strategy edge has finite cost. Invalid (infinite-cost) edges are
+        # pruned and get no variable. None means "no pruning filter".
         self._valid_keys: set[tuple] | None = None
+        self.profile: dict[str, Any] = {"timings": {}}
+        t_init_start = time.perf_counter()
         t0 = time.perf_counter()
         self.strats = self.build_sharding_metadata()
+        t_strategy = time.perf_counter() - t0
+        self.profile["timings"]["strategy_enumeration_s"] = t_strategy
+        logger.info("ShardingOptimizer: strategy enumeration took %.3fs", t_strategy)
         # nodes/node_map are derived from strats (not graph.nodes) so that
         # shape-computation nodes skipped by build_sharding_metadata don't
         # appear and indices stay consistent.
         self.nodes = list(self.strats.keys())
         self.node_map = {node: i for i, node in enumerate(self.nodes)}
-        logger.debug("Placement options took %.3fs", time.perf_counter() - t0)
+        logger.debug("Placement options took %.3fs", t_strategy)
         from autoparallel.shardings.placement_options import get_placement_options_timer
 
         get_placement_options_timer().report()
 
+        # Node-level: cluster-copy node idx -> root node idx (option indices are
+        # identical between copy and root; resolved on demand via
+        # _cluster_root_key / _linked_option_keys).
         self.cluster_links: dict[int, int] = {}
         self._root_to_copies: dict[int, list[int]] = defaultdict(list)
+
         if repeated_subgraphs:
             t = time.time()
             clusters = get_identical_regions(self.gm.graph, self.strats)
@@ -294,22 +327,30 @@ class ShardingOptimizer:
         self.prob = pulp.LpProblem("AutoParallel", pulp.LpMinimize)
         self.add_default_constraints()
         t3 = time.perf_counter()
-        n_unique_vars = len(self.pulp_variables)
-        n_constraints = len(self.prob.constraints)
-        logger.debug(
-            "ILP construction took %.3fs "
-            "(decision_vars=%.3fs, validate=%.3fs, constraints=%.3fs)",
-            t3 - t0,
-            t1 - t0,
-            t2 - t1,
-            t3 - t2,
+        self.profile["timings"].update(
+            {
+                "decision_var_build_s": t1 - t0,
+                "validation_s": t2 - t1,
+                "constraint_construction_s": t3 - t2,
+                "init_total_s": t3 - t_init_start,
+            }
         )
-        logger.debug(
-            "ILP problem size: %d unique vars, %d decision vars, %d constraints",
-            n_unique_vars,
+        n_constraints = len(self.prob.constraints)
+        logger.info(
+            "ShardingOptimizer: build done in %.3fs (%d unique vars, %d decision "
+            "vars, %d constraints)",
+            t3 - t_init_start,
+            len(self.pulp_variables),
             len(self.decision_vars),
             n_constraints,
         )
+
+    @staticmethod
+    def _safe_float(value):
+        try:
+            return float(value)
+        except Exception:
+            return math.nan
 
     def _get_next_name(self, prefix):
         idx = self._name_counters.setdefault(prefix, 0)
@@ -326,6 +367,9 @@ class ShardingOptimizer:
 
     def build_sharding_metadata(self):
         strats = {}
+        # Enumeration's redistribute_cost matrices are overwritten with real
+        # costs in _build_decision_vars, so skip computing them here (see
+        # _skip_enumeration_redistribute_cost).
         with _skip_enumeration_redistribute_cost(self.fast_build):
             for node in self.graph.nodes:
                 if node.op in ("placeholder", "get_attr"):
@@ -378,28 +422,40 @@ class ShardingOptimizer:
         return strats
 
     def create_cluster_links(self, clusters):
-        """Create a node-level mapping between identical optimization nodes."""
+        """Map each cluster-copy node to its root node (node-level). The optimizer
+        reuses the root's decision variable for every copy, and the per-(arg, out,
+        inp) option index is identical between a copy and its root, so we store
+        only the node->node map and reconstruct option keys on demand (see
+        _cluster_root_key / _linked_option_keys). Materializing one dict entry per
+        option-tuple instead costs tens of millions of entries (and seconds of
+        build time) on large/3D meshes."""
         for cluster_group in clusters:
             cluster0 = cluster_group[0]
             for cluster_i in cluster_group[1:]:
                 for n0, ni in zip(cluster0, cluster_i):
-                    idx0 = self.node_map[n0]
-                    idx1 = self.node_map[ni]
-                    options_n0 = list(self.walk_over_options(n0))
-                    options_ni = list(self.walk_over_options(ni))
-                    assert options_n0 == options_ni, (
-                        f"Problem with graph clustering: {n0} and {ni} don't have the same number "
-                        "of input/output placements. Please report a bug"
+                    assert len(self.strats[n0].strategies) == len(
+                        self.strats[ni].strategies
+                    ), (
+                        f"Problem with graph clustering: {n0} and {ni} don't have "
+                        "the same number of strategies. Please report a bug"
                     )
-                    self.cluster_links[idx1] = idx0
+                    self.cluster_links[self.node_map[ni]] = self.node_map[n0]
 
     def _cluster_root_key(self, key):
+        """Resolve an option key to its cluster-root option key, or return it
+        unchanged when the node is not a cluster copy. The (arg, out, inp) indices
+        are identical between a copy and its root."""
         root_idx = self.cluster_links.get(key[0])
         return key if root_idx is None else (root_idx, key[1], key[2], key[3])
 
     def _linked_option_keys(self, root_key):
-        for copy_idx in self._root_to_copies.get(root_key[0], ()):
-            yield (copy_idx, root_key[1], root_key[2], root_key[3])
+        """The option keys on the cluster copies of root_key's node (each a mirror
+        of root_key with the copy's node index). A copy mirrors its root's
+        per-option validity, so callers pass valid root keys only."""
+        copies = self._root_to_copies.get(root_key[0])
+        if not copies:
+            return ()
+        return [(c, root_key[1], root_key[2], root_key[3]) for c in copies]
 
     def _all_input_nodes(self, node):
         """Variant of node.all_input_nodes that preserves duplicate nodes.
@@ -433,14 +489,25 @@ class ShardingOptimizer:
                 for inp_idx in range(len(strategy.redistribute_cost[argi])):
                     yield argi, out_idx, inp_idx
 
-    def _create_pulp_variables(self):
-        """Create PuLP binary variables for all decision points, resolving
-        cluster links so that identical nodes share the same variable.
+    def _create_pulp_variables(self, variable_category=pulp.LpBinary):
+        """Create PuLP variables for all decision points, resolving cluster
+        links so that identical nodes share the same variable.
 
         Returns a dict mapping root (node_idx, argi, out_idx, inp_idx) keys
         to their PuLP variables. Linked keys are not stored; use
         _get_pulp_variable() to resolve them through cluster_links.
+
+        Keys whose strategy is invalid (infinite cost) are pruned: if
+        self._valid_keys is set, only those keys get a variable. These
+        variables would otherwise be forced to zero by an inf-cost
+        constraint, so skipping them shrinks the ILP without changing the
+        optimum (see _build_decision_vars).
         """
+        if variable_category not in {pulp.LpBinary, pulp.LpContinuous}:
+            raise ValueError(
+                f"Unsupported variable_category={variable_category!r}; "
+                "expected pulp.LpBinary or pulp.LpContinuous"
+            )
         cluster_linked_node_idxs = set(self.cluster_links)
 
         pulp_variables = {}
@@ -455,17 +522,26 @@ class ShardingOptimizer:
                 if self._valid_keys is not None and key not in self._valid_keys:
                     continue
                 root_node = self.nodes[node_idx]
+                bounds = (
+                    {"lowBound": 0, "upBound": 1}
+                    if variable_category == pulp.LpContinuous
+                    else {}
+                )
                 pulp_variables[key] = pulp.LpVariable(
                     f"n={root_node},s={node_idx},arg={argi},"
                     f"output_p={out_idx},input_p={inp_idx}",
-                    cat=pulp.LpBinary,
+                    cat=variable_category,
+                    **bounds,
                 )
 
         return pulp_variables
 
     def _get_pulp_variable(self, key):
         """Look up the PuLP variable for a key, resolving through
-        cluster_links if the key belongs to a linked node."""
+        cluster_links if the key belongs to a linked node.
+
+        Returns None if the key was pruned (invalid/infinite-cost strategy).
+        """
         root_key = self._cluster_root_key(key)
         return self.pulp_variables.get(root_key)
 
@@ -506,11 +582,15 @@ class ShardingOptimizer:
 
     def _build_decision_vars(self):
         """Build DecisionVar entries for every (node_idx, argi, out_idx, inp_idx)
-        combination in the strategy space."""
-        t_pulp_start = time.perf_counter()
-        self.pulp_variables = {}
-        self._valid_keys = set()
+        combination in the strategy space.
 
+        Strategy edges whose total cost is infinite (invalid redistributions)
+        are pruned: no variable is created for them. Such a variable would be
+        forced to zero by an inf-cost constraint anyway, so dropping it leaves
+        the optimum unchanged while removing ~30% of the variables and the
+        corresponding ~80% of constraints that are pure ``var == 0`` bounds.
+
+        """
         # Precompute which node indices are cluster-linked so we can
         # copy costs from the root instead of recomputing them.
         self._cluster_linked_node_idxs = set(self.cluster_links)
@@ -521,11 +601,15 @@ class ShardingOptimizer:
         n_pruned = 0
         n_cluster_copied = 0
 
+        t_pulp_start = time.perf_counter()
+        self.pulp_variables = {}
+        self._valid_keys = set()
         decision_vars = {}
         strats_items = [
             (self.node_map[node], node, strat) for node, strat in self.strats.items()
         ]
 
+        # Phase A: compute every root node's per-edge costs.
         root_idxs = [
             node_idx
             for node_idx, node, _ in strats_items
@@ -535,22 +619,32 @@ class ShardingOptimizer:
         node_results = [self._compute_node_edge_costs(idx) for idx in root_idxs]
         t_edge = time.perf_counter() - tc0
 
+        # Phase B: assemble decision vars (and PuLP variables) from the computed
+        # costs. Serial because PuLP vars and DecisionVars hold parent-owned
+        # strategy objects; byte-identical to computing the costs inline. This
+        # also writes the real costs back into each strat's redistribute_cost
+        # (overwriting the enumeration dummies) for the cluster batch-copy and
+        # _compute_solution_cost readers below.
         for node_idx, out_data in node_results:
             node = self.nodes[node_idx]
             op_strategy = self.strats[node]
             for out_idx, (per_arg_compute, arg_rows) in enumerate(out_data):
                 output_strategy = op_strategy.strategies[out_idx]
                 for argi, redist_costs in enumerate(output_strategy.redistribute_cost):
+                    input_spec = output_strategy.input_specs[argi]
                     for inp_idx, (comm_cost, transition_cost) in enumerate(
                         arg_rows[argi]
                     ):
-                        key = (node_idx, argi, out_idx, inp_idx)
                         redist_costs[inp_idx] = comm_cost
                         cost = comm_cost + per_arg_compute + transition_cost
+                        # Prune invalid (infinite-cost) edges: no variable, no
+                        # DecisionVar. A key absent from decision_vars is treated
+                        # as forbidden by both the ILP and the approximate solver.
                         if not math.isfinite(cost):
                             n_pruned += 1
                             continue
 
+                        key = (node_idx, argi, out_idx, inp_idx)
                         var = pulp.LpVariable(
                             f"n={node},s={node_idx},arg={argi},"
                             f"output_p={out_idx},input_p={inp_idx}",
@@ -558,8 +652,6 @@ class ShardingOptimizer:
                         )
                         self.pulp_variables[key] = var
                         self._valid_keys.add(key)
-                        n_vars += 1
-
                         decision_vars[key] = DecisionVar(
                             var=var,
                             cost=cost,
@@ -568,8 +660,9 @@ class ShardingOptimizer:
                             sharding_transition_cost=transition_cost,
                             strategy=output_strategy,
                             output_spec=output_strategy.output_specs,
-                            input_spec=output_strategy.input_specs[argi],
+                            input_spec=input_spec,
                         )
+                        n_vars += 1
 
         # Batch-copy redistribute_cost from root strats to linked strats.
         # The root pass above updated redistribute_cost in place with
@@ -588,6 +681,9 @@ class ShardingOptimizer:
                 ]
         n_cluster_copied = len(self.cluster_links)
 
+        # Root node idx -> [copy node idxs]. Option keys are reconstructed on
+        # demand (see _linked_option_keys); a copy mirrors its root's per-option
+        # validity, so no per-option filtering is needed here.
         self._root_to_copies = defaultdict(list)
         for copy_idx, root_idx in self.cluster_links.items():
             self._root_to_copies[root_idx].append(copy_idx)
@@ -595,18 +691,19 @@ class ShardingOptimizer:
         t_pulp_end = time.perf_counter()
         logger.debug(
             "_build_decision_vars breakdown (%d vars, %d pruned-inf, %d cluster-copied): "
-            "pulp_vars=%.3fs, compute_cost=%.3fs, edge_cost=%.3fs",
-            n_vars,
+            "build=%.3fs, compute_cost=%.3fs, edge_cost=%.3fs",
+            len(decision_vars),
             n_pruned,
             n_cluster_copied,
             t_pulp_end - t_pulp_start,
             t_compute,
             t_edge,
         )
+        self.profile["timings"]["cost_estimation_s"] = t_compute + t_edge
         return decision_vars
 
     def _compute_node_edge_costs(self, node_idx):
-        """Compute per-edge costs for one cluster-root node."""
+        """Compute per-edge costs for one root node."""
         node = self.nodes[node_idx]
         op_strategy = self.strats[node]
         num_args = len(op_strategy.strategies[0].input_specs)
@@ -645,10 +742,10 @@ class ShardingOptimizer:
         dv = self.decision_vars.get(key)
         if dv is not None:
             return dv
-        root_key = self._cluster_root_key(key)
-        root_dv = self.decision_vars[root_key]
         node_idx, argi, out_idx, _ = key
         strategy = self.strats[self.nodes[node_idx]].strategies[out_idx]
+        root_key = self._cluster_root_key(key)
+        root_dv = self.decision_vars[root_key]
         return DecisionVar(
             var=self._get_pulp_variable(key),
             cost=root_dv.cost,
@@ -661,11 +758,24 @@ class ShardingOptimizer:
         )
 
     def _find_decision_var(self, node_idx, argi, out_idx):
-        node = self.nodes[node_idx]
-        for _, _, inp_idx in self.walk_over_options(node, argi):
+        """Return a DecisionVar for any surviving inp_idx of (node, arg, out),
+        or None if every edge for that output strategy was pruned.
+
+        compute_cost is identical across inp_idx for a given out_idx, so callers
+        that only need per-strategy costs can use whichever edge survived.
+        """
+        strategy = self.strats[self.nodes[node_idx]].strategies[out_idx]
+        n_inp = (
+            len(strategy.redistribute_cost[argi]) if strategy.redistribute_cost else 1
+        )
+        for inp_idx in range(n_inp):
             key = (node_idx, argi, out_idx, inp_idx)
-            root_key = self._cluster_root_key(key)
-            if root_key in self.decision_vars:
+            if key in self.decision_vars:
+                return self._resolve_decision_var(key)
+            if (
+                key[0] in self.cluster_links
+                and self._cluster_root_key(key) in self.decision_vars
+            ):
                 return self._resolve_decision_var(key)
         return None
 
@@ -684,10 +794,10 @@ class ShardingOptimizer:
             if key[0] in self.cluster_links:
                 if not resolve_clusters:
                     continue
-                var = self._get_pulp_variable(key)
+                var = self.pulp_variables.get(self._cluster_root_key(key))
             else:
                 var = self.pulp_variables.get(key)
-            if var is None:
+            if var is None:  # pruned (invalid/infinite-cost) strategy edge
                 continue
             group_key = out_idx if group_by == "out_idx" else inp_idx
             result.setdefault(group_key, []).append(var)
@@ -698,6 +808,11 @@ class ShardingOptimizer:
             if node.op != "call_function":
                 continue
             if node not in self.strats:
+                continue
+            # Cluster copies are structurally identical to their root (same
+            # strategies and input structure, asserted in create_cluster_links),
+            # so validating the root covers them.
+            if self.node_map[node] in self.cluster_links:
                 continue
             strat = self.strats[node]
             strat0 = strat.strategies[0]
@@ -741,16 +856,15 @@ class ShardingOptimizer:
             if node_idx in self._cluster_linked_node_idxs:
                 continue
             arg_vars = {}
-            num_args = len(self.strats[node].strategies[0].input_specs)
             for argi, out_idx, inp_idx in self.walk_over_options(node):
                 key = (node_idx, argi, out_idx, inp_idx)
                 var = self.pulp_variables.get(key)
-                if var is None:
+                if var is None:  # pruned (invalid) strategy edge
                     continue
                 arg_vars.setdefault(argi, []).append(var)
-            for argi in range(num_args):
+            for eqs in arg_vars.values():
                 self.prob += (
-                    pulp.lpSum(arg_vars.get(argi, [])) == 1,
+                    pulp.lpSum(eqs) == 1,
                     self._get_next_name("unique_decision"),
                 )
 
@@ -770,27 +884,24 @@ class ShardingOptimizer:
                 continue
             if len(self._all_input_nodes(node)) <= 1:
                 continue
+            # Group vars by (argi, out_idx). Pruning can leave an arg with no
+            # vars for a given out_idx, so we key explicitly by out_idx rather
+            # than relying on positional alignment: a missing entry means an
+            # empty sum (== 0), which correctly forbids that output strategy.
             num_args = len(self._all_input_nodes(node))
-            num_outputs = len(self.strats[node].strategies)
-            vars_per_output = {}
+            vars_per_output: dict[tuple[int, int], list] = {}
             for argi, out_idx, inp_idx in self.walk_over_options(node):
                 key = (node_idx, argi, out_idx, inp_idx)
                 var = self.pulp_variables.get(key)
-                if var is None:
+                if var is None:  # pruned (invalid) strategy edge
                     continue
                 vars_per_output.setdefault((argi, out_idx), []).append(var)
-            eqs_per_arg = [
-                [
-                    pulp.lpSum(vars_per_output.get((argi, out_idx), []))
-                    for out_idx in range(num_outputs)
-                ]
-                for argi in range(num_args)
-            ]
-            arg0 = eqs_per_arg[0]
-            for arg_eqs in eqs_per_arg[1:]:
-                for i in range(len(arg0)):
+            all_out_idxs = {oi for (_, oi) in vars_per_output}
+            for out_idx in all_out_idxs:
+                arg0_eq = pulp.lpSum(vars_per_output.get((0, out_idx), []))
+                for argi in range(1, num_args):
                     self.prob += (
-                        arg0[i] == arg_eqs[i],
+                        arg0_eq == pulp.lpSum(vars_per_output.get((argi, out_idx), [])),
                         self._get_next_name("same_across_args"),
                     )
 
@@ -864,6 +975,11 @@ class ShardingOptimizer:
                     )
                     continue
 
+                # Pruning can leave a producer output strategy with no matching
+                # consumer var (the consumer cannot accept that placement) or
+                # vice versa. Iterate the union and treat a missing side as an
+                # empty sum (== 0): this forbids the unmatched output strategy,
+                # exactly as the old inf-cost (== 0) variables did.
                 for k in vars_producer.keys() | vars_consumer.keys():
                     self.prob += (
                         pulp.lpSum(vars_producer.get(k, []))
@@ -872,7 +988,16 @@ class ShardingOptimizer:
                     )
 
     def add_inf_cost_constraint(self):
-        """COST (Category 4): Invalid configurations are excluded."""
+        """COST (Category 4): Variables with infinite cost (invalid configurations)
+        are forced to zero.
+
+        ∀i,a,o,j: c_{i,a,o,j} = ∞ ⟹ x_{i,a,o,j} = 0
+
+        Freshly built optimizers prune these edges in _build_decision_vars, so
+        no variable exists and this is a no-op. It still runs for optimizers
+        loaded from save files produced before pruning was introduced, whose
+        decision_vars may still contain infinite-cost entries.
+        """
         for key, dv in self.decision_vars.items():
             if not math.isfinite(dv.cost):
                 dv.cost = 10000.0
@@ -944,22 +1069,116 @@ class ShardingOptimizer:
     # ---- Solution ----
 
     def _set_objective(self):
-        """Add the cost minimization objective to the ILP."""
+        """Add the cost minimization objective to the ILP.
+
+        Idempotent: a no-op if the objective has already been set. This lets the
+        approximate solver populate ``prob.objective`` (so its assignment can be
+        scored with ``pulp.value(prob.objective)``) without clobbering or
+        double-adding it, and keeps repeated get_solution() calls safe.
+        """
+        if self.prob.objective is not None:
+            return
         terms = []
         for key, dv in self.decision_vars.items():
             multiplier = 1 + len(self._root_to_copies.get(key[0], ()))
             terms.append(dv.var * dv.cost * multiplier)
         self.prob += pulp.lpSum(terms)
 
+    def get_lower_bound(self, verbose=False):
+        """Solve the LP relaxation and return a lower bound on the ILP objective.
+
+        This relaxes the existing binary PuLP variables to continuous variables
+        in [0, 1], solves the current problem with all constraints already added,
+        then restores the optimizer state. The result is a certificate only:
+        fractional LP values are not valid sharding placements.
+        """
+        t0 = time.perf_counter()
+        old_objective = self.prob.objective
+        old_status = self.prob.status
+        old_sol_status = getattr(self.prob, "sol_status", None)
+        old_selected_keys_marker = object()
+        old_selected_keys = getattr(self, "selected_keys", old_selected_keys_marker)
+        var_states = {
+            var: (var.cat, var.lowBound, var.upBound, var.varValue)
+            for var in self.pulp_variables.values()
+        }
+
+        try:
+            if self.prob.objective is None:
+                self._set_objective()
+            # The relaxation must include the parameter-memory constraint, or it
+            # is a lower bound on a different (unconstrained) problem and can fall
+            # below the true ILP optimum.
+            self._apply_memory_constraint()
+
+            for var in self.pulp_variables.values():
+                var.cat = pulp.LpContinuous
+                var.lowBound = 0
+                var.upBound = 1
+                var.varValue = None
+
+            solver = pulp.PULP_CBC_CMD(msg=verbose)
+            t_solve0 = time.perf_counter()
+            with tempfile.TemporaryDirectory() as tmpdir:
+                solver.tmpDir = tmpdir
+                self.prob.solve(solver)
+            solve_s = time.perf_counter() - t_solve0
+
+            status = pulp.LpStatus.get(self.prob.status, self.prob.status)
+            objective = self._safe_float(pulp.value(self.prob.objective))
+            result = LPRelaxationResult(
+                objective=objective,
+                status=status,
+                solve_s=solve_s,
+                total_s=time.perf_counter() - t0,
+            )
+            logger.info(
+                "ShardingOptimizer LP relaxation: status=%s objective=%.4f "
+                "solve=%.3fs",
+                result.status,
+                result.objective,
+                result.solve_s,
+            )
+            return result
+        finally:
+            for var, (cat, low_bound, up_bound, value) in var_states.items():
+                var.cat = cat
+                var.lowBound = low_bound
+                var.upBound = up_bound
+                var.varValue = value
+            self.prob.objective = old_objective
+            self.prob.status = old_status
+            if old_sol_status is None:
+                if hasattr(self.prob, "sol_status"):
+                    delattr(self.prob, "sol_status")
+            else:
+                self.prob.sol_status = old_sol_status
+            if old_selected_keys is old_selected_keys_marker:
+                if hasattr(self, "selected_keys"):
+                    delattr(self, "selected_keys")
+            else:
+                self.selected_keys = old_selected_keys
+
     def _solve(self, verbose=False):
         self._apply_memory_constraint()
-        solver = pulp.PULP_CBC_CMD(msg=verbose)
+        # The sharding ILP has a near-totally-unimodular (flow-like) structure:
+        # CBC's LP relaxation is naturally integral, so it solves in seconds
+        # with zero branch-and-bound. CBC's integer *preprocessing* (probing,
+        # substitutions over hundreds of thousands of binary columns) is then
+        # pure overhead — it dominates the solve. Disabling it (correctness is
+        # unaffected; CBC still does full branch-and-bound if the relaxation is
+        # fractional) makes the solve ~10x faster on large graphs.
+        # Pass as a single string: PuLP prefixes each options entry with "-",
+        # so this becomes the CBC flag "-preprocess off".
+        solver = pulp.PULP_CBC_CMD(msg=verbose, options=["preprocess off"])
         # Use a dedicated temp directory for PuLP's intermediate files (.mps,
         # .sol, etc.) so they are always cleaned up, even if the process is
         # killed.  Without this, leftover files can fill up /tmp (tmpfs).
+        t0 = time.perf_counter()
         with tempfile.TemporaryDirectory() as tmpdir:
             solver.tmpDir = tmpdir
             self.prob.solve(solver)
+        solve_s = time.perf_counter() - t0
 
         self.selected_keys = [
             key for key, dv in self.decision_vars.items() if dv.var.value() == 1
@@ -977,6 +1196,77 @@ class ShardingOptimizer:
                 "constraints, and consider relaxing input/output constraints or "
                 "using a larger mesh."
             )
+        return solve_s
+
+    def solve_lp_relaxation(self, verbose=False, frac_tol=1e-6, extract=False):
+        """Solve the continuous relaxation of the ILP (binary variables relaxed
+        to [0, 1]) and report diagnostics, restoring the binary categories on
+        exit so a later ILP solve is unaffected.
+
+        Returns a dict with the relaxation objective (a lower bound on the ILP
+        optimum), the solve time, the number/fraction of decision variables that
+        came out fractional, and the solver status.  This is the lens for
+        understanding why constraints (e.g. propagated annotations) speed up the
+        ILP: a relaxation that is tighter (objective closer to the ILP optimum)
+        and less fractional leaves branch-and-bound far less work.
+
+        For this sharding problem the relaxation is empirically integral, so the
+        relaxation optimum equals the ILP optimum.  With ``extract=True`` and an
+        integral solution, the dict also contains a ``"solution"`` key with the
+        per-node strategy dict (same form as :meth:`get_solution`) — i.e. the LP
+        relaxation can be used as a much cheaper exact solve, skipping
+        branch-and-bound.  ``"solution"`` is ``None`` when the relaxation came
+        out fractional.
+
+        The objective is initialized on demand and its prior state is restored.
+        """
+        old_objective = self.prob.objective
+        if old_objective is None:
+            self._set_objective()
+        variables = self.prob.variables()
+        original_cats = [v.cat for v in variables]
+        self._apply_memory_constraint()
+        t0 = time.perf_counter()
+        try:
+            for v in variables:
+                v.cat = pulp.LpContinuous  # bounds are already [0, 1] for binaries
+            solver = pulp.PULP_CBC_CMD(msg=verbose)
+            with tempfile.TemporaryDirectory() as tmpdir:
+                solver.tmpDir = tmpdir
+                self.prob.solve(solver)
+            solve_time = time.perf_counter() - t0
+            objective = pulp.value(self.prob.objective)
+            n_fractional = 0
+            n_vars = 0
+            for v in variables:
+                val = v.value()
+                if val is None:
+                    continue
+                n_vars += 1
+                if min(val, 1.0 - val) > frac_tol:
+                    n_fractional += 1
+            solution = None
+            if extract and n_fractional == 0:
+                self.selected_keys = [
+                    key
+                    for key, dv in self.decision_vars.items()
+                    if dv.var.value() is not None and dv.var.value() > 0.5
+                ]
+                for root_key in list(self.selected_keys):
+                    self.selected_keys.extend(self._linked_option_keys(root_key))
+                solution = self._to_orig_solution(self._extract_and_validate_solution())
+        finally:
+            for v, cat in zip(variables, original_cats):
+                v.cat = cat
+            self.prob.objective = old_objective
+        return {
+            "objective": objective,
+            "solve_time": solve_time,
+            "n_fractional": n_fractional,
+            "n_vars": n_vars,
+            "status": pulp.LpStatus[self.prob.status],
+            "solution": solution,
+        }
 
     def _extract_and_validate_solution(self):
         """Validate the ILP solution and return the optimal strategy per node."""
@@ -1023,11 +1313,12 @@ class ShardingOptimizer:
         t0 = time.perf_counter()
         self._set_objective()
         self._solve(verbose)
-        obj_value = pulp.value(self.prob.objective)
-        logger.debug(
+        obj_value = self._safe_float(pulp.value(self.prob.objective))
+        solution = self._to_orig_solution(self._extract_and_validate_solution())
+        logger.info(
             "ILP solve took %.3fs (objective=%.4f)", time.perf_counter() - t0, obj_value
         )
-        return self._to_orig_solution(self._extract_and_validate_solution())
+        return solution
 
     def resolve(self, verbose=False):
         """Re-solve the ILP after adding or removing constraints.
@@ -1037,13 +1328,14 @@ class ShardingOptimizer:
         """
         t0 = time.perf_counter()
         self._solve(verbose)
-        obj_value = pulp.value(self.prob.objective)
-        logger.debug(
+        obj_value = self._safe_float(pulp.value(self.prob.objective))
+        solution = self._to_orig_solution(self._extract_and_validate_solution())
+        logger.info(
             "ILP re-solve took %.3fs (objective=%.4f)",
             time.perf_counter() - t0,
             obj_value,
         )
-        return self._to_orig_solution(self._extract_and_validate_solution())
+        return solution
 
     def remove_constraints(self, names):
         """Remove constraints by name, allowing re-solve to revert to the
@@ -1139,7 +1431,9 @@ class ShardingOptimizer:
 
             # Use pre-computed costs from decision vars instead of
             # estimate_strategy_runtime_cost, which needs node.meta["val"]
-            # (absent on loaded optimizers).
+            # (absent on loaded optimizers). The (.,0,out_idx,0) edge may be
+            # pruned, so find any surviving inp_idx for arg 0 (compute_cost is
+            # identical across inp_idx for a given out_idx).
             dv = self._find_decision_var(node_idx, 0, out_idx)
             if dv is None:
                 continue
@@ -1227,10 +1521,8 @@ class ShardingOptimizer:
 
         # Build node-level cluster mapping: linked_node -> root_node
         cluster_roots: dict[torch.fx.Node, torch.fx.Node] = {}
-        for linked_idx, root_idx in self.cluster_links.items():
-            linked_node = self.nodes[linked_idx]
-            root_node = self.nodes[root_idx]
-            cluster_roots[linked_node] = root_node
+        for copy_idx, root_idx in self.cluster_links.items():
+            cluster_roots[self.nodes[copy_idx]] = self.nodes[root_idx]
 
         _normalize_cluster_layer(cluster_roots)
 
@@ -1473,13 +1765,13 @@ class ShardingOptimizer:
         if constraint_name is None:
             constraint_name = "user_constraint"
         node_idx = self.node_map[node]
-        num_args = len(self.strats[node].strategies[0].input_specs)
-        vars_per_arg = {argi: [] for argi in range(num_args)}
+        vars_per_arg = {}
         for argi, out_idx, inp_idx in self.walk_over_options(node):
             if out_idx in output_constraint_indices:
                 var = self._get_pulp_variable((node_idx, argi, out_idx, inp_idx))
-                if var is not None:
-                    vars_per_arg[argi].append(var)
+                if var is None:  # pruned (invalid) strategy edge
+                    continue
+                vars_per_arg.setdefault(argi, []).append(var)
         names = []
         for eqs in vars_per_arg.values():
             name = self._get_next_name(constraint_name)
@@ -1506,9 +1798,9 @@ class ShardingOptimizer:
                 # This placement exists in node_a but not in node_b.
                 # Disable it: force sum of its decision variables to 0.
                 v_a = [
-                    var
+                    v
                     for inp_idx in range(num_inp_a)
-                    if (var := self._get_pulp_variable((idx_a, 0, out_idx, inp_idx)))
+                    if (v := self._get_pulp_variable((idx_a, 0, out_idx, inp_idx)))
                     is not None
                 ]
                 self.prob += (
@@ -1518,15 +1810,15 @@ class ShardingOptimizer:
                 continue
             out_idx_b = strat_b.index(sp)
             v_a = [
-                var
+                v
                 for inp_idx in range(num_inp_a)
-                if (var := self._get_pulp_variable((idx_a, 0, out_idx, inp_idx)))
+                if (v := self._get_pulp_variable((idx_a, 0, out_idx, inp_idx)))
                 is not None
             ]
             v_b = [
-                var
+                v
                 for inp_idx in range(num_inp_b)
-                if (var := self._get_pulp_variable((idx_b, 0, out_idx_b, inp_idx)))
+                if (v := self._get_pulp_variable((idx_b, 0, out_idx_b, inp_idx)))
                 is not None
             ]
             self.prob += (
@@ -1731,7 +2023,7 @@ class ShardingOptimizer:
             ratios: list[float] = []
             for out_idx in range(num_out_strat):
                 dv = self._find_decision_var(node_idx, 0, out_idx)
-                if dv is None:
+                if dv is None:  # every edge for this strategy was pruned
                     continue
                 spec: DTensorSpec = dv.input_spec
                 assert spec.tensor_meta is not None
@@ -1742,8 +2034,6 @@ class ShardingOptimizer:
                 ratio = new_size / old_size
                 ratios.append(ratio)
                 elms.append(dv.var * ratio)
-            if not ratios:
-                continue
             best_ratio: float = min(ratios)
             budget_low += max(best_ratio, memory_factor_low)
             budget_high += max(best_ratio, memory_factor_high)

--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -263,9 +263,25 @@ class ShardingOptimizer:
         force_grad_reduce_in_higher_precision=False,
         repeated_subgraphs=False,
         fast_build=True,
+        build_pulp=True,
+        build_costs=True,
     ):
         self.orig_gm = gm
         self.fast_build = fast_build
+        # When False, skip building the per-edge decision-var costs (Phase A of
+        # _build_decision_vars, the comm-cost estimate over millions of edges that
+        # dominates build). Strategies + cluster_links are still built; the
+        # approximate solver computes the costs it needs on demand (lazy build),
+        # only for the branches TRW-S actually touches. Implies build_pulp=False
+        # (a PuLP problem needs the costs in its objective).
+        self.build_costs = build_costs
+        # When False, skip creating PuLP variables and constraints entirely.
+        # decision_var costs + strategies + cluster_links are still built, which
+        # is all the approximate solver needs (it derives the constraint topology
+        # directly). This avoids constructing millions of PuLP objects on large /
+        # 3D meshes, where that dominates build time.
+        self.build_pulp = build_pulp and build_costs
+        self.prob = None
         # The optimizer works on a concretized copy of the graph where all
         # symbolic shapes are replaced with their concrete hint values. This
         # centralizes dynamic-shape handling: the optimization pipeline
@@ -324,8 +340,9 @@ class ShardingOptimizer:
         t1 = time.perf_counter()
         self.validate()
         t2 = time.perf_counter()
-        self.prob = pulp.LpProblem("AutoParallel", pulp.LpMinimize)
-        self.add_default_constraints()
+        if self.build_pulp:
+            self.prob = pulp.LpProblem("AutoParallel", pulp.LpMinimize)
+            self.add_default_constraints()
         t3 = time.perf_counter()
         self.profile["timings"].update(
             {
@@ -335,7 +352,7 @@ class ShardingOptimizer:
                 "init_total_s": t3 - t_init_start,
             }
         )
-        n_constraints = len(self.prob.constraints)
+        n_constraints = len(self.prob.constraints) if self.prob is not None else 0
         logger.info(
             "ShardingOptimizer: build done in %.3fs (%d unique vars, %d decision "
             "vars, %d constraints)",
@@ -590,7 +607,14 @@ class ShardingOptimizer:
         the optimum unchanged while removing ~30% of the variables and the
         corresponding ~80% of constraints that are pure ``var == 0`` bounds.
 
+        When ``build_pulp`` is False (approximate solver only) no PuLP variables
+        are created (``DecisionVar.var`` is None); the valid-key set is still
+        built so the approximate solver can treat a key absent from
+        ``decision_vars`` as forbidden.
         """
+        if not self.build_costs:
+            return self._build_decision_vars_lazy()
+
         # Precompute which node indices are cluster-linked so we can
         # copy costs from the root instead of recomputing them.
         self._cluster_linked_node_idxs = set(self.cluster_links)
@@ -645,12 +669,15 @@ class ShardingOptimizer:
                             continue
 
                         key = (node_idx, argi, out_idx, inp_idx)
-                        var = pulp.LpVariable(
-                            f"n={node},s={node_idx},arg={argi},"
-                            f"output_p={out_idx},input_p={inp_idx}",
-                            cat=pulp.LpBinary,
-                        )
-                        self.pulp_variables[key] = var
+                        if self.build_pulp:
+                            var = pulp.LpVariable(
+                                f"n={node},s={node_idx},arg={argi},"
+                                f"output_p={out_idx},input_p={inp_idx}",
+                                cat=pulp.LpBinary,
+                            )
+                            self.pulp_variables[key] = var
+                        else:
+                            var = None
                         self._valid_keys.add(key)
                         decision_vars[key] = DecisionVar(
                             var=var,
@@ -702,6 +729,25 @@ class ShardingOptimizer:
         self.profile["timings"]["cost_estimation_s"] = t_compute + t_edge
         return decision_vars
 
+    def _build_decision_vars_lazy(self):
+        """Lazy build (build_costs=False): skip the expensive per-edge cost
+        estimation (Phase A) and the DecisionVar/PuLP materialization (Phase B).
+
+        Strategies, cluster_links and the redistribute_cost *shape* (the
+        enumeration dummies) are preserved, which is all the approximate solver
+        needs to derive the topology; it computes the comm/compute costs it
+        actually uses on demand. Returns an empty decision_vars dict — callers
+        that read it (the approx solver) must route through their lazy provider.
+        """
+        self._cluster_linked_node_idxs = set(self.cluster_links)
+        self.pulp_variables = {}
+        self._valid_keys = None
+        self._root_to_copies = defaultdict(list)
+        for copy_idx, root_idx in self.cluster_links.items():
+            self._root_to_copies[root_idx].append(copy_idx)
+        self.profile["timings"]["cost_estimation_s"] = 0.0
+        return {}
+
     def _compute_node_edge_costs(self, node_idx):
         """Compute per-edge costs for one root node."""
         node = self.nodes[node_idx]
@@ -745,9 +791,24 @@ class ShardingOptimizer:
         node_idx, argi, out_idx, _ = key
         strategy = self.strats[self.nodes[node_idx]].strategies[out_idx]
         root_key = self._cluster_root_key(key)
-        root_dv = self.decision_vars[root_key]
+        root_dv = self.decision_vars.get(root_key)
+        if root_dv is None:
+            # Lazy build (build_costs=False): no DecisionVars were materialized.
+            # The approximate solver scores via its own lazy cost provider; here
+            # only .strategy / specs are needed (solution extraction), so the
+            # cost fields are zero placeholders.
+            return DecisionVar(
+                var=None,
+                cost=0.0,
+                compute_cost=0.0,
+                comm_cost=0.0,
+                sharding_transition_cost=0.0,
+                strategy=strategy,
+                output_spec=strategy.output_specs,
+                input_spec=strategy.input_specs[argi],
+            )
         return DecisionVar(
-            var=self._get_pulp_variable(key),
+            var=self._get_pulp_variable(key) if self.pulp_variables else None,
             cost=root_dv.cost,
             compute_cost=root_dv.compute_cost,
             comm_cost=root_dv.comm_cost,
@@ -1476,6 +1537,8 @@ class ShardingOptimizer:
     # ---- Logging ----
 
     def get_violated_constraints_log(self):
+        if self.prob is None:
+            return "Violated constraints: [] (no PuLP problem; lite build)"
         violated_constraints = [
             (k, c) for k, c in self.prob.constraints.items() if not c.valid()
         ]
@@ -2003,6 +2066,8 @@ class ShardingOptimizer:
         """
         if self._memory_constraint is None:
             return
+        if self.prob is None:
+            return  # approx (lite) build reads the factors from _constraint_log
         memory_factor_low, memory_factor_high = self._memory_constraint
 
         # Remove previous memory constraints before rebuilding
@@ -2079,6 +2144,8 @@ class ShardingOptimizer:
             raise RuntimeError(
                 f"Couldn't find appropriate constraint {node} {constraint_name} {placement}"
             )
+        if self.prob is None:
+            return []  # approx (lite) build replays this from _constraint_log
         names = self._add_node_constraint(
             node,
             output_constraint_indices=output_constraint_indices,

--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -103,8 +103,11 @@ from .graph_passes.graph_utils import (
     build_param_derived_set,
     build_terminal_derived_set,
 )
-from .shardings.placement_options import get_placement_options_for_node
-from .shardings.propagation_rules import _create_all_options
+from .shardings.placement_options import (
+    get_placement_options_for_node,
+    reset_placement_options_cache,
+)
+from .shardings.propagation_rules import _create_all_options, set_current_seed_node
 
 logger = logging.getLogger(__name__)
 
@@ -265,6 +268,8 @@ class ShardingOptimizer:
         fast_build=True,
         build_pulp=True,
         build_costs=True,
+        strategy_seed=None,
+        strategy_radius=None,
     ):
         self.orig_gm = gm
         self.fast_build = fast_build
@@ -295,6 +300,8 @@ class ShardingOptimizer:
         self.force_grad_reduce_in_higher_precision = (
             force_grad_reduce_in_higher_precision
         )
+        self.strategy_seed = strategy_seed
+        self.strategy_radius = strategy_radius
         self._constraint_log: list[tuple[str, dict]] = []
         self._memory_constraint: tuple[float, float] | None = None
         # Maps ILP constraint name → node_name for active node constraints,
@@ -309,7 +316,21 @@ class ShardingOptimizer:
         self.profile: dict[str, Any] = {"timings": {}}
         t_init_start = time.perf_counter()
         t0 = time.perf_counter()
-        self.strats = self.build_sharding_metadata()
+        if self.strategy_seed is None:
+            self.strats = self.build_sharding_metadata()
+        else:
+            from .shardings import propagation_rules as _propagation_rules
+
+            _propagation_rules.set_strategy_seed(
+                self.strategy_seed, self.strategy_radius
+            )
+            reset_placement_options_cache()
+            try:
+                self.strats = self.build_sharding_metadata()
+            finally:
+                _propagation_rules.set_strategy_seed(None, None)
+                set_current_seed_node(None)
+                reset_placement_options_cache()
         t_strategy = time.perf_counter() - t0
         self.profile["timings"]["strategy_enumeration_s"] = t_strategy
         logger.info("ShardingOptimizer: strategy enumeration took %.3fs", t_strategy)
@@ -389,6 +410,7 @@ class ShardingOptimizer:
         # _skip_enumeration_redistribute_cost).
         with _skip_enumeration_redistribute_cost(self.fast_build):
             for node in self.graph.nodes:
+                set_current_seed_node(node.name)
                 if node.op in ("placeholder", "get_attr"):
                     val = node.meta.get("val")
                     if isinstance(val, torch.Tensor):
@@ -436,6 +458,7 @@ class ShardingOptimizer:
                     strats[node] = user_strats
                 else:
                     raise ValueError(f"Unexpected node op: {node.op}")
+        set_current_seed_node(None)
         return strats
 
     def create_cluster_links(self, clusters):

--- a/autoparallel/serialization.py
+++ b/autoparallel/serialization.py
@@ -135,7 +135,7 @@ def save_optimizer(opt, path):
     # Re-key strats by node name, saving only root nodes (non-linked).
     # Linked nodes share identical strats with their root and are
     # reconstructed on load from cluster_links.
-    linked_node_names = {opt.nodes[lk[0]].name for lk in opt.cluster_links}
+    linked_node_names = {opt.nodes[c].name for c in opt.cluster_links}
     strats_by_name = {
         node.name: strat
         for node, strat in opt.strats.items()
@@ -193,8 +193,7 @@ def save_optimizer(opt, path):
         "dv_costs_keys": dv_costs_keys,
         "dv_costs_vals": dv_costs_vals,
         "cluster_links_node_by_name": {
-            opt.nodes[lk[0]].name: opt.nodes[rk[0]].name
-            for lk, rk in opt.cluster_links.items()
+            opt.nodes[c].name: opt.nodes[r].name for c, r in opt.cluster_links.items()
         },
         "constraint_log": opt._constraint_log,
         "selected_keys_by_name": selected_keys_by_name,
@@ -264,27 +263,34 @@ def load_optimizer(cls, path):
     opt._memory_constraint = None
     opt._node_constraint_names = {}
     opt._name_counters = {}
+    # Loaded optimizers rebuild the PuLP problem below but carry no init-time
+    # profiling; an empty profile is enough for the solve-time timing writes.
+    opt.build_pulp = True
+    opt.profile = {"timings": {}}
 
-    # Reconstruct cluster_links by expanding the node-level mapping over
-    # all (argi, out_idx, inp_idx) combinations.
-    opt.cluster_links = {}
-    for linked_name, root_name in cluster_links_node_by_name.items():
-        linked_node = nodes_by_name[linked_name]
-        root_node = nodes_by_name[root_name]
-        linked_idx = opt.node_map[linked_node]
-        root_idx = opt.node_map[root_node]
-        for argi, out_idx, inp_idx in opt.walk_over_options(linked_node):
-            opt.cluster_links[(linked_idx, argi, out_idx, inp_idx)] = (
-                root_idx,
-                argi,
-                out_idx,
-                inp_idx,
-            )
-    opt._cluster_linked_node_idxs = {key[0] for key in opt.cluster_links}
+    # cluster_links is node-level: copy node idx -> root node idx.
+    opt.cluster_links = {
+        opt.node_map[nodes_by_name[linked_name]]: opt.node_map[nodes_by_name[root_name]]
+        for linked_name, root_name in cluster_links_node_by_name.items()
+    }
+    opt._cluster_linked_node_idxs = set(opt.cluster_links)
 
     # Mesh placeholder — provides shape/dim_names for get_json() and ndim
     # for add_node_constraint() default placement, without needing a PG
     opt.mesh = _MeshPlaceholder(save_dict["mesh_shape"], save_dict["mesh_dim_names"])
+
+    # Map saved decision-var keys to loaded node indices. Only these keys had
+    # a finite-cost (valid) strategy edge at save time; invalid edges were
+    # pruned and must not get a variable, so seed _valid_keys before creating
+    # the PuLP variables (see ShardingOptimizer._build_decision_vars).
+    save_node_names = save_dict["dv_costs_node_names"]
+    keys_t = save_dict["dv_costs_keys"].tolist()
+    vals_t = save_dict["dv_costs_vals"].tolist()
+    mapped_keys = [
+        (opt.node_map[nodes_by_name[save_node_names[k[0]]]], k[1], k[2], k[3])
+        for k in keys_t
+    ]
+    opt._valid_keys = set(mapped_keys)
 
     # Rebuild PuLP variables and decision vars from saved costs.
     t2 = time.perf_counter()
@@ -296,19 +302,14 @@ def load_optimizer(cls, path):
         len(opt.pulp_variables),
     )
     # Reconstruct decision_vars from compact tensors.
-    save_node_names = save_dict["dv_costs_node_names"]
-    keys_t = save_dict["dv_costs_keys"].tolist()
-    vals_t = save_dict["dv_costs_vals"].tolist()
     opt.decision_vars = {}
-    for (save_node_idx, argi, out_idx, inp_idx), (
+    for key, (
         compute_cost,
         comm_cost,
         transition_cost,
-    ) in zip(keys_t, vals_t):
-        node_name = save_node_names[save_node_idx]
-        node = nodes_by_name[node_name]
-        node_idx = opt.node_map[node]
-        key = (node_idx, argi, out_idx, inp_idx)
+    ) in zip(mapped_keys, vals_t):
+        node_idx, argi, out_idx, inp_idx = key
+        node = opt.nodes[node_idx]
         strategy = opt.strats[node].strategies[out_idx]
         opt.decision_vars[key] = DecisionVar(
             var=opt.pulp_variables[key],
@@ -329,9 +330,9 @@ def load_optimizer(cls, path):
         len(opt.decision_vars),
     )
 
-    opt._root_to_linked = defaultdict(list)
-    for linked_key, root_key in opt.cluster_links.items():
-        opt._root_to_linked[root_key].append(linked_key)
+    opt._root_to_copies = defaultdict(list)
+    for copy_idx, root_idx in opt.cluster_links.items():
+        opt._root_to_copies[root_idx].append(copy_idx)
 
     opt.prob = pulp.LpProblem("AutoParallel", pulp.LpMinimize)
     opt.add_default_constraints()
@@ -384,7 +385,7 @@ def _restore_solution(opt, selected_keys_by_name, nodes_by_name):
 
     # Expand cluster links
     for root_key in list(opt.selected_keys):
-        opt.selected_keys.extend(opt._root_to_linked.get(root_key, []))
+        opt.selected_keys.extend(opt._linked_option_keys(root_key))
 
 
 def save_placements(opt, path):

--- a/autoparallel/shardings/placement_options.py
+++ b/autoparallel/shardings/placement_options.py
@@ -31,7 +31,14 @@ from torch.utils._pytree import tree_flatten, tree_map_only
 from autoparallel.shardings.propagation_rules import generate_dummy_redistribute_costs
 
 from .dtensor_sharding_helpers import get_op_strategy, with_implicit_strategies
-from .propagation_rules import _op_rules, remove_invalid_configs
+from .propagation_rules import (
+    _op_rules,
+    get_current_seed_node,
+    get_strategy_radius,
+    get_strategy_seed,
+    remove_invalid_configs,
+    within_strategy_seed_ball,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -277,19 +284,57 @@ def reset_placement_options_timer():
     _placement_options_timer = PlacementOptionsTimer()
 
 
+def _seed_cache_key():
+    seed = get_strategy_seed()
+    if seed is None:
+        return None
+    node_name = get_current_seed_node()
+    placements = seed.get(node_name) if node_name is not None else None
+    placement_key = None if placements is None else tuple(str(p) for p in placements)
+    # Key on the seed PLACEMENT (not node_name): the seed-filtered result depends only
+    # on (op, input specs, seed placement, radius), so repeated ops across layers with
+    # the same seed placement share the placement-options cache instead of missing
+    # per node (which re-runs get_op_strategy for every node).
+    return placement_key, get_strategy_radius()
+
+
+def _filter_by_strategy_seed(out_strat):
+    if get_strategy_seed() is None:
+        return out_strat
+
+    kept = []
+    for strategy in out_strat.strategies:
+        specs = strategy.output_specs
+        placements = None
+        if isinstance(specs, DTensorSpec):
+            placements = specs.placements
+        elif isinstance(specs, (tuple, list)):
+            for spec in specs:
+                if isinstance(spec, DTensorSpec):
+                    placements = spec.placements
+                    break
+        if placements is None or within_strategy_seed_ball(placements):
+            kept.append(strategy)
+
+    return out_strat if not kept else OpStrategy(kept)
+
+
 def get_placement_options(mesh, op, specs, user_args, user_kwargs):
     assert len(specs) == len(user_args)
     timer = _placement_options_timer
     t_start = time.perf_counter()
 
     try:
+        mesh_key = (id(mesh), mesh.device_type, tuple(mesh.shape), mesh.ndim)
         cache_key = (
+            mesh_key,
             op,
             tuple(_fingerprint_arg(s) for s in specs),
             tuple(_fingerprint_arg(a) for a in user_args),
             tuple(_fingerprint_arg(v) for v in user_kwargs.values())
             if user_kwargs
             else (),
+            _seed_cache_key(),
         )
         hash(cache_key)  # fail fast if key contains unhashable types (e.g. SymInts)
     except TypeError:
@@ -331,6 +376,7 @@ def get_placement_options(mesh, op, specs, user_args, user_kwargs):
     else:
         with with_implicit_strategies():
             out_strat = get_op_strategy(op, op_schema)
+    out_strat = _filter_by_strategy_seed(out_strat)
     t1 = time.perf_counter()
 
     # operator.getitem is self-contained: its input is a tuple of tensors

--- a/autoparallel/shardings/propagation_rules.py
+++ b/autoparallel/shardings/propagation_rules.py
@@ -53,6 +53,55 @@ from torch.distributed.tensor.placement_types import (
 from ..cast_parametrization import dtype_cast  # noqa
 from .dtensor_sharding_helpers import _try_single_dim_strategy, get_op_strategy
 
+_strategy_seed: "dict[str, tuple[Placement, ...]] | None" = None
+_strategy_radius: "int | dict[str, int] | None" = None
+_current_seed_node: "str | None" = None
+
+
+def set_strategy_seed(seed, radius):
+    global _strategy_seed, _strategy_radius
+    _strategy_seed = seed
+    _strategy_radius = radius
+
+
+def get_strategy_seed():
+    return _strategy_seed
+
+
+def get_strategy_radius():
+    return _strategy_radius
+
+
+def set_current_seed_node(name):
+    global _current_seed_node
+    _current_seed_node = name
+
+
+def get_current_seed_node():
+    return _current_seed_node
+
+
+def within_strategy_seed_ball(placements) -> bool:
+    if _strategy_seed is None:
+        return True
+    node_name = _current_seed_node
+    if node_name is None:
+        return True
+    seed_placements = _strategy_seed.get(node_name)
+    if seed_placements is None:
+        return True
+
+    radius = _strategy_radius
+    if isinstance(radius, dict):
+        radius = radius.get(node_name, 0)
+    if radius is None:
+        radius = 0
+
+    distance = abs(len(placements) - len(seed_placements))
+    distance += sum(1 for a, b in zip(placements, seed_placements) if a != b)
+    return distance <= radius
+
+
 _op_rules = {}
 
 
@@ -194,6 +243,8 @@ def _create_all_options(mesh, shape, tensor_meta=None, tensor=None):
     all_options = list(itertools.product(*[possible_options for _ in range(mesh.ndim)]))
     strats = []
     for placement in all_options:
+        if not within_strategy_seed_ball(placement):
+            continue
         spec = DTensorSpec(mesh, placement, tensor_meta=tensor_meta)
         strats.append(OpSpec(spec, input_specs=[spec], redistribute_cost=[[0.0]]))
     out_strats = OpStrategy(strats)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,14 @@ def apply_cuda_patches(func):
     return func
 
 
+@pytest.fixture(autouse=True)
+def _reset_placement_options_cache():
+    from autoparallel.shardings.placement_options import reset_placement_options_cache
+
+    reset_placement_options_cache()
+    yield
+
+
 @pytest.fixture(scope="module", autouse=True)
 def init_pg():
     world_size = 256

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ _CUDA_PATCHES = [
                 "name": "H100",
                 "total_memory": 80 * 1024**3,
                 "multi_processor_count": 132,
+                "L2_cache_size": 50 * 1024**2,
             },
         )(),
     ),
@@ -42,6 +43,8 @@ def apply_cuda_patches(func):
 
 @pytest.fixture(autouse=True)
 def _reset_placement_options_cache():
+    """The placement-options cache is a process-global; clear it before each test
+    so optimizer builds never reuse stale strategies from a prior test's model."""
     from autoparallel.shardings.placement_options import reset_placement_options_cache
 
     reset_placement_options_cache()

--- a/tests/test_approximate_sharding.py
+++ b/tests/test_approximate_sharding.py
@@ -1,0 +1,216 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import math
+
+import pulp
+import pytest
+import torch
+from conftest import apply_cuda_patches
+from torch.distributed.fsdp import MixedPrecisionPolicy
+from torch.distributed.tensor._dtensor_spec import DTensorSpec
+from torch.distributed.tensor.placement_types import Replicate, Shard
+
+from autoparallel._testing.models.llama3 import Transformer, TransformerModelArgs
+from autoparallel.api import AutoParallel
+from autoparallel.approximate_sharding import ApproximateShardingSolver
+
+
+def _fake_2d_mesh():
+    return torch.distributed.device_mesh.init_device_mesh(
+        "cuda", (4, 2), mesh_dim_names=("dp", "tp")
+    )
+
+
+def _tiny_llama3_autop(mesh, solver="ilp"):
+    vocab_size = 128
+    seq_len = 16
+    batch_size = 2 * mesh.shape[0]
+    model_args = TransformerModelArgs(
+        dim=64,
+        n_layers=2,
+        n_heads=4,
+        n_kv_heads=2,
+        vocab_size=vocab_size,
+        multiple_of=32,
+        rope_theta=500000,
+        max_seq_len=seq_len,
+    )
+    with torch.device("meta"):
+        model = Transformer(model_args)
+
+    def input_fn():
+        return torch.randint(0, vocab_size, (batch_size, seq_len), device="cuda")
+
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=torch.bfloat16, reduce_dtype=torch.float32
+    )
+    return AutoParallel(
+        model, input_fn, mesh, mp_policy, repeated_subgraphs=True, solver=solver
+    )
+
+
+def _add_constraints(autop, mesh):
+    autop.add_parameter_memory_constraint(low=None, high=None)
+    autop.add_input_constraints([(Shard(0),) + (Replicate(),) * (mesh.ndim - 1)])
+    autop.add_output_constraints([(Shard(0), Shard(2))])
+
+
+@apply_cuda_patches
+@pytest.mark.filterwarnings("ignore:Constructing LpVariable")
+@pytest.mark.filterwarnings("ignore:Overwriting previously set objective")
+def test_approx_objective_close_to_ilp():
+    """The approximate solver should be much faster than the ILP while staying
+    within a small objective gap on a tiny LLaMA3 block + 2D mesh."""
+    mesh = _fake_2d_mesh()
+    with _tiny_llama3_autop(mesh) as autop:
+        _add_constraints(autop, mesh)
+        opt = autop.sharding_optimizer
+
+        autop.optimize_placement(verbose=False, solver="approx")
+        approx_objective = pulp.value(opt.prob.objective)
+        # The approx assignment must be ILP-feasible (flow consistency etc.);
+        # an infeasible assignment can score artificially low and silently pass
+        # the objective bound below.
+        violated = [n for n, c in opt.prob.constraints.items() if not c.valid()]
+        assert not violated, f"approx violated {len(violated)} constraints"
+
+        autop.optimize_placement(verbose=False, solver="ilp")
+        ilp_objective = pulp.value(opt.prob.objective)
+
+        assert math.isfinite(approx_objective)
+        assert ilp_objective > 0
+        assert approx_objective >= ilp_objective - 1e-6  # ILP is optimal
+        assert approx_objective <= ilp_objective * 1.20 + 1e-6, (
+            f"approx={approx_objective} ilp={ilp_objective} "
+            f"gap={(approx_objective / ilp_objective - 1) * 100:.1f}%"
+        )
+
+
+@apply_cuda_patches
+@pytest.mark.filterwarnings("ignore:Constructing LpVariable")
+@pytest.mark.filterwarnings("ignore:Overwriting previously set objective")
+def test_approx_memory_constrained_matches_ilp():
+    """A non-tight parameter-memory budget routes the approx solver through the
+    Lagrangian relaxation. The result must respect the budget and stay within a
+    small objective gap of the budget-constrained ILP optimum."""
+    mesh = _fake_2d_mesh()
+    with _tiny_llama3_autop(mesh) as autop:
+        # high=0.5 > 1/world_size, so the budget is non-tight (params are not
+        # pinned at build time) and can bind the runtime-optimal placement.
+        autop.add_parameter_memory_constraint(low=0.0, high=0.5)
+        autop.add_input_constraints([(Shard(0),) + (Replicate(),) * (mesh.ndim - 1)])
+        autop.add_output_constraints([(Shard(0), Shard(2))])
+        opt = autop.sharding_optimizer
+
+        autop.optimize_placement(verbose=False, solver="approx")
+        approx_objective = pulp.value(opt.prob.objective)
+        # Materialize the memory rows and check the approx assignment against ALL
+        # constraints, including the budget it was solved under.
+        opt._apply_memory_constraint()
+        violated = [n for n, c in opt.prob.constraints.items() if not c.valid()]
+        assert not violated, f"approx violated {len(violated)} constraints"
+
+        autop.optimize_placement(verbose=False, solver="ilp")
+        ilp_objective = pulp.value(opt.prob.objective)
+
+        assert math.isfinite(approx_objective)
+        assert approx_objective >= ilp_objective - 1e-6  # ILP is optimal
+        assert approx_objective <= ilp_objective * 1.05 + 1e-6, (
+            f"approx={approx_objective} ilp={ilp_objective} "
+            f"gap={(approx_objective / ilp_objective - 1) * 100:.2f}%"
+        )
+
+
+@apply_cuda_patches
+@pytest.mark.filterwarnings("ignore:Constructing LpVariable")
+@pytest.mark.filterwarnings("ignore:Overwriting previously set objective")
+def test_lp_solver_matches_ilp():
+    """The LP-relaxation solver returns an integral, ILP-feasible assignment whose
+    objective equals the exact ILP optimum (the relaxation is integral here)."""
+    mesh = _fake_2d_mesh()
+    with _tiny_llama3_autop(mesh) as autop:
+        _add_constraints(autop, mesh)
+        opt = autop.sharding_optimizer
+
+        autop.optimize_placement(verbose=False, solver="lp")
+        lp_objective = pulp.value(opt.prob.objective)
+        violated = [n for n, c in opt.prob.constraints.items() if not c.valid()]
+        assert not violated, f"lp violated {len(violated)} constraints"
+
+        autop.optimize_placement(verbose=False, solver="ilp")
+        ilp_objective = pulp.value(opt.prob.objective)
+
+        assert math.isfinite(lp_objective)
+        assert lp_objective == pytest.approx(ilp_objective, rel=1e-6)
+
+
+@apply_cuda_patches
+@pytest.mark.filterwarnings("ignore:Constructing LpVariable")
+@pytest.mark.filterwarnings("ignore:Overwriting previously set objective")
+def test_optimality_check_logs_certified_gap(caplog):
+    """optimality_check=True solves the LP lower bound and logs the certified gap."""
+    mesh = _fake_2d_mesh()
+    with _tiny_llama3_autop(mesh) as autop:
+        _add_constraints(autop, mesh)
+        with caplog.at_level(logging.INFO, logger="autoparallel.api"):
+            autop.optimize_placement(
+                verbose=False, solver="approx", optimality_check=True
+            )
+        assert any("optimality check" in r.message for r in caplog.records)
+
+
+@apply_cuda_patches
+@pytest.mark.filterwarnings("ignore:Constructing LpVariable")
+def test_approx_objective_is_faithful():
+    """The solver's internal energy must equal the exact ILP objective evaluated
+    on its assignment (pulp.value), so comparisons against the ILP are valid."""
+    mesh = _fake_2d_mesh()
+    with _tiny_llama3_autop(mesh) as autop:
+        _add_constraints(autop, mesh)
+        opt = autop.sharding_optimizer
+
+        solver = ApproximateShardingSolver(opt)
+        solver.get_solution(verbose=False)
+
+        pulp_objective = pulp.value(opt.prob.objective)
+        internal_energy = solver.total_objective()
+        assert math.isfinite(internal_energy)
+        assert internal_energy == pytest.approx(pulp_objective, rel=1e-6)
+        # No forbidden decision variable should be selected.
+        assert all(key not in solver.forbidden for key in opt.selected_keys)
+        # And every ILP constraint must hold (flow consistency, paired, memory).
+        violated = [n for n, c in opt.prob.constraints.items() if not c.valid()]
+        assert not violated, f"approx violated {len(violated)} constraints"
+
+
+@apply_cuda_patches
+@pytest.mark.filterwarnings("ignore:Constructing LpVariable")
+def test_approx_respects_input_output_constraints():
+    """User input/output placement constraints must be honored by the solution."""
+    mesh = _fake_2d_mesh()
+    x_sharding = (Shard(0),) + (Replicate(),) * (mesh.ndim - 1)
+    out_sharding = (Shard(0), Shard(2))
+    with _tiny_llama3_autop(mesh) as autop:
+        autop.add_parameter_memory_constraint(low=None, high=None)
+        autop.add_input_constraints([x_sharding])
+        autop.add_output_constraints([out_sharding])
+
+        solution = autop.optimize_placement(verbose=False, solver="approx")
+        assert solution
+
+        placements = {
+            spec.placements
+            for strat in solution.values()
+            for spec in (
+                strat.output_specs
+                if isinstance(strat.output_specs, (list, tuple))
+                else (strat.output_specs,)
+            )
+            if isinstance(spec, DTensorSpec)
+        }
+        assert x_sharding in placements
+        assert out_sharding in placements

--- a/tests/test_approximate_sharding.py
+++ b/tests/test_approximate_sharding.py
@@ -214,3 +214,32 @@ def test_approx_respects_input_output_constraints():
         }
         assert x_sharding in placements
         assert out_sharding in placements
+
+
+@apply_cuda_patches
+@pytest.mark.filterwarnings("ignore:Constructing LpVariable")
+def test_lite_build_matches_full():
+    """Building with solver="approx" skips PuLP variables/constraints (faster
+    setup); the resulting assignment must be byte-identical to running the
+    approximate solver on a full PuLP build."""
+    mesh = _fake_2d_mesh()
+
+    with _tiny_llama3_autop(mesh, solver="ilp") as autop:
+        _add_constraints(autop, mesh)
+        assert autop.sharding_optimizer.prob is not None
+        autop.optimize_placement(verbose=False, solver="approx")
+        obj_full = autop.sharding_optimizer.profile["approximate"]["objective"]
+        keys_full = set(autop.sharding_optimizer.selected_keys)
+
+    with _tiny_llama3_autop(mesh, solver="approx") as autop:
+        _add_constraints(autop, mesh)
+        # Lite build: no PuLP problem or variables were constructed.
+        assert autop.sharding_optimizer.prob is None
+        assert not autop.sharding_optimizer.pulp_variables
+        solution = autop.optimize_placement(verbose=False)
+        obj_lite = autop.sharding_optimizer.profile["approximate"]["objective"]
+        keys_lite = set(autop.sharding_optimizer.selected_keys)
+        assert solution
+
+    assert obj_lite == pytest.approx(obj_full, rel=1e-9)
+    assert keys_lite == keys_full

--- a/tests/test_export_json.py
+++ b/tests/test_export_json.py
@@ -96,9 +96,9 @@ def test_normalize_cluster_layer_swaps_backward_roots(device_mesh_1d):
 
     # Build cluster_roots from cluster_links
     cluster_roots = {}
-    for linked_key, root_key in opt.cluster_links.items():
-        linked_node = opt.nodes[linked_key[0]]
-        root_node = opt.nodes[root_key[0]]
+    for linked_idx, root_idx in opt.cluster_links.items():
+        linked_node = opt.nodes[linked_idx]
+        root_node = opt.nodes[root_idx]
         cluster_roots[linked_node] = root_node
 
     if not cluster_roots:

--- a/tests/test_grad_reduce_dtype.py
+++ b/tests/test_grad_reduce_dtype.py
@@ -100,7 +100,7 @@ def _assert_no_pre_cast_redistribution(
                 continue
             dv = opt._resolve_decision_var(key)
             validated_pre_cast_keys += 1
-            if key in opt.cluster_links:
+            if node_idx in opt.cluster_links:
                 validated_linked_keys += 1
             assert dv.comm_cost == 0, (
                 f"Pre-cast node {opt.nodes[node_idx].name} has chosen decision var "
@@ -265,7 +265,7 @@ def _assert_no_fwd_pre_cast_redistribution(
                 continue
             dv = opt._resolve_decision_var(key)
             validated_keys += 1
-            if key in opt.cluster_links:
+            if node_idx in opt.cluster_links:
                 validated_linked_keys += 1
             assert dv.comm_cost == 0, (
                 f"Forward pre-cast node {opt.nodes[node_idx].name} has chosen "

--- a/tests/test_lp_relaxation.py
+++ b/tests/test_lp_relaxation.py
@@ -1,0 +1,103 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+
+import pulp
+import pytest
+import torch
+from conftest import apply_cuda_patches
+from torch.distributed.fsdp import MixedPrecisionPolicy
+from torch.distributed.tensor.placement_types import Replicate, Shard
+
+from autoparallel._testing.models.llama3 import Transformer, TransformerModelArgs
+from autoparallel.api import AutoParallel
+
+
+def _fake_dp4_tp4_mesh():
+    return torch.distributed.device_mesh.init_device_mesh(
+        "cuda",
+        (4, 4),
+        mesh_dim_names=("dp", "tp"),
+    )
+
+
+def _llama3_example_autop(device_mesh):
+    vocab_size = 128
+    seq_len = 16
+    batch_size = 2 * device_mesh.shape[0]
+    model_args = TransformerModelArgs(
+        dim=64,
+        n_layers=1,
+        n_heads=4,
+        n_kv_heads=2,
+        vocab_size=vocab_size,
+        multiple_of=32,
+        rope_theta=500000,
+        max_seq_len=seq_len,
+    )
+    with torch.device("meta"):
+        model = Transformer(model_args)
+
+    def input_fn():
+        return torch.randint(0, vocab_size, (batch_size, seq_len), device="cuda")
+
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=torch.bfloat16,
+        reduce_dtype=torch.float32,
+    )
+    return AutoParallel(
+        model,
+        input_fn,
+        device_mesh,
+        mp_policy,
+        repeated_subgraphs=True,
+    )
+
+
+@apply_cuda_patches
+@pytest.mark.filterwarnings("ignore:Constructing LpVariable")
+@pytest.mark.filterwarnings("ignore:Using LpProblem.constraints")
+def test_lp_relaxation_certifies_llama3_example_search():
+    mesh = _fake_dp4_tp4_mesh()
+    with _llama3_example_autop(mesh) as autop:
+        autop.add_parameter_memory_constraint(low=None, high=None)
+        x_sharding = (Shard(0), Replicate())
+        out_sharding = (Shard(0), Shard(2))
+        autop.add_input_constraints([x_sharding])
+        autop.add_output_constraints([out_sharding])
+
+        opt = autop.sharding_optimizer
+
+        binary_vars = list(opt.pulp_variables.values())
+        assert binary_vars
+        assert all(var.cat == pulp.LpInteger for var in binary_vars)
+        assert all(var.lowBound == 0 and var.upBound == 1 for var in binary_vars)
+
+        continuous_vars = opt._create_pulp_variables(pulp.LpContinuous)
+        assert continuous_vars
+        assert all(var.cat == pulp.LpContinuous for var in continuous_vars.values())
+        assert all(
+            var.lowBound == 0 and var.upBound == 1 for var in continuous_vars.values()
+        )
+
+        lower_bound = opt.get_lower_bound()
+        assert lower_bound.status == "Optimal"
+        assert math.isfinite(lower_bound.objective)
+        assert lower_bound.objective >= 0
+
+        assert not hasattr(opt, "selected_keys")
+        assert opt.prob.objective is None
+        assert all(var.cat == pulp.LpInteger for var in opt.pulp_variables.values())
+
+        solution = opt.get_solution()
+        feasible_cost = pulp.value(opt.prob.objective)
+        certificate_gap = (
+            feasible_cost - lower_bound.objective
+        ) / lower_bound.objective
+        assert solution
+        assert lower_bound.objective <= feasible_cost + 1e-5
+        assert certificate_gap >= -1e-8
+        assert math.isfinite(certificate_gap)

--- a/tests/test_optimize_placement.py
+++ b/tests/test_optimize_placement.py
@@ -164,7 +164,6 @@ def test_optimization_finds_fsdp_and_ddp_1d(device_mesh_1d, high_mem, model_type
         assert p.output_specs.placements == (Shard(0),)
         # weight is replicated, mimicing DDP
         assert p.input_specs[1].placements == (Replicate(),)
-
     # bwd grad weight
     # For mm: [N, B*S] @ [B*S, K] → batch dim is at position 1 for input 0
     # For einsum: bsn,bsk->nk → batch dim is at position 0 for both inputs
@@ -181,6 +180,30 @@ def test_optimization_finds_fsdp_and_ddp_1d(device_mesh_1d, high_mem, model_type
         assert p.input_specs[0].placements == (Shard(0),)
         assert p.output_specs.placements == (Shard(0),)
         assert p.input_specs[1].placements == (Replicate(),)
+
+
+@apply_cuda_patches
+def test_fast_build_preserves_optimizer_solution(device_mesh_1d):
+    def solve(fast_build):
+        model_fn, input_fn = _make_model_and_input_fn(
+            device_mesh_1d, "transformer_block"
+        )
+        with torch.device("meta"):
+            model = model_fn()
+        with AutoParallel(
+            model, input_fn, device_mesh_1d, fast_build=fast_build
+        ) as autop:
+            autop.add_input_constraints([(Shard(0),)])
+            autop.add_output_constraints([(Shard(0),)])
+            autop.add_parameter_memory_constraint(low=None, high=None)
+            solution = autop.optimize_placement()
+        return {
+            node.name: tuple(str(p) for p in strategy.output_specs.placements)
+            for node, strategy in solution.items()
+            if not isinstance(strategy.output_specs, (tuple, list))
+        }
+
+    assert solve(True) == solve(False)
 
 
 _expected_param_placements_ffn = [(Shard(0), Shard(0)), (Shard(0), Shard(1))]
@@ -844,3 +867,36 @@ def test_remove_node_constraint_restores_memory_budget(device_mesh_1d):
         # With memory budget enforced and no node constraint, the optimizer
         # should shard this param again
         assert solution[orig_node].output_specs.placements == (Shard(0),)
+
+
+@apply_cuda_patches
+def test_invalid_strategies_are_pruned(device_mesh_2d):
+    """Infinite-cost (invalid) strategy edges must not be materialized as
+    variables or constraints, and pruning them must not change the optimum."""
+    import math
+
+    mesh = device_mesh_2d
+    model_fn, input_fn = _make_model_and_input_fn(mesh, "transformer_block")
+    with torch.device("meta"):
+        model = model_fn()
+
+    with AutoParallel(model, input_fn, mesh) as autop:
+        autop.add_input_constraints([(Shard(0), Replicate())])
+        autop.add_output_constraints([(Shard(0), Replicate())])
+        autop.add_parameter_memory_constraint(low=None, high=None)
+        opt = autop.sharding_optimizer
+
+        # Invariant: every materialized decision var is finite-cost, and the
+        # PuLP variable set is exactly the set of valid (finite) keys.
+        assert all(math.isfinite(dv.cost) for dv in opt.decision_vars.values())
+        assert set(opt.pulp_variables) == opt._valid_keys
+        assert all(k in opt._valid_keys for k in opt.decision_vars)
+
+        # No inf-cost (== 0) constraints should be emitted any more.
+        assert not any(name.startswith("inf_cases") for name in opt.prob.constraints)
+
+        # The pruned problem must still solve to a valid solution.
+        solution = autop.optimize_placement()
+        param_nodes = get_param_nodes(autop.gm.graph)
+        for node in param_nodes:
+            assert node in solution

--- a/tests/test_split_dim_seed.py
+++ b/tests/test_split_dim_seed.py
@@ -1,0 +1,142 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+
+import pulp
+import pytest
+import torch
+from conftest import apply_cuda_patches
+from torch._subclasses.fake_tensor import unset_fake_temporarily
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor.placement_types import Partial, Replicate, Shard
+
+from autoparallel._testing.models.dsv3 import (
+    MoEMeshRoles,
+    build_moe_local_map_placements,
+)
+from autoparallel.api import AutoParallel
+from autoparallel.cost_models.nccl_cost_model import h100_topo_config
+from autoparallel.mesh_search import (
+    _project_local_map_to_dim,
+    _split_dim_seed_cache_key,
+    build_split_dim_seed,
+)
+from autoparallel.optimize_sharding import ShardingOptimizer
+
+pytestmark = [
+    pytest.mark.filterwarnings("ignore:Constructing LpVariable.*:DeprecationWarning"),
+    pytest.mark.filterwarnings(
+        "ignore:Using LpProblem.constraints.*:DeprecationWarning"
+    ),
+]
+
+
+class TinyMLP(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.in_proj = torch.nn.Linear(16, 32)
+        self.out_proj = torch.nn.Linear(32, 16)
+
+    def forward(self, x):
+        return self.out_proj(torch.relu(self.in_proj(x)))
+
+
+def _input_fn():
+    return torch.randn(8, 16, device="cuda", requires_grad=True)
+
+
+def test_split_dim_projects_local_map_placements(device_mesh_3d):
+    dim_names = device_mesh_3d.mesh_dim_names
+    assert dim_names is not None
+    roles = MoEMeshRoles(ep_axis_names=(dim_names[1], dim_names[2]), ep_group_name="ep")
+    token, weight, count = build_moe_local_map_placements(dim_names, roles)
+
+    graph = torch.fx.Graph()
+    node = graph.placeholder("x")
+    graph.output(node)
+    gm = torch.fx.GraphModule({}, graph)
+    local_map_kwargs = {
+        "in_placements": (token, weight, None),
+        "out_placements": (token, count),
+        "device_mesh": device_mesh_3d,
+    }
+    node.meta["local_map_kwargs"] = local_map_kwargs
+
+    for dim_idx, dim_name in enumerate(dim_names):
+        mesh_1d = device_mesh_3d[dim_name]
+        with _project_local_map_to_dim(gm, mesh_1d, dim_idx, len(dim_names)):
+            projected = node.meta["local_map_kwargs"]
+            assert projected["device_mesh"] == mesh_1d
+            assert projected["in_placements"] == (
+                (Shard(0),),
+                ((Replicate(),) if dim_idx == 0 else (Shard(0),)),
+                None,
+            )
+            assert projected["out_placements"] == (
+                (Shard(0),),
+                (Partial("sum"),),
+            )
+        assert node.meta["local_map_kwargs"] is local_map_kwargs
+
+    shape = tuple(device_mesh_3d.shape)
+    assert _split_dim_seed_cache_key(
+        shape[0], Replicate(), "roofline", shape, 0, fabric_aware=False
+    ) != _split_dim_seed_cache_key(
+        shape[1], Replicate(), "roofline", shape, 1, fabric_aware=False
+    )
+
+
+@apply_cuda_patches
+def test_split_dim_seed_hamming_space_solves_with_ilp_and_lp():
+    config = h100_topo_config(num_nodes=2, gpus_per_node=4)
+    with unset_fake_temporarily():
+        mesh = init_device_mesh(
+            "cuda",
+            (2, 2, 2),
+            mesh_dim_names=("dp", "mid", "inner"),
+        )
+
+    with torch.device("meta"):
+        model = TinyMLP()
+
+    input_placement = (Shard(0), Replicate(), Replicate())
+    one_d_cache = {}
+
+    with AutoParallel(
+        model,
+        _input_fn,
+        mesh,
+        cost_model=config,
+        repeated_subgraphs=False,
+    ) as autop:
+        seed = build_split_dim_seed(
+            autop.gm,
+            tuple(mesh.shape),
+            input_placement,
+            cost_model=config,
+            repeated_subgraphs=False,
+            one_d_cache=one_d_cache,
+        )
+
+        opt = ShardingOptimizer(
+            autop.gm,
+            mesh,
+            repeated_subgraphs=False,
+            strategy_seed=seed,
+            strategy_radius=2,
+        )
+        opt.add_sharded_input_constraint([input_placement])
+        opt.add_sharded_output_constraint([input_placement])
+        opt.add_parameter_memory_constraint(0.0, 1.0)
+
+        lp_result = opt.solve_lp_relaxation(extract=True)
+        assert lp_result["status"] == "Optimal"
+        assert math.isfinite(lp_result["objective"])
+
+        solution = opt.get_solution(verbose=False)
+        assert solution
+        assert pulp.LpStatus[opt.prob.status] == "Optimal"
+        assert math.isfinite(pulp.value(opt.prob.objective))


### PR DESCRIPTION
> **Aggregate only. Do not review or merge this combined diff.**
>
> Review and merge the stack in order: #520 -> #521 -> #522 -> #523.

## Review stack

1. #520: algorithm-preserving optimizer construction, compact cluster links, invalid-edge pruning and serialization.
2. #521: LP relaxation and eager full-cost TRW-S.
3. #522: lazy/no-PuLP cost construction for TRW-S.
4. #523: corrected split-dimension seed search and per-dimension PR514 `local_map` projection.

This Draft keeps the complete top-of-stack diff and profiling context in one place. Its head mirrors #523. The four stacked PRs are the merge targets.

## Final-tree policy

The stack was rebuilt from this PR's final implementation rather than replaying PR484/PR511/PR513 wholesale. This preserves the selected main+PR511 propagation behavior and excludes abandoned PR484 annotation/DP/min-sum paths.

Compared with the previous aggregate head, implementation files are unchanged except for the direct-LP objective fix. Additional differences remove machine-local configuration and unrelated artifacts, update tests for node-level cluster links, and add a fast-build equivalence regression.

PR514 remains the source of truth for 3+D MoE `local_map`, flattened EP groups, efsdp boundary placements, and backward-gradient duality.

## Validation

- Changed-file pre-commit passes whitespace, AST, conflict, large-file, EOF, Black, flake8, isort and mypy.
- Full repository suite: 528 passed, 1 xfailed, 4 xpassed.
- Foundation related suites: 33 passed.
- LP/eager-TRW-S suites: 7 passed.
- Lazy/no-PuLP suites: 8 passed.
- Split/local-map suites: 3 passed.

The five new failures from the previous aggregate CI are resolved: LP constraint feasibility, export JSON cluster links, both repeated-subgraph dtype constraints, and direct split-seed LP objective initialization.

## Corrected MoE profiles

Profiles use fake tensors and a fake process group; they measure search latency and host RSS, not distributed execution. Each result is one deterministic run; variance is unavailable.

- **2D `(8,8)`** uses direct unseeded lazy TRW-S, not split-dim: 33.05s versus 37.02s full-cost TRW-S, with identical objective `45680.5744` and placement.
- **3D `(2,4,8)`** corrected split + lazy TRW-S: 111.15s, objective `44260.3021`, `+1.698%` versus unrestricted full/lazy `43521.3868`. The unrestricted solution lies inside radius 2; the delta is compute `0`, communication `+675.915`, transition `+63`.
- **4D `(8,2,2,2)`** corrected split + lazy TRW-S: 201.41s, objective `47952.1351`, peak RSS 3.44 GiB. Unrestricted eager and lazy searches exceeded 20 minutes, so no objective gap or speedup is claimed. No 4D sampling experiment was run.

Authored with Claude.

## Inherited base checks

PR514 currently has the same unrelated repo-wide mypy failure in `autoparallel/tools/overlap_simulator/run.py:404` and the same TorchTitan upstream config-registry failure. The stack does not include unrelated fixes for either path.
