### PR TITLE
Speed up sharding optimizer construction

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -233,6 +233,7 @@ class AutoParallel:
     Args:
         mesh: Defines placement options.
         The meta model is moved to a fake device based on mesh.device_type.
+        fast_build: Skip DTensor enumeration costs that AutoParallel recomputes.
     """
 
     def __init__(
@@ -245,6 +246,7 @@ class AutoParallel:
         dynamic: bool = False,
         cost_model: Any = "nccl",
         repeated_subgraphs: bool = True,
+        fast_build: bool = True,
     ):
         self.stack = ExitStack()
         self.fake_mode = (
@@ -257,6 +259,7 @@ class AutoParallel:
         self.mp_policy = mp_policy
         self.cost_model = cost_model
         self.repeated_subgraphs = repeated_subgraphs
+        self.fast_build = fast_build
         # copy user model to avoid modifying it in-place
         # in dtype casting and move_to_fake
         model = copy.deepcopy(model)
@@ -323,6 +326,7 @@ class AutoParallel:
                 self.mesh,
                 force_grad_reduce_in_higher_precision,
                 repeated_subgraphs=self.repeated_subgraphs,
+                fast_build=self.fast_build,
             )
 
             self.sharding_optimizer = sharding_optimizer

--- a/autoparallel/graph_passes/graph_clustering.py
+++ b/autoparallel/graph_passes/graph_clustering.py
@@ -65,18 +65,17 @@ def _prepare_op_strategy(op_strategy):
     return str(op_strategy)
 
 
-def _hash_node(node, strategies, input_pickler):
+def _hash_node(node, strategies, input_pickler, op_str):
+    # op_str caches _prepare_op_strategy(strategies[n]) per node: each node's
+    # (large, 3D-mesh) strategy string is otherwise rebuilt once as self plus
+    # once per consumer, dominating clustering time on deep models.
     key = (
         str(node.target),
         node.meta.get("partitioner_tag"),
         node.meta.get("stack_trace"),
         _normalize_args(node),
-        _prepare_op_strategy(strategies[node]),
-        tuple(
-            _prepare_op_strategy(strategies[s])
-            for s in node.all_input_nodes
-            if s in strategies
-        ),
+        op_str[node],
+        tuple(op_str[s] for s in node.all_input_nodes if s in strategies),
     )
     return sha256_hash(input_pickler.dumps(key))
 
@@ -107,6 +106,7 @@ def get_identical_regions(
     hash_to_duplicates: dict[str, IdenticalNodes] = defaultdict(list)
     node_to_duplicates: dict[Node, IdenticalNodes] = {}
     t = time.time()
+    op_str = {n: _prepare_op_strategy(s) for n, s in strategies.items()}
     for node in graph.nodes:
         if node.op == "placeholder":
             continue
@@ -115,7 +115,9 @@ def get_identical_regions(
             # HOP submodule get_attr nodes are not in strategies.
             continue
 
-        duplicates = hash_to_duplicates[_hash_node(node, strategies, input_pickler)]
+        duplicates = hash_to_duplicates[
+            _hash_node(node, strategies, input_pickler, op_str)
+        ]
         duplicates.append(node)
         node_to_duplicates[node] = duplicates
     logger.debug(f"Hashed nodes in {time.time() - t} s")

--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -41,10 +41,10 @@ subject to the following constraint categories:
 
    → Implemented in: add_output_input_consistent_constraint()
 
-4. COST CONSTRAINTS: Variables with infinite cost (invalid configurations) are
-   forced to zero. Efficiency penalties for inefficient collective operations
-   (e.g., non-batch-dim shard-to-replicate) are embedded in the cost coefficients
-   computed by the cost model (see cost_models/collective_runtime_estimation.py).
+4. COST CONSTRAINTS: Invalid configurations are excluded. Efficiency penalties
+   for inefficient collective operations (e.g., non-batch-dim
+   shard-to-replicate) are embedded in the cost coefficients computed by the
+   cost model (see cost_models/collective_runtime_estimation.py).
 
    ∀i,a,o,j: c_{i,a,o,j} = ∞ ⟹ x_{i,a,o,j} = 0
 
@@ -69,6 +69,7 @@ The solver finds the globally optimal sharding strategy that minimizes total
 runtime cost while satisfying all constraints.
 """
 
+import contextlib
 import logging
 import math
 import operator
@@ -106,6 +107,22 @@ from .shardings.placement_options import get_placement_options_for_node
 from .shardings.propagation_rules import _create_all_options
 
 logger = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def _skip_enumeration_redistribute_cost(enabled):
+    if not enabled:
+        yield
+        return
+
+    import torch.distributed.tensor._ops.utils as dt_utils
+
+    orig = dt_utils.redistribute_cost
+    dt_utils.redistribute_cost = lambda *args, **kwargs: 0.0
+    try:
+        yield
+    finally:
+        dt_utils.redistribute_cost = orig
 
 
 def concretize_symint(val):
@@ -188,7 +205,7 @@ def concretize_gm(gm):
     return concrete_gm, orig_to_concrete, concrete_to_orig
 
 
-@dataclass
+@dataclass(slots=True)
 class DecisionVar:
     """A decision variable in the ILP, representing one (node, arg, output_placement,
     input_placement) choice with its associated costs and strategy metadata."""
@@ -224,8 +241,10 @@ class ShardingOptimizer:
         mesh,
         force_grad_reduce_in_higher_precision=False,
         repeated_subgraphs=False,
+        fast_build=True,
     ):
         self.orig_gm = gm
+        self.fast_build = fast_build
         # The optimizer works on a concretized copy of the graph where all
         # symbolic shapes are replaced with their concrete hint values. This
         # centralizes dynamic-shape handling: the optimization pipeline
@@ -246,6 +265,7 @@ class ShardingOptimizer:
         # remove_constraints can keep this in sync.
         self._node_constraint_names: dict[str, str] = {}
         self._name_counters: dict[str, int] = {}
+        self._valid_keys: set[tuple] | None = None
         t0 = time.perf_counter()
         self.strats = self.build_sharding_metadata()
         # nodes/node_map are derived from strats (not graph.nodes) so that
@@ -258,7 +278,8 @@ class ShardingOptimizer:
 
         get_placement_options_timer().report()
 
-        self.cluster_links: dict[tuple, tuple] = {}
+        self.cluster_links: dict[int, int] = {}
+        self._root_to_copies: dict[int, list[int]] = defaultdict(list)
         if repeated_subgraphs:
             t = time.time()
             clusters = get_identical_regions(self.gm.graph, self.strats)
@@ -305,58 +326,59 @@ class ShardingOptimizer:
 
     def build_sharding_metadata(self):
         strats = {}
-        for node in self.graph.nodes:
-            if node.op in ("placeholder", "get_attr"):
-                val = node.meta.get("val")
-                if isinstance(val, torch.Tensor):
-                    strats[node] = _create_all_options(self.mesh, val.shape, tensor=val)
-                elif node.op == "placeholder":
-                    # Non-tensor placeholders (e.g. baked-in booleans/strings):
-                    # keep them in strats with empty-shape replicate options
-                    # so the constraint system can reference them.
-                    strats[node] = _create_all_options(self.mesh, ())
+        with _skip_enumeration_redistribute_cost(self.fast_build):
+            for node in self.graph.nodes:
+                if node.op in ("placeholder", "get_attr"):
+                    val = node.meta.get("val")
+                    if isinstance(val, torch.Tensor):
+                        strats[node] = _create_all_options(
+                            self.mesh, val.shape, tensor=val
+                        )
+                    elif node.op == "placeholder":
+                        # Non-tensor placeholders (e.g. baked-in booleans/strings):
+                        # keep them in strats with empty-shape replicate options
+                        # so the constraint system can reference them.
+                        strats[node] = _create_all_options(self.mesh, ())
+                    else:
+                        # Non-tensor get_attr: GraphModule submodules used by
+                        # HOPs — not added to strats, invisible to the ILP.
+                        # _all_input_nodes filters them.
+                        assert node.op == "get_attr"
+                        assert any(
+                            isinstance(u.target, torch._ops.HigherOrderOperator)
+                            or "local_map" in u.name
+                            for u in node.users
+                        ), f"Non-tensor get_attr {node} is not used by a HOP"
+                elif node.op == "call_function":
+                    if not _produces_tensor(node.meta.get("val")):
+                        # Shape-computation nodes (sym_size, operator.mul, etc.)
+                        # produce scalars, not tensors — skip sharding.
+                        continue
+                    user_strats = tree_map_only(
+                        torch.fx.Node,
+                        lambda x: strats.get(x, x.meta.get("val")),
+                        node.args,
+                    )
+                    user_args = tree_map_only(
+                        torch.fx.Node, lambda x: x.meta.get("val"), node.args
+                    )
+                    user_kwargs = tree_map_only(
+                        torch.fx.Node, lambda x: x.meta.get("val"), node.kwargs
+                    )
+                    strats[node] = get_placement_options_for_node(
+                        self.mesh, node, user_strats, user_args, user_kwargs
+                    )
+                elif node.op == "output":
+                    user_strats = tree_map_only(
+                        torch.fx.Node, lambda x: strats[x], node.args
+                    )
+                    strats[node] = user_strats
                 else:
-                    # Non-tensor get_attr: GraphModule submodules used by
-                    # HOPs — not added to strats, invisible to the ILP.
-                    # _all_input_nodes filters them.
-                    assert node.op == "get_attr"
-                    assert any(
-                        isinstance(u.target, torch._ops.HigherOrderOperator)
-                        or "local_map" in u.name
-                        for u in node.users
-                    ), f"Non-tensor get_attr {node} is not used by a HOP"
-            elif node.op == "call_function":
-                if not _produces_tensor(node.meta.get("val")):
-                    # Shape-computation nodes (sym_size, operator.mul, etc.)
-                    # produce scalars, not tensors — skip sharding.
-                    continue
-                user_strats = tree_map_only(
-                    torch.fx.Node,
-                    lambda x: strats.get(x, x.meta.get("val")),
-                    node.args,
-                )
-                user_args = tree_map_only(
-                    torch.fx.Node, lambda x: x.meta.get("val"), node.args
-                )
-                user_kwargs = tree_map_only(
-                    torch.fx.Node, lambda x: x.meta.get("val"), node.kwargs
-                )
-                strats[node] = get_placement_options_for_node(
-                    self.mesh, node, user_strats, user_args, user_kwargs
-                )
-            elif node.op == "output":
-                user_strats = tree_map_only(
-                    torch.fx.Node, lambda x: strats[x], node.args
-                )
-                strats[node] = user_strats
-            else:
-                raise ValueError(f"Unexpected node op: {node.op}")
+                    raise ValueError(f"Unexpected node op: {node.op}")
         return strats
 
     def create_cluster_links(self, clusters):
-        """Create a mapping between identical optimization nodes to reduce the
-        optimization space. If cluster_links[key1] == key2, the optimization
-        problem uses key2's variable in place of key1."""
+        """Create a node-level mapping between identical optimization nodes."""
         for cluster_group in clusters:
             cluster0 = cluster_group[0]
             for cluster_i in cluster_group[1:]:
@@ -369,13 +391,15 @@ class ShardingOptimizer:
                         f"Problem with graph clustering: {n0} and {ni} don't have the same number "
                         "of input/output placements. Please report a bug"
                     )
-                    for argi, out_idx, inp_idx in options_n0:
-                        self.cluster_links[(idx1, argi, out_idx, inp_idx)] = (
-                            idx0,
-                            argi,
-                            out_idx,
-                            inp_idx,
-                        )
+                    self.cluster_links[idx1] = idx0
+
+    def _cluster_root_key(self, key):
+        root_idx = self.cluster_links.get(key[0])
+        return key if root_idx is None else (root_idx, key[1], key[2], key[3])
+
+    def _linked_option_keys(self, root_key):
+        for copy_idx in self._root_to_copies.get(root_key[0], ()):
+            yield (copy_idx, root_key[1], root_key[2], root_key[3])
 
     def _all_input_nodes(self, node):
         """Variant of node.all_input_nodes that preserves duplicate nodes.
@@ -417,7 +441,7 @@ class ShardingOptimizer:
         to their PuLP variables. Linked keys are not stored; use
         _get_pulp_variable() to resolve them through cluster_links.
         """
-        cluster_linked_node_idxs = {key[0] for key in self.cluster_links}
+        cluster_linked_node_idxs = set(self.cluster_links)
 
         pulp_variables = {}
         for node, _ in self.strats.items():
@@ -428,6 +452,8 @@ class ShardingOptimizer:
                 continue
             for argi, out_idx, inp_idx in self.walk_over_options(node):
                 key = (node_idx, argi, out_idx, inp_idx)
+                if self._valid_keys is not None and key not in self._valid_keys:
+                    continue
                 root_node = self.nodes[node_idx]
                 pulp_variables[key] = pulp.LpVariable(
                     f"n={root_node},s={node_idx},arg={argi},"
@@ -440,8 +466,8 @@ class ShardingOptimizer:
     def _get_pulp_variable(self, key):
         """Look up the PuLP variable for a key, resolving through
         cluster_links if the key belongs to a linked node."""
-        root_key = self.cluster_links.get(key, key)
-        return self.pulp_variables[root_key]
+        root_key = self._cluster_root_key(key)
+        return self.pulp_variables.get(root_key)
 
     def _compute_edge_costs(
         self,
@@ -482,16 +508,17 @@ class ShardingOptimizer:
         """Build DecisionVar entries for every (node_idx, argi, out_idx, inp_idx)
         combination in the strategy space."""
         t_pulp_start = time.perf_counter()
-        self.pulp_variables = self._create_pulp_variables()
-        t_pulp_end = time.perf_counter()
+        self.pulp_variables = {}
+        self._valid_keys = set()
 
         # Precompute which node indices are cluster-linked so we can
         # copy costs from the root instead of recomputing them.
-        self._cluster_linked_node_idxs = {key[0] for key in self.cluster_links}
+        self._cluster_linked_node_idxs = set(self.cluster_links)
 
         t_compute = 0.0
         t_edge = 0.0
         n_vars = 0
+        n_pruned = 0
         n_cluster_copied = 0
 
         decision_vars = {}
@@ -499,49 +526,43 @@ class ShardingOptimizer:
             (self.node_map[node], node, strat) for node, strat in self.strats.items()
         ]
 
-        # Build DVs for root nodes only (not cluster-linked).
-        for node_idx, node, op_strategy in strats_items:
-            if node.op == "output":
-                continue
-            if node_idx in self._cluster_linked_node_idxs:
-                continue
+        root_idxs = [
+            node_idx
+            for node_idx, node, _ in strats_items
+            if node.op != "output" and node_idx not in self._cluster_linked_node_idxs
+        ]
+        tc0 = time.perf_counter()
+        node_results = [self._compute_node_edge_costs(idx) for idx in root_idxs]
+        t_edge = time.perf_counter() - tc0
 
-            num_args = len(op_strategy.strategies[0].input_specs)
-
-            for out_idx, output_strategy in enumerate(op_strategy.strategies):
-                tc0 = time.perf_counter()
-                compute_cost = estimate_strategy_runtime_cost(node, output_strategy)
-                tc1 = time.perf_counter()
-                t_compute += tc1 - tc0
-                per_arg_compute = compute_cost / num_args
-
+        for node_idx, out_data in node_results:
+            node = self.nodes[node_idx]
+            op_strategy = self.strats[node]
+            for out_idx, (per_arg_compute, arg_rows) in enumerate(out_data):
+                output_strategy = op_strategy.strategies[out_idx]
                 for argi, redist_costs in enumerate(output_strategy.redistribute_cost):
-                    for inp_idx, default_comm_cost in enumerate(redist_costs):
+                    for inp_idx, (comm_cost, transition_cost) in enumerate(
+                        arg_rows[argi]
+                    ):
                         key = (node_idx, argi, out_idx, inp_idx)
-
-                        all_input_nodes = self._all_input_nodes(node)
-                        producer_strategy = (
-                            self.strats[all_input_nodes[argi]]
-                            if all_input_nodes
-                            else None
-                        )
-                        te0 = time.perf_counter()
-                        comm_cost, transition_cost = self._compute_edge_costs(
-                            node,
-                            output_strategy,
-                            argi,
-                            inp_idx,
-                            default_comm_cost,
-                            producer_strategy,
-                        )
-                        te1 = time.perf_counter()
-                        t_edge += te1 - te0
-
                         redist_costs[inp_idx] = comm_cost
+                        cost = comm_cost + per_arg_compute + transition_cost
+                        if not math.isfinite(cost):
+                            n_pruned += 1
+                            continue
+
+                        var = pulp.LpVariable(
+                            f"n={node},s={node_idx},arg={argi},"
+                            f"output_p={out_idx},input_p={inp_idx}",
+                            cat=pulp.LpBinary,
+                        )
+                        self.pulp_variables[key] = var
+                        self._valid_keys.add(key)
+                        n_vars += 1
 
                         decision_vars[key] = DecisionVar(
-                            var=self.pulp_variables[key],
-                            cost=comm_cost + per_arg_compute + transition_cost,
+                            var=var,
+                            cost=cost,
                             compute_cost=per_arg_compute,
                             comm_cost=comm_cost,
                             sharding_transition_cost=transition_cost,
@@ -549,16 +570,12 @@ class ShardingOptimizer:
                             output_spec=output_strategy.output_specs,
                             input_spec=output_strategy.input_specs[argi],
                         )
-                        n_vars += 1
 
         # Batch-copy redistribute_cost from root strats to linked strats.
         # The root pass above updated redistribute_cost in place with
         # edge-computed costs; linked strats need the same values for
         # _compute_solution_cost and other readers.
-        linked_node_to_root_node: dict[int, int] = {}
-        for linked_key, root_key in self.cluster_links.items():
-            linked_node_to_root_node[linked_key[0]] = root_key[0]
-        for linked_node_idx, root_node_idx in linked_node_to_root_node.items():
+        for linked_node_idx, root_node_idx in self.cluster_links.items():
             linked_node = self.nodes[linked_node_idx]
             root_node = self.nodes[root_node_idx]
             linked_op = self.strats[linked_node]
@@ -570,16 +587,17 @@ class ShardingOptimizer:
                     list(costs) for costs in root_spec.redistribute_cost
                 ]
         n_cluster_copied = len(self.cluster_links)
-        n_vars += n_cluster_copied
 
-        self._root_to_linked: dict[tuple, list[tuple]] = defaultdict(list)
-        for linked_key, root_key in self.cluster_links.items():
-            self._root_to_linked[root_key].append(linked_key)
+        self._root_to_copies = defaultdict(list)
+        for copy_idx, root_idx in self.cluster_links.items():
+            self._root_to_copies[root_idx].append(copy_idx)
 
+        t_pulp_end = time.perf_counter()
         logger.debug(
-            "_build_decision_vars breakdown (%d vars, %d cluster-copied): "
+            "_build_decision_vars breakdown (%d vars, %d pruned-inf, %d cluster-copied): "
             "pulp_vars=%.3fs, compute_cost=%.3fs, edge_cost=%.3fs",
             n_vars,
+            n_pruned,
             n_cluster_copied,
             t_pulp_end - t_pulp_start,
             t_compute,
@@ -587,12 +605,47 @@ class ShardingOptimizer:
         )
         return decision_vars
 
+    def _compute_node_edge_costs(self, node_idx):
+        """Compute per-edge costs for one cluster-root node."""
+        node = self.nodes[node_idx]
+        op_strategy = self.strats[node]
+        num_args = len(op_strategy.strategies[0].input_specs)
+        input_nodes = self._all_input_nodes(node)
+        producer_strategies = [self.strats[n] for n in input_nodes]
+        out_data = []
+        for output_strategy in op_strategy.strategies:
+            per_arg_compute = (
+                estimate_strategy_runtime_cost(node, output_strategy) / num_args
+            )
+            arg_rows = []
+            for argi, redist_costs in enumerate(output_strategy.redistribute_cost):
+                producer_strategy = (
+                    producer_strategies[argi]
+                    if argi < len(producer_strategies)
+                    else None
+                )
+                arg_rows.append(
+                    [
+                        self._compute_edge_costs(
+                            node,
+                            output_strategy,
+                            argi,
+                            inp_idx,
+                            default_comm_cost,
+                            producer_strategy,
+                        )
+                        for inp_idx, default_comm_cost in enumerate(redist_costs)
+                    ]
+                )
+            out_data.append((per_arg_compute, arg_rows))
+        return node_idx, out_data
+
     def _resolve_decision_var(self, key):
         """Return a DecisionVar for key, reconstructing on the fly for linked keys."""
         dv = self.decision_vars.get(key)
         if dv is not None:
             return dv
-        root_key = self.cluster_links[key]
+        root_key = self._cluster_root_key(key)
         root_dv = self.decision_vars[root_key]
         node_idx, argi, out_idx, _ = key
         strategy = self.strats[self.nodes[node_idx]].strategies[out_idx]
@@ -607,6 +660,15 @@ class ShardingOptimizer:
             input_spec=strategy.input_specs[argi],
         )
 
+    def _find_decision_var(self, node_idx, argi, out_idx):
+        node = self.nodes[node_idx]
+        for _, _, inp_idx in self.walk_over_options(node, argi):
+            key = (node_idx, argi, out_idx, inp_idx)
+            root_key = self._cluster_root_key(key)
+            if root_key in self.decision_vars:
+                return self._resolve_decision_var(key)
+        return None
+
     def _collect_vars(self, node, node_idx, argi, group_by, resolve_clusters=False):
         """Collect PuLP variables for a node's options, grouped by strategy index.
 
@@ -619,12 +681,14 @@ class ShardingOptimizer:
         result = {}
         for _, out_idx, inp_idx in self.walk_over_options(node, argi):
             key = (node_idx, argi, out_idx, inp_idx)
-            if key in self.cluster_links:
+            if key[0] in self.cluster_links:
                 if not resolve_clusters:
                     continue
-                var = self.pulp_variables[self.cluster_links[key]]
+                var = self._get_pulp_variable(key)
             else:
-                var = self.pulp_variables[key]
+                var = self.pulp_variables.get(key)
+            if var is None:
+                continue
             group_key = out_idx if group_by == "out_idx" else inp_idx
             result.setdefault(group_key, []).append(var)
         return result
@@ -677,13 +741,16 @@ class ShardingOptimizer:
             if node_idx in self._cluster_linked_node_idxs:
                 continue
             arg_vars = {}
+            num_args = len(self.strats[node].strategies[0].input_specs)
             for argi, out_idx, inp_idx in self.walk_over_options(node):
                 key = (node_idx, argi, out_idx, inp_idx)
-                var = self.pulp_variables[key]
+                var = self.pulp_variables.get(key)
+                if var is None:
+                    continue
                 arg_vars.setdefault(argi, []).append(var)
-            for eqs in arg_vars.values():
+            for argi in range(num_args):
                 self.prob += (
-                    pulp.lpSum(eqs) == 1,
+                    pulp.lpSum(arg_vars.get(argi, [])) == 1,
                     self._get_next_name("unique_decision"),
                 )
 
@@ -703,17 +770,24 @@ class ShardingOptimizer:
                 continue
             if len(self._all_input_nodes(node)) <= 1:
                 continue
+            num_args = len(self._all_input_nodes(node))
+            num_outputs = len(self.strats[node].strategies)
             vars_per_output = {}
             for argi, out_idx, inp_idx in self.walk_over_options(node):
                 key = (node_idx, argi, out_idx, inp_idx)
-                var = self.pulp_variables[key]
+                var = self.pulp_variables.get(key)
+                if var is None:
+                    continue
                 vars_per_output.setdefault((argi, out_idx), []).append(var)
-            eqs_per_arg = [[] for _ in self._all_input_nodes(node)]
-            for (argi, out_idx), value in vars_per_output.items():
-                eqs_per_arg[argi].append(pulp.lpSum(value))
+            eqs_per_arg = [
+                [
+                    pulp.lpSum(vars_per_output.get((argi, out_idx), []))
+                    for out_idx in range(num_outputs)
+                ]
+                for argi in range(num_args)
+            ]
             arg0 = eqs_per_arg[0]
             for arg_eqs in eqs_per_arg[1:]:
-                assert len(arg0) == len(arg_eqs)
                 for i in range(len(arg0)):
                     self.prob += (
                         arg0[i] == arg_eqs[i],
@@ -790,22 +864,15 @@ class ShardingOptimizer:
                     )
                     continue
 
-                assert (
-                    vars_producer.keys() == vars_consumer.keys()
-                ), f"{vars_producer}, {vars_consumer}"
-
-                for k in vars_producer:
+                for k in vars_producer.keys() | vars_consumer.keys():
                     self.prob += (
-                        pulp.lpSum(vars_producer[k]) == pulp.lpSum(vars_consumer[k]),
+                        pulp.lpSum(vars_producer.get(k, []))
+                        == pulp.lpSum(vars_consumer.get(k, [])),
                         self._get_next_name("output_input_consistent"),
                     )
 
     def add_inf_cost_constraint(self):
-        """COST (Category 4): Variables with infinite cost (invalid configurations)
-        are forced to zero.
-
-        ∀i,a,o,j: c_{i,a,o,j} = ∞ ⟹ x_{i,a,o,j} = 0
-        """
+        """COST (Category 4): Invalid configurations are excluded."""
         for key, dv in self.decision_vars.items():
             if not math.isfinite(dv.cost):
                 dv.cost = 10000.0
@@ -880,7 +947,7 @@ class ShardingOptimizer:
         """Add the cost minimization objective to the ILP."""
         terms = []
         for key, dv in self.decision_vars.items():
-            multiplier = 1 + len(self._root_to_linked.get(key, []))
+            multiplier = 1 + len(self._root_to_copies.get(key[0], ()))
             terms.append(dv.var * dv.cost * multiplier)
         self.prob += pulp.lpSum(terms)
 
@@ -898,7 +965,7 @@ class ShardingOptimizer:
             key for key, dv in self.decision_vars.items() if dv.var.value() == 1
         ]
         for root_key in list(self.selected_keys):
-            self.selected_keys.extend(self._root_to_linked.get(root_key, []))
+            self.selected_keys.extend(self._linked_option_keys(root_key))
 
         if self.prob.status == -1:
             logger.warning(self.get_violated_constraints_log())
@@ -1073,7 +1140,9 @@ class ShardingOptimizer:
             # Use pre-computed costs from decision vars instead of
             # estimate_strategy_runtime_cost, which needs node.meta["val"]
             # (absent on loaded optimizers).
-            dv = self._resolve_decision_var((node_idx, 0, out_idx, 0))
+            dv = self._find_decision_var(node_idx, 0, out_idx)
+            if dv is None:
+                continue
             num_args = max(len(strategy.input_specs), 1)
             total_compute += dv.compute_cost * num_args
 
@@ -1158,9 +1227,9 @@ class ShardingOptimizer:
 
         # Build node-level cluster mapping: linked_node -> root_node
         cluster_roots: dict[torch.fx.Node, torch.fx.Node] = {}
-        for linked_key, root_key in self.cluster_links.items():
-            linked_node = self.nodes[linked_key[0]]
-            root_node = self.nodes[root_key[0]]
+        for linked_idx, root_idx in self.cluster_links.items():
+            linked_node = self.nodes[linked_idx]
+            root_node = self.nodes[root_idx]
             cluster_roots[linked_node] = root_node
 
         _normalize_cluster_layer(cluster_roots)
@@ -1404,11 +1473,13 @@ class ShardingOptimizer:
         if constraint_name is None:
             constraint_name = "user_constraint"
         node_idx = self.node_map[node]
-        vars_per_arg = {}
+        num_args = len(self.strats[node].strategies[0].input_specs)
+        vars_per_arg = {argi: [] for argi in range(num_args)}
         for argi, out_idx, inp_idx in self.walk_over_options(node):
             if out_idx in output_constraint_indices:
                 var = self._get_pulp_variable((node_idx, argi, out_idx, inp_idx))
-                vars_per_arg.setdefault(argi, []).append(var)
+                if var is not None:
+                    vars_per_arg[argi].append(var)
         names = []
         for eqs in vars_per_arg.values():
             name = self._get_next_name(constraint_name)
@@ -1435,8 +1506,10 @@ class ShardingOptimizer:
                 # This placement exists in node_a but not in node_b.
                 # Disable it: force sum of its decision variables to 0.
                 v_a = [
-                    self._get_pulp_variable((idx_a, 0, out_idx, inp_idx))
+                    var
                     for inp_idx in range(num_inp_a)
+                    if (var := self._get_pulp_variable((idx_a, 0, out_idx, inp_idx)))
+                    is not None
                 ]
                 self.prob += (
                     pulp.lpSum(v_a) == 0,
@@ -1445,12 +1518,16 @@ class ShardingOptimizer:
                 continue
             out_idx_b = strat_b.index(sp)
             v_a = [
-                self._get_pulp_variable((idx_a, 0, out_idx, inp_idx))
+                var
                 for inp_idx in range(num_inp_a)
+                if (var := self._get_pulp_variable((idx_a, 0, out_idx, inp_idx)))
+                is not None
             ]
             v_b = [
-                self._get_pulp_variable((idx_b, 0, out_idx_b, inp_idx))
+                var
                 for inp_idx in range(num_inp_b)
+                if (var := self._get_pulp_variable((idx_b, 0, out_idx_b, inp_idx)))
+                is not None
             ]
             self.prob += (
                 pulp.lpSum(v_b) == pulp.lpSum(v_a),
@@ -1653,7 +1730,9 @@ class ShardingOptimizer:
             num_out_strat = len(self.strats[node].strategies)
             ratios: list[float] = []
             for out_idx in range(num_out_strat):
-                dv = self._resolve_decision_var((node_idx, 0, out_idx, 0))
+                dv = self._find_decision_var(node_idx, 0, out_idx)
+                if dv is None:
+                    continue
                 spec: DTensorSpec = dv.input_spec
                 assert spec.tensor_meta is not None
                 tensor_shape: torch.Size = spec.tensor_meta.shape
@@ -1663,6 +1742,8 @@ class ShardingOptimizer:
                 ratio = new_size / old_size
                 ratios.append(ratio)
                 elms.append(dv.var * ratio)
+            if not ratios:
+                continue
             best_ratio: float = min(ratios)
             budget_low += max(best_ratio, memory_factor_low)
             budget_high += max(best_ratio, memory_factor_high)

--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -115,14 +115,19 @@ def _skip_enumeration_redistribute_cost(enabled):
         yield
         return
 
-    import torch.distributed.tensor._ops.utils as dt_utils
+    try:
+        import torch.distributed.tensor._ops.utils as dt_utils
 
-    orig = dt_utils.redistribute_cost
+        original = dt_utils.redistribute_cost
+    except (ImportError, AttributeError):
+        yield
+        return
+
     dt_utils.redistribute_cost = lambda *args, **kwargs: 0.0
     try:
         yield
     finally:
-        dt_utils.redistribute_cost = orig
+        dt_utils.redistribute_cost = original
 
 
 def concretize_symint(val):

--- a/autoparallel/serialization.py
+++ b/autoparallel/serialization.py
@@ -135,7 +135,7 @@ def save_optimizer(opt, path):
     # Re-key strats by node name, saving only root nodes (non-linked).
     # Linked nodes share identical strats with their root and are
     # reconstructed on load from cluster_links.
-    linked_node_names = {opt.nodes[lk[0]].name for lk in opt.cluster_links}
+    linked_node_names = {opt.nodes[c].name for c in opt.cluster_links}
     strats_by_name = {
         node.name: strat
         for node, strat in opt.strats.items()
@@ -193,8 +193,7 @@ def save_optimizer(opt, path):
         "dv_costs_keys": dv_costs_keys,
         "dv_costs_vals": dv_costs_vals,
         "cluster_links_node_by_name": {
-            opt.nodes[lk[0]].name: opt.nodes[rk[0]].name
-            for lk, rk in opt.cluster_links.items()
+            opt.nodes[c].name: opt.nodes[r].name for c, r in opt.cluster_links.items()
         },
         "constraint_log": opt._constraint_log,
         "selected_keys_by_name": selected_keys_by_name,
@@ -264,27 +263,34 @@ def load_optimizer(cls, path):
     opt._memory_constraint = None
     opt._node_constraint_names = {}
     opt._name_counters = {}
+    # Loaded optimizers rebuild the PuLP problem below but carry no init-time
+    # profiling; an empty profile is enough for the solve-time timing writes.
+    opt.build_pulp = True
+    opt.profile = {"timings": {}}
 
-    # Reconstruct cluster_links by expanding the node-level mapping over
-    # all (argi, out_idx, inp_idx) combinations.
-    opt.cluster_links = {}
-    for linked_name, root_name in cluster_links_node_by_name.items():
-        linked_node = nodes_by_name[linked_name]
-        root_node = nodes_by_name[root_name]
-        linked_idx = opt.node_map[linked_node]
-        root_idx = opt.node_map[root_node]
-        for argi, out_idx, inp_idx in opt.walk_over_options(linked_node):
-            opt.cluster_links[(linked_idx, argi, out_idx, inp_idx)] = (
-                root_idx,
-                argi,
-                out_idx,
-                inp_idx,
-            )
-    opt._cluster_linked_node_idxs = {key[0] for key in opt.cluster_links}
+    # cluster_links is node-level: copy node idx -> root node idx.
+    opt.cluster_links = {
+        opt.node_map[nodes_by_name[linked_name]]: opt.node_map[nodes_by_name[root_name]]
+        for linked_name, root_name in cluster_links_node_by_name.items()
+    }
+    opt._cluster_linked_node_idxs = set(opt.cluster_links)
 
     # Mesh placeholder — provides shape/dim_names for get_json() and ndim
     # for add_node_constraint() default placement, without needing a PG
     opt.mesh = _MeshPlaceholder(save_dict["mesh_shape"], save_dict["mesh_dim_names"])
+
+    # Map saved decision-var keys to loaded node indices. Only these keys had
+    # a finite-cost (valid) strategy edge at save time; invalid edges were
+    # pruned and must not get a variable, so seed _valid_keys before creating
+    # the PuLP variables (see ShardingOptimizer._build_decision_vars).
+    save_node_names = save_dict["dv_costs_node_names"]
+    keys_t = save_dict["dv_costs_keys"].tolist()
+    vals_t = save_dict["dv_costs_vals"].tolist()
+    mapped_keys = [
+        (opt.node_map[nodes_by_name[save_node_names[k[0]]]], k[1], k[2], k[3])
+        for k in keys_t
+    ]
+    opt._valid_keys = set(mapped_keys)
 
     # Rebuild PuLP variables and decision vars from saved costs.
     t2 = time.perf_counter()
@@ -296,19 +302,14 @@ def load_optimizer(cls, path):
         len(opt.pulp_variables),
     )
     # Reconstruct decision_vars from compact tensors.
-    save_node_names = save_dict["dv_costs_node_names"]
-    keys_t = save_dict["dv_costs_keys"].tolist()
-    vals_t = save_dict["dv_costs_vals"].tolist()
     opt.decision_vars = {}
-    for (save_node_idx, argi, out_idx, inp_idx), (
+    for key, (
         compute_cost,
         comm_cost,
         transition_cost,
-    ) in zip(keys_t, vals_t):
-        node_name = save_node_names[save_node_idx]
-        node = nodes_by_name[node_name]
-        node_idx = opt.node_map[node]
-        key = (node_idx, argi, out_idx, inp_idx)
+    ) in zip(mapped_keys, vals_t):
+        node_idx, argi, out_idx, inp_idx = key
+        node = opt.nodes[node_idx]
         strategy = opt.strats[node].strategies[out_idx]
         opt.decision_vars[key] = DecisionVar(
             var=opt.pulp_variables[key],
@@ -329,9 +330,9 @@ def load_optimizer(cls, path):
         len(opt.decision_vars),
     )
 
-    opt._root_to_linked = defaultdict(list)
-    for linked_key, root_key in opt.cluster_links.items():
-        opt._root_to_linked[root_key].append(linked_key)
+    opt._root_to_copies = defaultdict(list)
+    for copy_idx, root_idx in opt.cluster_links.items():
+        opt._root_to_copies[root_idx].append(copy_idx)
 
     opt.prob = pulp.LpProblem("AutoParallel", pulp.LpMinimize)
     opt.add_default_constraints()
@@ -384,7 +385,7 @@ def _restore_solution(opt, selected_keys_by_name, nodes_by_name):
 
     # Expand cluster links
     for root_key in list(opt.selected_keys):
-        opt.selected_keys.extend(opt._root_to_linked.get(root_key, []))
+        opt.selected_keys.extend(opt._linked_option_keys(root_key))
 
 
 def save_placements(opt, path):

--- a/autoparallel/serialization.py
+++ b/autoparallel/serialization.py
@@ -376,7 +376,9 @@ def _restore_solution(opt, selected_keys_by_name, nodes_by_name):
         for argi, out_idx, inp_idx in key_parts:
             opt.selected_keys.append((node_idx, argi, out_idx, inp_idx))
 
-    # Set PuLP variable values: selected = 1.0, all others default to 0.0
+    # Set PuLP variable values: selected = 1.0, all others = 0.0.
+    for var in opt.pulp_variables.values():
+        var.varValue = 0.0
     selected_set = set(opt.selected_keys)
     for key in selected_set:
         dv = opt.decision_vars.get(key)
@@ -386,6 +388,9 @@ def _restore_solution(opt, selected_keys_by_name, nodes_by_name):
     # Expand cluster links
     for root_key in list(opt.selected_keys):
         opt.selected_keys.extend(opt._linked_option_keys(root_key))
+
+    opt.prob.status = pulp.LpStatusOptimal
+    opt.prob.sol_status = pulp.LpSolutionOptimal
 
 
 def save_placements(opt, path):

--- a/tests/search_profile.py
+++ b/tests/search_profile.py
@@ -1,0 +1,506 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import platform
+import resource
+import subprocess
+import time
+import traceback
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import patch
+
+import pulp
+import torch
+from torch._functorch._aot_autograd.fx_utils import (
+    get_param_and_grad_nodes,
+    get_plain_input_and_grad_nodes,
+    get_plain_output_and_tangent_nodes,
+)
+from torch.distributed.fsdp import MixedPrecisionPolicy
+from torch.distributed.tensor._dtensor_spec import DTensorSpec
+from torch.distributed.tensor.placement_types import Replicate, Shard
+from torch.testing._internal.distributed.fake_pg import FakeStore
+
+from autoparallel.api import AutoParallel
+
+LLAMA_CONFIGS = {
+    "llama1b": {
+        "dim": 2048,
+        "n_layers": 16,
+        "n_heads": 32,
+        "n_kv_heads": 8,
+        "ffn_dim_multiplier": 1.5,
+        "multiple_of": 256,
+    },
+    "llama8b": {
+        "dim": 4096,
+        "n_layers": 32,
+        "n_heads": 32,
+        "n_kv_heads": 8,
+        "ffn_dim_multiplier": 1.3,
+        "multiple_of": 1024,
+    },
+}
+
+DSV3_DEGREES = {
+    "dp_replicate": 8,
+    "dp_shard": 8,
+    "cp": 1,
+    "tp": 1,
+    "ep": 8,
+}
+
+
+class ProfiledAutoParallel(AutoParallel):
+    def build_model_graph(self):
+        started = time.perf_counter()
+        try:
+            return super().build_model_graph()
+        finally:
+            self.profile_graph_trace_s = time.perf_counter() - started
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Profile AutoParallel placement search on fake H100 devices."
+    )
+    parser.add_argument("--model", choices=(*LLAMA_CONFIGS, "dsv3"), required=True)
+    parser.add_argument("--mesh", help="Comma-separated LLaMA mesh dimensions")
+    parser.add_argument("--moe-layout", choices=("2d",))
+    parser.add_argument("--solver", choices=("ilp",), required=True)
+    parser.add_argument("--revision-label", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--detailed-solution", action="store_true")
+    return parser.parse_args(argv)
+
+
+def fake_cuda_context(stack):
+    properties = type(
+        "Props",
+        (),
+        {
+            "major": 9,
+            "minor": 0,
+            "name": "H100",
+            "total_memory": 80 * 1024**3,
+            "multi_processor_count": 132,
+            "L2_cache_size": 50 * 1024**2,
+        },
+    )()
+    for target, replacement in (
+        ("torch.cuda.device_count", lambda: 8),
+        ("torch.cuda.get_device_name", lambda *args, **kwargs: "H100"),
+        ("torch.cuda.get_device_capability", lambda *args, **kwargs: (9, 0)),
+        (
+            "torch.cuda.get_device_properties",
+            lambda *args, **kwargs: properties,
+        ),
+    ):
+        stack.enter_context(patch(target, replacement))
+
+
+def make_llama(model_name, mesh_shape):
+    from autoparallel._testing.models.llama3 import Transformer, TransformerModelArgs
+
+    if len(mesh_shape) != 2:
+        raise ValueError(f"LLaMA profiles require a 2D mesh, got {mesh_shape}")
+    seq_len = 2048
+    vocab_size = 128256
+    config = {
+        **LLAMA_CONFIGS[model_name],
+        "rope_theta": 500000,
+        "vocab_size": vocab_size,
+        "max_seq_len": seq_len,
+    }
+    with torch.device("meta"):
+        model = Transformer(TransformerModelArgs(**config))
+    names = ("dp", "tp")
+    mesh = torch.distributed.device_mesh.init_device_mesh(
+        "cuda", mesh_shape, mesh_dim_names=names
+    )
+    batch_size = 2 * mesh_shape[0]
+
+    def input_fn():
+        return torch.randint(0, vocab_size, (batch_size, seq_len), device="cuda")
+
+    input_placement = (Shard(0), Replicate())
+    output_placement = (Shard(0), Shard(2))
+    expanded = {
+        "family": "llama3",
+        "config": config,
+        "batch_size": batch_size,
+        "sequence_length": seq_len,
+        "mesh_shape": list(mesh_shape),
+        "mesh_dim_names": list(names),
+    }
+    return model, input_fn, mesh, input_placement, output_placement, expanded
+
+
+def make_dsv3():
+    from autoparallel._testing.models.dsv3 import (
+        DeepSeekV3Model,
+        build_moe_mesh,
+        make_dsv3_config,
+    )
+
+    mesh, roles = build_moe_mesh(**DSV3_DEGREES)
+    config = make_dsv3_config(num_experts=64, max_seq_len=2048)
+    with torch.device("meta"):
+        model = DeepSeekV3Model(
+            config, mesh=mesh, roles=roles, compute_dtype=torch.bfloat16
+        )
+    batch_size = 8 * mesh.size()
+
+    def input_fn():
+        return torch.randint(0, config.vocab_size, (batch_size, 2048), device="cuda")
+
+    placement = (Shard(0),) * mesh.ndim
+    expanded = {
+        "family": "dsv3",
+        "config": {
+            "dim": config.dim,
+            "vocab_size": config.vocab_size,
+            "n_layers": len(config.layers),
+            "n_dense_layers": sum(layer.moe is None for layer in config.layers),
+            "num_experts": 64,
+            "sequence_length": 2048,
+            "batch_size": batch_size,
+        },
+        "degrees": DSV3_DEGREES,
+        "mesh_shape": list(mesh.shape),
+        "mesh_dim_names": list(mesh.mesh_dim_names),
+        "ep_axis_names": list(roles.ep_axis_names),
+        "ep_group_name": roles.ep_group_name,
+    }
+    return model, input_fn, mesh, placement, placement, expanded
+
+
+def output_specs(value):
+    specs = value if isinstance(value, (tuple, list)) else (value,)
+    return [
+        [repr(placement) for placement in spec.placements]
+        for spec in specs
+        if isinstance(spec, DTensorSpec)
+    ]
+
+
+def solution_fingerprint(solution):
+    canonical = [
+        (node.name, output_specs(strategy.output_specs))
+        for node, strategy in sorted(solution.items(), key=lambda item: item[0].name)
+    ]
+    payload = json.dumps(canonical, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode()).hexdigest(), len(canonical)
+
+
+def spec_details(value):
+    if isinstance(value, DTensorSpec):
+        shape = None
+        if value.tensor_meta is not None:
+            shape = [str(dim) for dim in value.tensor_meta.shape]
+        return {
+            "placements": [repr(placement) for placement in value.placements],
+            "shape": shape,
+        }
+    if isinstance(value, (tuple, list)):
+        return [spec_details(item) for item in value]
+    return None
+
+
+def solution_details(solution, graph):
+    roles = {}
+    for desc, (node, grad) in get_param_and_grad_nodes(graph).items():
+        roles[node.name] = f"parameter:{desc.target}"
+        if grad is not None:
+            roles[grad.name] = f"parameter_grad:{desc.target}"
+    for desc, (node, grad) in get_plain_input_and_grad_nodes(graph).items():
+        roles[node.name] = f"input:{desc.idx}"
+        if grad is not None:
+            roles[grad.name] = f"input_grad:{desc.idx}"
+    for desc, (node, tangent) in get_plain_output_and_tangent_nodes(graph).items():
+        roles[node.name] = f"output:{desc.idx}"
+        if tangent is not None:
+            roles[tangent.name] = f"output_tangent:{desc.idx}"
+
+    rows = []
+    for node, strategy in sorted(solution.items(), key=lambda item: item[0].name):
+        stack = node.meta.get("stack_trace") or ""
+        source = " | ".join(
+            line.strip() for line in stack.splitlines()[-2:] if line.strip()
+        )
+        rows.append(
+            {
+                "node": node.name,
+                "op": node.op,
+                "target": getattr(node.target, "__name__", str(node.target)),
+                "role": roles.get(node.name),
+                "source": source,
+                "output_specs": spec_details(strategy.output_specs),
+                "input_specs": spec_details(strategy.input_specs),
+            }
+        )
+    return rows
+
+
+def cost_contributions(opt):
+    if hasattr(opt, "_cluster_root_key"):
+        selected = {}
+        for key in opt.selected_keys:
+            root_key = opt._cluster_root_key(key)
+            if root_key in opt.decision_vars:
+                selected[root_key] = (
+                    opt.decision_vars[root_key],
+                    1 + len(opt._root_to_copies.get(root_key[0], ())),
+                )
+    else:
+        selected = {
+            key: (opt._resolve_decision_var(key), 1) for key in opt.selected_keys
+        }
+    by_node = {}
+    for key, (decision, multiplier) in selected.items():
+        node_idx, _arg_idx, out_idx, _inp_idx = key
+        row = by_node.setdefault(
+            node_idx,
+            {
+                "node": opt.nodes[node_idx].name,
+                "output_index": out_idx,
+                "multiplier": multiplier,
+                "compute": 0.0,
+                "communication": 0.0,
+                "transition": 0.0,
+                "total": 0.0,
+            },
+        )
+        row["compute"] += decision.compute_cost * multiplier
+        row["communication"] += decision.comm_cost * multiplier
+        row["transition"] += decision.sharding_transition_cost * multiplier
+        row["total"] += decision.cost * multiplier
+    return list(by_node.values())
+
+
+def finite(value):
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def run_git(*args):
+    return subprocess.check_output(("git", *args), text=True).strip()
+
+
+def git_metadata():
+    status = run_git("status", "--short")
+    return {
+        "commit": run_git("rev-parse", "HEAD"),
+        "branch": run_git("branch", "--show-current"),
+        "worktree": run_git("rev-parse", "--show-toplevel"),
+        "status": status,
+    }
+
+
+def cpu_model():
+    try:
+        for line in Path("/proc/cpuinfo").read_text().splitlines():
+            if line.startswith("model name"):
+                return line.split(":", 1)[1].strip()
+    except OSError:
+        pass
+    return platform.processor() or None
+
+
+def validate_args(args):
+    if args.model == "dsv3":
+        if args.moe_layout != "2d" or args.mesh is not None:
+            raise ValueError("dsv3 requires --moe-layout 2d and no --mesh")
+        return 64, None
+    if args.mesh is None or args.moe_layout is not None:
+        raise ValueError("LLaMA requires --mesh and no --moe-layout")
+    mesh_shape = tuple(int(part) for part in args.mesh.split(","))
+    world_size = math.prod(mesh_shape)
+    if world_size != 64:
+        raise ValueError(f"world size must be 64, got {world_size}")
+    return world_size, mesh_shape
+
+
+def validate_solution(objective, solution_nodes, violations, pulp_status):
+    if objective is None:
+        raise RuntimeError("placement objective is not finite")
+    if solution_nodes == 0:
+        raise RuntimeError("placement solution is empty")
+    if violations:
+        raise RuntimeError(f"placement violates {len(violations)} constraints")
+    if pulp_status != "Optimal":
+        raise RuntimeError(f"ILP placement is not optimal: {pulp_status}")
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    started = time.perf_counter()
+    result = {
+        "schema_version": 1,
+        "status": "error",
+        "request": vars(args) | {"output": str(args.output)},
+        "environment": {
+            "python": platform.python_version(),
+            "torch": torch.__version__,
+            "cuda": torch.version.cuda,
+            "pulp": pulp.__version__,
+            "platform": platform.platform(),
+            "cpu_model": cpu_model(),
+            "cpu_count": os.cpu_count(),
+            "pid": os.getpid(),
+        },
+    }
+    try:
+        result["git"] = git_metadata()
+        world_size, mesh_shape = validate_args(args)
+        torch.manual_seed(0)
+        with ExitStack() as stack:
+            fake_cuda_context(stack)
+            torch.distributed.init_process_group(
+                "fake", store=FakeStore(), rank=0, world_size=world_size
+            )
+
+            model_started = time.perf_counter()
+            built = (
+                make_dsv3()
+                if args.model == "dsv3"
+                else make_llama(args.model, mesh_shape)
+            )
+            model, input_fn, mesh, input_placement, output_placement, expanded = built
+            result["expanded_config"] = expanded
+            result["timings"] = {
+                "model_and_mesh_setup_s": time.perf_counter() - model_started
+            }
+
+            autop = ProfiledAutoParallel(
+                model,
+                input_fn,
+                mesh,
+                mp_policy=MixedPrecisionPolicy(
+                    param_dtype=torch.bfloat16, reduce_dtype=torch.float32
+                ),
+                repeated_subgraphs=True,
+                dynamic=args.model == "dsv3",
+            )
+            enter_started = time.perf_counter()
+            stack.enter_context(autop)
+            enter_elapsed = time.perf_counter() - enter_started
+            opt = autop.sharding_optimizer
+            graph_trace_s = autop.profile_graph_trace_s
+            build_enter_s = max(enter_elapsed - graph_trace_s, 0.0)
+
+            constraint_started = time.perf_counter()
+            autop.add_parameter_memory_constraint(low=None, high=None)
+            autop.add_input_constraints([input_placement])
+            autop.add_output_constraints([output_placement])
+            constraint_s = time.perf_counter() - constraint_started
+
+            solve_started = time.perf_counter()
+            solution = autop.optimize_placement(verbose=False)
+            solve_call_s = time.perf_counter() - solve_started
+            search_total_s = time.perf_counter() - enter_started
+            unaccounted_s = max(
+                search_total_s
+                - graph_trace_s
+                - build_enter_s
+                - constraint_s
+                - solve_call_s,
+                0.0,
+            )
+            result["timings"].update(
+                {
+                    "enter_total_s": enter_elapsed,
+                    "graph_trace_s": graph_trace_s,
+                    "build_enter_s": build_enter_s,
+                    "user_constraints_s": constraint_s,
+                    "solve_call_s": solve_call_s,
+                    "search_total_s": search_total_s,
+                    "unaccounted_s": unaccounted_s,
+                }
+            )
+
+            fingerprint, solution_nodes = solution_fingerprint(solution)
+            objective = finite(pulp.value(opt.prob.objective))
+            violations = [
+                name
+                for name, constraint in opt.prob.constraints.items()
+                if not constraint.valid(1e-6)
+            ]
+            pulp_status = pulp.LpStatus.get(opt.prob.status, str(opt.prob.status))
+            solution_status = pulp.LpSolution.get(
+                getattr(opt.prob, "sol_status", None),
+                str(getattr(opt.prob, "sol_status", None)),
+            )
+            validation = {
+                "pulp_status": pulp_status,
+                "pulp_solution_status": solution_status,
+                "constraint_violations": len(violations),
+                "violated_constraint_names": violations[:100],
+            }
+            result.update(
+                {
+                    "objective": objective,
+                    "placement_sha256": fingerprint,
+                    "solution_nodes": solution_nodes,
+                    "validation": validation,
+                    "counts": {
+                        "graph_nodes": len(list(opt.graph.nodes)),
+                        "strategy_nodes": len(opt.strats),
+                        "decision_vars": len(opt.decision_vars),
+                        "pulp_variables": len(opt.pulp_variables),
+                        "constraints": len(opt.prob.constraints),
+                        "selected_keys": len(opt.selected_keys),
+                    },
+                }
+            )
+            validate_solution(objective, solution_nodes, violations, pulp_status)
+
+            if args.detailed_solution:
+                contributions = cost_contributions(opt)
+                result["solution_detail"] = solution_details(solution, autop.gm.graph)
+                result["cost_contributions"] = contributions
+                result["cost_contribution_sum"] = sum(
+                    row["total"] for row in contributions
+                )
+            result["status"] = "success"
+    except Exception as error:
+        result["error"] = {
+            "type": type(error).__name__,
+            "message": str(error),
+            "traceback": traceback.format_exc(),
+        }
+    finally:
+        if torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+        result["elapsed_s"] = time.perf_counter() - started
+        result["max_rss_kib"] = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+        print(
+            json.dumps(
+                {
+                    "status": result["status"],
+                    "output": str(args.output),
+                    "objective": result.get("objective"),
+                    "placement_sha256": result.get("placement_sha256"),
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+    return 0 if result["status"] == "success" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_export_json.py
+++ b/tests/test_export_json.py
@@ -96,9 +96,9 @@ def test_normalize_cluster_layer_swaps_backward_roots(device_mesh_1d):
 
     # Build cluster_roots from cluster_links
     cluster_roots = {}
-    for linked_key, root_key in opt.cluster_links.items():
-        linked_node = opt.nodes[linked_key[0]]
-        root_node = opt.nodes[root_key[0]]
+    for linked_idx, root_idx in opt.cluster_links.items():
+        linked_node = opt.nodes[linked_idx]
+        root_node = opt.nodes[root_idx]
         cluster_roots[linked_node] = root_node
 
     if not cluster_roots:

--- a/tests/test_grad_reduce_dtype.py
+++ b/tests/test_grad_reduce_dtype.py
@@ -100,7 +100,7 @@ def _assert_no_pre_cast_redistribution(
                 continue
             dv = opt._resolve_decision_var(key)
             validated_pre_cast_keys += 1
-            if key in opt.cluster_links:
+            if node_idx in opt.cluster_links:
                 validated_linked_keys += 1
             assert dv.comm_cost == 0, (
                 f"Pre-cast node {opt.nodes[node_idx].name} has chosen decision var "
@@ -265,7 +265,7 @@ def _assert_no_fwd_pre_cast_redistribution(
                 continue
             dv = opt._resolve_decision_var(key)
             validated_keys += 1
-            if key in opt.cluster_links:
+            if node_idx in opt.cluster_links:
                 validated_linked_keys += 1
             assert dv.comm_cost == 0, (
                 f"Forward pre-cast node {opt.nodes[node_idx].name} has chosen "

--- a/tests/test_optimize_placement.py
+++ b/tests/test_optimize_placement.py
@@ -14,6 +14,8 @@ from torch.distributed.tensor.placement_types import Partial, Replicate, Shard
 
 from autoparallel.api import AutoParallel, auto_parallel
 from autoparallel.collectives import local_map
+from autoparallel.optimize_sharding import _skip_enumeration_redistribute_cost
+from autoparallel.shardings.placement_options import reset_placement_options_cache
 
 
 class FFN(nn.Module):
@@ -183,8 +185,30 @@ def test_optimization_finds_fsdp_and_ddp_1d(device_mesh_1d, high_mem, model_type
 
 
 @apply_cuda_patches
-def test_fast_build_preserves_optimizer_solution(device_mesh_1d):
+def test_fast_build_falls_back_without_torch_cost(monkeypatch):
+    import torch.distributed.tensor._ops.utils as dt_utils
+
+    monkeypatch.delattr(dt_utils, "redistribute_cost")
+    with _skip_enumeration_redistribute_cost(True):
+        pass
+
+
+@apply_cuda_patches
+def test_fast_build_preserves_optimizer_solution(device_mesh_1d, monkeypatch):
+    import torch.distributed.tensor._ops.utils as dt_utils
+
+    original_redistribute_cost = dt_utils.redistribute_cost
+    redistribute_cost_calls = 0
+
+    def counted_redistribute_cost(*args, **kwargs):
+        nonlocal redistribute_cost_calls
+        redistribute_cost_calls += 1
+        return original_redistribute_cost(*args, **kwargs)
+
+    monkeypatch.setattr(dt_utils, "redistribute_cost", counted_redistribute_cost)
+
     def solve(fast_build):
+        reset_placement_options_cache()
         model_fn, input_fn = _make_model_and_input_fn(
             device_mesh_1d, "transformer_block"
         )
@@ -197,13 +221,28 @@ def test_fast_build_preserves_optimizer_solution(device_mesh_1d):
             autop.add_output_constraints([(Shard(0),)])
             autop.add_parameter_memory_constraint(low=None, high=None)
             solution = autop.optimize_placement()
-        return {
-            node.name: tuple(str(p) for p in strategy.output_specs.placements)
-            for node, strategy in solution.items()
-            if not isinstance(strategy.output_specs, (tuple, list))
-        }
+            objective = autop.sharding_optimizer.prob.objective.value()
+        return (
+            {
+                node.name: tuple(str(p) for p in strategy.output_specs.placements)
+                for node, strategy in solution.items()
+                if not isinstance(strategy.output_specs, (tuple, list))
+            },
+            objective,
+        )
 
-    assert solve(True) == solve(False)
+    try:
+        baseline_solution, baseline_objective = solve(False)
+        baseline_calls = redistribute_cost_calls
+        fast_solution, fast_objective = solve(True)
+
+        assert baseline_calls > 0
+        assert redistribute_cost_calls == baseline_calls
+        assert dt_utils.redistribute_cost is counted_redistribute_cost
+        assert fast_solution == baseline_solution
+        assert fast_objective == pytest.approx(baseline_objective)
+    finally:
+        reset_placement_options_cache()
 
 
 _expected_param_placements_ffn = [(Shard(0), Shard(0)), (Shard(0), Shard(1))]

--- a/tests/test_optimize_placement.py
+++ b/tests/test_optimize_placement.py
@@ -164,7 +164,6 @@ def test_optimization_finds_fsdp_and_ddp_1d(device_mesh_1d, high_mem, model_type
         assert p.output_specs.placements == (Shard(0),)
         # weight is replicated, mimicing DDP
         assert p.input_specs[1].placements == (Replicate(),)
-
     # bwd grad weight
     # For mm: [N, B*S] @ [B*S, K] → batch dim is at position 1 for input 0
     # For einsum: bsn,bsk->nk → batch dim is at position 0 for both inputs
@@ -181,6 +180,30 @@ def test_optimization_finds_fsdp_and_ddp_1d(device_mesh_1d, high_mem, model_type
         assert p.input_specs[0].placements == (Shard(0),)
         assert p.output_specs.placements == (Shard(0),)
         assert p.input_specs[1].placements == (Replicate(),)
+
+
+@apply_cuda_patches
+def test_fast_build_preserves_optimizer_solution(device_mesh_1d):
+    def solve(fast_build):
+        model_fn, input_fn = _make_model_and_input_fn(
+            device_mesh_1d, "transformer_block"
+        )
+        with torch.device("meta"):
+            model = model_fn()
+        with AutoParallel(
+            model, input_fn, device_mesh_1d, fast_build=fast_build
+        ) as autop:
+            autop.add_input_constraints([(Shard(0),)])
+            autop.add_output_constraints([(Shard(0),)])
+            autop.add_parameter_memory_constraint(low=None, high=None)
+            solution = autop.optimize_placement()
+        return {
+            node.name: tuple(str(p) for p in strategy.output_specs.placements)
+            for node, strategy in solution.items()
+            if not isinstance(strategy.output_specs, (tuple, list))
+        }
+
+    assert solve(True) == solve(False)
 
 
 _expected_param_placements_ffn = [(Shard(0), Shard(0)), (Shard(0), Shard(1))]
@@ -844,3 +867,36 @@ def test_remove_node_constraint_restores_memory_budget(device_mesh_1d):
         # With memory budget enforced and no node constraint, the optimizer
         # should shard this param again
         assert solution[orig_node].output_specs.placements == (Shard(0),)
+
+
+@apply_cuda_patches
+def test_invalid_strategies_are_pruned(device_mesh_2d):
+    """Infinite-cost (invalid) strategy edges must not be materialized as
+    variables or constraints, and pruning them must not change the optimum."""
+    import math
+
+    mesh = device_mesh_2d
+    model_fn, input_fn = _make_model_and_input_fn(mesh, "transformer_block")
+    with torch.device("meta"):
+        model = model_fn()
+
+    with AutoParallel(model, input_fn, mesh) as autop:
+        autop.add_input_constraints([(Shard(0), Replicate())])
+        autop.add_output_constraints([(Shard(0), Replicate())])
+        autop.add_parameter_memory_constraint(low=None, high=None)
+        opt = autop.sharding_optimizer
+
+        # Invariant: every materialized decision var is finite-cost, and the
+        # PuLP variable set is exactly the set of valid (finite) keys.
+        assert all(math.isfinite(dv.cost) for dv in opt.decision_vars.values())
+        assert set(opt.pulp_variables) == opt._valid_keys
+        assert all(k in opt._valid_keys for k in opt.decision_vars)
+
+        # No inf-cost (== 0) constraints should be emitted any more.
+        assert not any(name.startswith("inf_cases") for name in opt.prob.constraints)
+
+        # The pruned problem must still solve to a valid solution.
+        solution = autop.optimize_placement()
+        param_nodes = get_param_nodes(autop.gm.graph)
+        for node in param_nodes:
+            assert node in solution

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -6,6 +6,8 @@
 import json
 import tempfile
 
+import pulp
+import pytest
 import torch
 from conftest import apply_cuda_patches
 from torch import nn
@@ -86,8 +88,6 @@ def test_resolve_target_aten_op():
 
 
 def test_resolve_target_unknown_raises():
-    import pytest
-
     with pytest.raises(RuntimeError, match="Cannot resolve"):
         _resolve_target("nonexistent.op.name")
 
@@ -158,6 +158,7 @@ def test_save_load_preserves_solution(device_mesh_1d):
         autop.add_output_constraints([(Shard(0),)])
         opt = autop.sharding_optimizer
         opt.get_solution()
+        objective = pulp.value(opt.prob.objective)
 
     with tempfile.NamedTemporaryFile(suffix=".ap") as f:
         opt.save(f.name)
@@ -165,6 +166,33 @@ def test_save_load_preserves_solution(device_mesh_1d):
 
     assert hasattr(loaded, "selected_keys")
     assert len(loaded.selected_keys) > 0
+    assert loaded.prob.status == pulp.LpStatusOptimal
+    assert loaded.prob.sol_status == pulp.LpSolutionOptimal
+    assert all(var.varValue in (0.0, 1.0) for var in loaded.pulp_variables.values())
+    assert pulp.value(loaded.prob.objective) == pytest.approx(objective)
+    assert all(constraint.valid() for constraint in loaded.prob.constraints.values())
+    assert loaded.get_log()
+
+
+@apply_cuda_patches
+def test_save_load_preserves_unsolved_state(device_mesh_1d):
+    dim = 64
+    with torch.device("meta"):
+        model = _SimpleModel(dim)
+
+    autop = _setup_autop(model, dim, device_mesh_1d)
+    with autop:
+        autop.add_input_constraints([(Shard(0),)])
+        autop.add_output_constraints([(Shard(0),)])
+        opt = autop.sharding_optimizer
+
+    with tempfile.NamedTemporaryFile(suffix=".ap") as f:
+        opt.save(f.name)
+        loaded = type(opt).load(f.name)
+
+    assert not hasattr(loaded, "selected_keys")
+    assert loaded.prob.status == pulp.LpStatusNotSolved
+    assert loaded.get_solution()
 
 
 @apply_cuda_patches


### PR DESCRIPTION
## Summary

First PR in the PR519 review stack. It speeds up optimizer construction and reduces the ILP representation while preserving the ILP problem and objective: duplicate DTensor redistribution work is skipped, invalid decision edges are pruned, repeated-subgraph links are stored at node granularity, and serialization preserves the compact form.

This PR contains no LP, TRW-S, lazy-build, or split-dimension seed implementation.

## Interface

```python
autop = AutoParallel(
    model,
    input_fn,
    mesh,
    fast_build=True,
)
```

- `fast_build=True` skips redistribution costs during DTensor strategy enumeration because AutoParallel recomputes those costs when it constructs the optimizer problem.
- `fast_build=False` retains full DTensor enumeration for A/B validation.
- Enumeration is assumed to be non-concurrent within one Python process. The scoped Torch override is restored in `finally`; separate worker processes have independent module state.
- The former `AP_FAST_BUILD` environment variable is removed.

## Correctness validation

Focused cold-cache A/B and Torch compatibility regressions:

```bash
PYTHONPATH=. python -m pytest -q \
  tests/test_optimize_placement.py -k fast_build
```

Result at restacked final head `ad9ebabd111d6d85de329ac1c2c1d7396a6efe20`: `2 passed, 19 deselected`. The test clears the placement-options cache before both runs, verifies that only the non-fast path calls the original Torch cost function, checks restoration after the fast path, and compares the optimizer objective and placement assignment on the existing transformer-block model.

Related optimizer and serialization suites:

```bash
PYTHONPATH=. python -m pytest -q \
  tests/test_optimize_placement.py \
  tests/test_serialization.py \
  tests/test_export_json.py \
  tests/test_grad_reduce_dtype.py
```

Result: `48 passed`.

Full suite command:

```bash
PYTHONPATH=. python -m pytest -q tests
```

Changed-file checks:

```bash
black --check \
  autoparallel/optimize_sharding.py \
  tests/test_optimize_placement.py \
  tests/search_profile.py
isort --check-only --profile black \
  autoparallel/optimize_sharding.py \
  tests/test_optimize_placement.py \
  tests/search_profile.py
flake8 \
  autoparallel/optimize_sharding.py \
  tests/test_optimize_placement.py \
  tests/search_profile.py
mypy --ignore-missing-imports --scripts-are-modules --pretty \
  autoparallel/optimize_sharding.py \
  tests/test_optimize_placement.py \
  tests/search_profile.py
git diff --check
```

All changed-file checks pass. The PR CI runs the repository-wide checks and CUDA test jobs on the final head.

## Search-only reproduction

The checked-in harness is `tests/search_profile.py`. It uses the repository's LLaMA3 and DeepSeekV3 example models on `meta`, PyTorch's fake process group, and explicit H100 properties. It measures placement search and host RSS, not distributed model execution.

Run the following from a clean disposable worktree. The harness is read from the final PR head while `PYTHONPATH` resolves AutoParallel from each pinned revision, so neither measured worktree is modified:

```bash
set -euo pipefail

HARNESS_COMMIT=ad9ebabd111d6d85de329ac1c2c1d7396a6efe20
BASELINE=e2bcd4720da66d3bcd2bad2e7bb62359ea478a2c
CANDIDATE=392d4b4cfac815058eadbdeb7f99e87efd71fd56
RESULTS_DIR=../pr520-results
mkdir -p "$RESULTS_DIR"

run_profile() {
  commit="$1"
  label="$2"
  shift 2

  git switch --detach "$commit"
  git show "${HARNESS_COMMIT}:tests/search_profile.py" |
    PYTHONPATH=. PYTHONHASHSEED=0 /usr/bin/time -v \
      -o "${RESULTS_DIR}/${label}.time.txt" \
      timeout --signal=TERM --kill-after=30s 20m \
      python - "$@" --solver ilp --detailed-solution \
        --revision-label "$commit" \
        --output "${RESULTS_DIR}/${label}.json"
}

run_profile "$CANDIDATE" candidate_llama1b --model llama1b --mesh 8,8
run_profile "$CANDIDATE" candidate_llama8b --model llama8b --mesh 8,8
run_profile "$CANDIDATE" candidate_dsv3 --model dsv3 --moe-layout 2d
run_profile "$BASELINE" baseline_llama1b --model llama1b --mesh 8,8
run_profile "$BASELINE" baseline_llama8b --model llama8b --mesh 8,8
run_profile "$BASELINE" baseline_dsv3 --model dsv3 --moe-layout 2d
```

Each JSON records the expanded model and mesh config, environment, measured Git revision/status, constraints, solver status, objective, placement hash, node/variable counts, phase timings, process peak RSS, detailed placements, and component cost contributions.

### Environment and settings

- Python 3.12.13, PyTorch `2.14.0.dev20260629+cu130`, CUDA 13.0, PuLP 3.3.2.
- AMD EPYC 9654 host; GNU `time -v` supplies the reported peak RSS.
- `PYTHONHASHSEED=0`, `torch.manual_seed(0)`, ILP, repeated subgraphs, parameter `bfloat16`, reduction `float32`, and identical memory/input/output constraints.
- Fake H100: capability 9.0, 80 GiB, 132 SMs, 50 MiB L2, eight reported local devices; fake-process-group world size 64.
- LLaMA1B `(8,8)`: dim 2048, 16 layers, 32 heads, 8 KV heads, FFN multiplier 1.5, FFN multiple 256, RoPE theta 500000, vocab 128256, sequence 2048, global batch 16. Mesh axes are `(dp,tp)`; input is `(Shard(0),Replicate())` and output is `(Shard(0),Shard(2))`.
- LLaMA8B `(8,8)`: dim 4096, 32 layers, 32 heads, 8 KV heads, FFN multiplier 1.3, FFN multiple 1024; remaining settings and placements match LLaMA1B.
- DSv3 `(8,8)`: dim 256, 6 layers (1 dense), 16 heads, 64 experts, vocab 2048, sequence 2048, global batch 512; degrees `(8,8,1,1,8)` for `(dp_replicate,dp_shard,cp,tp,ep)`. Input and output are `Shard(0)` on both mesh axes.

The candidate jobs were run before the baseline jobs. Each row is one deterministic observation; no run-to-run variance was collected. Trace, build/enter, ILP solve, and search total use `time.perf_counter`. Build/enter is `enter_total - graph_trace`.

## Search-only results

| Workload | Revision | Trace | Build/enter | ILP solve | Search total | Peak RSS | Variables | Constraints | Objective |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|
| LLaMA1B | PR514@e2bcd47 | 6.214s | 29.766s | 82.001s | 117.981s | 3.261 GiB | 501409 | 184398 | 71178.582224 |
| LLaMA1B | candidate | 6.066s | 12.992s | 71.560s | 90.617s | 1.838 GiB | 349861 | 30061 | 71178.582224 |
| LLaMA8B | PR514@e2bcd47 | 12.223s | 36.555s | 72.240s | 121.019s | 4.574 GiB | 507914 | 188741 | 257769.291686 |
| LLaMA8B | candidate | 12.233s | 17.822s | 79.227s | 109.282s | 2.765 GiB | 355184 | 33222 | 257769.291686 |
| DSv3 | PR514@e2bcd47 | 14.969s | 40.119s | 37.637s | 92.725s | 3.383 GiB | 726826 | 273723 | 45680.574430 |
| DSv3 | candidate | 14.825s | 17.961s | 28.372s | 61.159s | 2.158 GiB | 502891 | 45216 | 45680.574430 |

| Workload | Build/enter speedup | Search speedup | RSS reduction | Placement difference |
|---|---:|---:|---:|---|
| LLaMA1B | 2.29x | 1.30x | 43.6% | 15/4299 equal-cost `view` placements |
| LLaMA8B | 2.05x | 1.11x | 39.5% | identical |
| DSv3 | 2.23x | 1.52x | 36.2% | 10/2288 equal-cost `permute` placements |

All objectives are identical. LLaMA1B changes 15 `view.default` outputs from `(Shard(0),Shard(2))` to `(Shard(0),Partial(sum))`. DSv3 changes five `(Partial,Partial)` `permute` outputs to `(Shard(1),Shard(1))` and five to `(Shard(0),Shard(0))`. These are alternative equal-cost optima. LLaMA8B is identical.

The single LLaMA8B ILP solve was 9.7% slower after construction; with no repetitions this is not attributed to the feature. The measured claims are the 2.05-2.29x candidate build/enter speedup and 36.2-43.6% candidate host-RSS reduction. Final-head commits after the pinned candidate restore serialization state and add compatibility/regression coverage; the final head was not reprofiled, so the table is explicitly evidence for the pinned candidate.

Authored with Claude.

## Stack

- **1/4: this PR**
- 2/4: #521
- 3/4: #522
- 4/4: #523
- Aggregate index only: #519

