### PR TITLE
Build TRW-S costs lazily without PuLP

### DIFF
--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -235,9 +235,13 @@ class AutoParallel:
         mesh: Defines placement options.
         The meta model is moved to a fake device based on mesh.device_type.
         fast_build: Skip DTensor enumeration costs that AutoParallel recomputes.
+        lazy_costs: Compute approximate-solver costs on demand. Only supported
+            with ``solver="approx"``; ``False`` retains eager costs for A/B checks.
     """
 
-    # Selectable solvers over the eagerly built optimizer problem.
+    # Selectable solvers. "ilp": exact PuLP/CBC. "approx": heuristic TRW-S
+    # (light build, no PuLP). "lp": LP relaxation used directly as the solve
+    # (empirically integral for this problem, so much cheaper than CBC).
     SOLVER_CHOICES = ("ilp", "approx", "lp")
 
     def __init__(
@@ -252,12 +256,21 @@ class AutoParallel:
         repeated_subgraphs: bool = True,
         fast_build: bool = True,
         solver: str = "ilp",
+        lazy_costs: Optional[bool] = None,
     ):
         self.stack = ExitStack()
+        # The solver chosen here decides how the optimizer is built: "ilp"/"lp"
+        # build the full PuLP problem (CBC exact solve / LP relaxation solve);
+        # "approx" builds a lighter optimizer (no PuLP variables/constraints),
+        # much faster to construct, solved heuristically. optimize_placement(
+        # solver=...) may override the solve as long as it is compatible with
+        # this build.
         if solver not in self.SOLVER_CHOICES:
             raise ValueError(
                 f"Unknown solver={solver!r}; expected one of {self.SOLVER_CHOICES}"
             )
+        if lazy_costs is True and solver != "approx":
+            raise ValueError("lazy_costs=True requires solver='approx'")
         self.solver = solver
         self.fake_mode = (
             FakeTensorMode()
@@ -270,6 +283,10 @@ class AutoParallel:
         self.cost_model = cost_model
         self.repeated_subgraphs = repeated_subgraphs
         self.fast_build = fast_build
+        # None => default per solver: approx builds lazy (no eager per-edge cost
+        # estimation; the TRW-S solver computes costs on demand), ilp/lp build
+        # eager (a PuLP objective needs the costs). True/False forces lazy/eager.
+        self.lazy_costs = lazy_costs
         # copy user model to avoid modifying it in-place
         # in dtype casting and move_to_fake
         model = copy.deepcopy(model)
@@ -337,6 +354,12 @@ class AutoParallel:
                 force_grad_reduce_in_higher_precision,
                 repeated_subgraphs=self.repeated_subgraphs,
                 fast_build=self.fast_build,
+                build_pulp=self.solver in ("ilp", "lp"),
+                build_costs=(
+                    (self.solver != "approx")
+                    if self.lazy_costs is None
+                    else (not self.lazy_costs)
+                ),
             )
 
             self.sharding_optimizer = sharding_optimizer
@@ -424,12 +447,15 @@ class AutoParallel:
         solver selects how the placement is solved (defaults to the solver chosen
         at AutoParallel construction):
           - "ilp":    exact PuLP/CBC solve.
-          - "approx": heuristic TRW-S ApproximateShardingSolver.
+          - "approx": heuristic TRW-S ApproximateShardingSolver — trades a small
+            objective gap for a much faster solve.
           - "lp":     solve the LP relaxation and use it directly. This problem is
             empirically integral, so the relaxation optimum equals the ILP optimum
             while skipping branch-and-bound; raises if it comes out fractional.
         approximate_options is forwarded as kwargs to the approximate solver
-        (e.g. candidate_limit, max_sweeps).
+        (e.g. candidate_limit, max_sweeps). The requested solver must be
+        compatible with how the optimizer was built: "ilp"/"lp" need a PuLP
+        problem (build with solver="ilp" or "lp").
 
         optimality_check: after solving, solve the LP relaxation as a lower bound
         and log the certified gap of the achieved objective from the optimum.
@@ -450,8 +476,20 @@ class AutoParallel:
             approx = ApproximateShardingSolver(opt, **(approximate_options or {}))
             self.sharding_placement = approx.get_solution(verbose=verbose)
         elif solver == "ilp":
+            if opt.prob is None:
+                raise RuntimeError(
+                    "solver='ilp' requires a PuLP problem, but this AutoParallel "
+                    "was constructed without one (e.g. solver='approx'). "
+                    "Construct with solver='ilp' to use the exact solver."
+                )
             self.sharding_placement = opt.get_solution(verbose=False)
         elif solver == "lp":
+            if opt.prob is None:
+                raise RuntimeError(
+                    "solver='lp' requires a PuLP problem, but this AutoParallel "
+                    "was constructed without one (e.g. solver='approx'). "
+                    "Construct with solver='lp' or 'ilp' to use the LP solver."
+                )
             opt._set_objective()
             res = opt.solve_lp_relaxation(verbose=verbose, extract=True)
             if res["solution"] is None:

--- a/autoparallel/approximate_sharding.py
+++ b/autoparallel/approximate_sharding.py
@@ -21,8 +21,14 @@ from typing import Any, Optional
 
 import numpy as np
 import pulp
+import torch
+from torch.distributed.tensor._dtensor_spec import DTensorSpec
+from torch.distributed.tensor.placement_types import Replicate, Shard
 
-from .cost_models.compute_estimation import _get_sharded_shape_stride
+from .cost_models.compute_estimation import (
+    _get_sharded_shape_stride,
+    estimate_strategy_runtime_cost,
+)
 from .optimize_sharding import _INVALID_COST
 
 logger = logging.getLogger(__name__)
@@ -115,6 +121,18 @@ class ApproximateShardingSolver:
         self.max_star_children = max_star_children
         self.group_domain_limit = group_domain_limit
 
+        # Lazy build: the optimizer was built with build_costs=False, so no
+        # DecisionVars / edge costs exist. We compute the comm/compute costs that
+        # TRW-S touches on demand (memoized) instead of reading opt.decision_vars.
+        self._lazy = not getattr(optimizer, "build_costs", True)
+        # (root v, argi, out_v, out_p) -> (comm_cost, transition_cost)
+        self._edge_cache: dict[tuple, tuple] = {}
+        self._compute_cache: dict[tuple, float] = {}  # (root v, out) -> per-arg compute
+        # Nodes whose redistribution must be forbidden because they precede a
+        # downcasting dtype_cast (the lazy analogue of the per-key dtype forbidden
+        # the eager build stamps); populated in _topology_direct.
+        self._pre_cast_nodes: set[int] = set()
+
         # Populated by _build_problem().
         self.cost_bearing: list[int] = []
         self.node_mult: dict[int, int] = {}
@@ -172,9 +190,16 @@ class ApproximateShardingSolver:
                 max((g.domain for g in self.groups), default=0),
             )
 
-        # max_time_s bounds TRW-S and polish, not factor construction.
+        # max_time_s bounds the *solve* (TRW-S + polish), so start the clock after
+        # the build. In the lazy build the per-edge costs are computed during
+        # _build_factors (not up front), which can exceed max_time_s on large
+        # meshes; measuring the deadline from t0 would then starve TRW-S of any
+        # sweeps and decode a near-random assignment.
         deadline = t_bf + self.max_time_s
-        # Initialize with TRW-S, then polish the assignment with local search.
+        # TRW-S init, then local-search polish. TRW-S reaches the exact MAP on the
+        # (integral) sharding problem, so the old greedy second candidate it used
+        # to be compared against is strictly dominated and has been dropped; the
+        # polish remains for the memory budget and as a local-search safety net.
         t_bp0 = time.perf_counter()
         mem = self._memory
         if mem is not None and not mem.get("tight"):
@@ -286,7 +311,11 @@ class ApproximateShardingSolver:
             self.allowed_out[opt.node_map[node]] = list(range(len(strat.strategies)))
 
         t = time.perf_counter()
-        paired_edges, authoritative = self._parse_constraints()
+        if opt.prob is None:
+            # Lite build: no PuLP problem was constructed, derive topology directly.
+            paired_edges, authoritative = self._topology_direct()
+        else:
+            paired_edges, authoritative = self._parse_constraints()
         # Flow edges are taken from the ILP's output_input_consistent constraints
         # (the authoritative producer per consumer-arg), NOT from _all_input_nodes:
         # the two disagree for some ops (einsum list-args, alias/backward nodes),
@@ -425,8 +454,214 @@ class ApproximateShardingSolver:
                 self.allowed_out[n] = [o for o in self.allowed_out[n] if o in out_set]
         return paired_edges, authoritative
 
+    def _topology_direct(self):
+        """Compute the same topology (forbidden / out_idx restrictions / paired
+        edges / flow producers) that _parse_constraints extracts, but directly
+        from the graph + cluster_links + _constraint_log, WITHOUT a PuLP problem.
+        This lets the optimizer skip building millions of PuLP variables and
+        constraints when only the approximate solver is used.
+
+        Mirrors ShardingOptimizer.add_inf_cost_constraint /
+        add_grad_reduce_dtype_constraints / add_forward_backward_consistency_constraints /
+        _add_paired_output_constraint / add_node_constraint /
+        add_output_input_consistent_constraint. Verified byte-identical to
+        _parse_constraints on a full build (see tests)."""
+        from torch._functorch._aot_autograd.fx_utils import (
+            get_param_and_grad_nodes,
+            get_plain_input_and_grad_nodes,
+            get_plain_output_and_tangent_nodes,
+        )
+
+        opt = self.opt
+        cl = opt.cluster_links  # node-level: copy node idx -> root node idx
+
+        def rootkey(k):
+            return opt._cluster_root_key(k)
+
+        cluster_linked = set(cl)
+        node_root = dict(cl)
+
+        def nroot(idx):
+            return node_root.get(idx, idx)
+
+        # 1. inf-cost forbidden (== add_inf_cost_constraint).
+        for key, dv in opt.decision_vars.items():
+            if not math.isfinite(dv.cost) or dv.cost == 10000.0:
+                self.forbidden.add(key)
+
+        # 2a. forward param-dtype forbidden (== add_grad_reduce_dtype_constraints
+        #     forward part, unconditional). Force the FSDP allgather to run after
+        #     a downcasting param dtype_cast (in the smaller param_dtype) by
+        #     forbidding any pre-cast redistribution.
+        cast_op = torch.ops.autoparallel.dtype_cast.default
+        fwd_pre_cast: set[int] = set()
+        for param, _grad in get_param_and_grad_nodes(opt.graph).values():
+            n = param
+            while True:
+                if n.target == cast_op:
+                    break
+                users = list(n.users.keys())
+                if len(users) != 1:
+                    break
+                child = users[0]
+                if len(child.all_input_nodes) != 1:
+                    break
+                n = child
+            if n.target != cast_op:
+                continue
+            if n.meta["val"].dtype.itemsize >= param.meta["val"].dtype.itemsize:
+                continue  # only constrain downcasts
+            node = n
+            while node != param:
+                if node in opt.node_map:
+                    fwd_pre_cast.add(opt.node_map[node])
+                node = node.all_input_nodes[0]
+        # In the lazy build there are no decision_vars to stamp, so record the
+        # pre-cast nodes; the lazy edge provider forbids their redistributions.
+        self._pre_cast_nodes.update(fwd_pre_cast)
+        for key, dv in opt.decision_vars.items():
+            if key[0] in fwd_pre_cast and dv.comm_cost > 0:
+                self.forbidden.add(key)
+
+        # 2. grad-reduce-dtype (backward) forbidden
+        #    (== add_grad_reduce_dtype_constraints backward part).
+        if getattr(opt, "force_grad_reduce_in_higher_precision", False):
+            cast_op = torch.ops.autoparallel.dtype_cast.default
+            pre_cast: set[int] = set()
+            for param, grad in get_param_and_grad_nodes(opt.graph).values():
+                if grad is None:
+                    continue
+                chain = [grad]
+                n = grad
+                while len(n.all_input_nodes) == 1:
+                    parent = n.all_input_nodes[0]
+                    if len(parent.all_input_nodes) != 1:
+                        break
+                    chain.append(parent)
+                    n = parent
+                cast_idx = next(
+                    (i for i, nd in enumerate(chain) if nd.target == cast_op), None
+                )
+                if cast_idx is None:
+                    continue
+                for nd in chain[cast_idx:]:
+                    if nd in opt.node_map:
+                        pre_cast.add(opt.node_map[nd])
+            self._pre_cast_nodes.update(pre_cast)
+            for key, dv in opt.decision_vars.items():
+                if key[0] in pre_cast and dv.comm_cost > 0:
+                    self.forbidden.add(key)
+
+        # 3. forward/backward paired output constraints + disables
+        #    (== add_forward_backward_consistency_constraints / _add_paired_output_constraint).
+        paired_edges: list[tuple[int, int, frozenset]] = []
+
+        def add_paired(node_a, node_b):
+            idx_a, idx_b = opt.node_map[node_a], opt.node_map[node_b]
+            strat_a = [str(s.output_specs) for s in opt.strats[node_a].strategies]
+            strat_b = [str(s.output_specs) for s in opt.strats[node_b].strategies]
+            num_inp_a = len(opt.strats[node_a].strategies[0].redistribute_cost[0])
+            for out_idx, sp in enumerate(strat_a):
+                if sp not in strat_b:
+                    for inp in range(num_inp_a):
+                        self.forbidden.add(rootkey((idx_a, 0, out_idx, inp)))
+                    continue
+                out_idx_b = strat_b.index(sp)
+                ra = rootkey((idx_a, 0, out_idx, 0))[0]
+                rb = rootkey((idx_b, 0, out_idx_b, 0))[0]
+                paired_edges.append((ra, rb, frozenset({(out_idx, out_idx_b)})))
+
+        for param, grad in get_param_and_grad_nodes(opt.graph).values():
+            if grad is not None:
+                add_paired(param, grad)
+        for node, gnode in get_plain_input_and_grad_nodes(opt.graph).values():
+            if gnode is not None:
+                add_paired(node, gnode)
+        for node, tnode in get_plain_output_and_tangent_nodes(opt.graph).values():
+            if tnode is not None:
+                add_paired(node, tnode)
+
+        # 4. user node/input/output placement restrictions (== add_node_constraint),
+        #    replayed from _constraint_log.
+        restrict: dict[int, set] = {}
+        for fname, kwargs in getattr(opt, "_constraint_log", []):
+            if fname != "add_node_constraint":
+                continue
+            node = next(
+                (nd for nd in opt.nodes if nd.name == kwargs["node_name"]), None
+            )
+            if node is None or node not in opt.strats:
+                continue
+            placement = kwargs["placement"]
+            if placement is None:
+                placement = (Shard(0),) + (Replicate(),) * (opt.mesh.ndim - 1)
+            out_set = set()
+            for i, s in enumerate(opt.strats[node].strategies):
+                specs = s.output_specs
+                if isinstance(specs, DTensorSpec):
+                    if specs.placements == placement:
+                        out_set.add(i)
+                elif isinstance(specs, (list, tuple)):
+                    for spec in specs:
+                        if isinstance(spec, DTensorSpec):
+                            if spec.placements == placement:
+                                out_set.add(i)
+                            break
+            r = nroot(opt.node_map[node])
+            restrict[r] = restrict.get(r, out_set) & out_set
+        for n_idx, out_set in restrict.items():
+            if n_idx in self.allowed_out:
+                self.allowed_out[n_idx] = [
+                    o for o in self.allowed_out[n_idx] if o in out_set
+                ]
+
+        # 5. flow producers (== add_output_input_consistent_constraint): for each
+        #    consumer-arg, the set of (cluster-resolved) producers feeding it.
+        authoritative: dict[tuple[int, int], set] = {}
+        for node in opt.graph.nodes:
+            if node.op == "output" or node not in opt.node_map:
+                continue
+            p_idx = opt.node_map[node]
+            p_linked = p_idx in cluster_linked
+            p_root = nroot(p_idx)
+            for user in node.users:
+                if user.op == "output" or user not in opt.node_map:
+                    continue
+                u_idx = opt.node_map[user]
+                if p_linked and u_idx in cluster_linked:
+                    continue
+                ain = opt._all_input_nodes(user)
+                argi = next((i for i, x in enumerate(ain) if x is node), None)
+                if argi is None:
+                    continue
+                ispecs = opt.strats[user].strategies[0].input_specs
+                if argi < len(ispecs) and ispecs[argi] is None:
+                    continue
+                authoritative.setdefault((nroot(u_idx), argi), set()).add(p_root)
+
+        return paired_edges, authoritative
+
     def _is_forbidden(self, key) -> bool:
-        """Return whether constraints or invalid-cost pruning removed an edge."""
+        """A strategy edge is forbidden if a constraint ruled it out OR it was
+        pruned for infinite cost. Pruning removes such keys from decision_vars
+        entirely (see ShardingOptimizer._build_decision_vars), so a key missing
+        from decision_vars is just as forbidden as one in ``self.forbidden``.
+
+        In the lazy build there are no decision_vars, so an infinite-cost edge
+        (an invalid redistribution, which the eager build prunes out of
+        decision_vars) is discovered by computing the edge cost on demand and
+        checking finiteness — same notion of forbidden, just learned lazily.
+        Keeping this in sync with the eager pruning is what lets _out_fully_
+        forbidden and candidate pruning drop the same infeasible strategies."""
+        if self._lazy:
+            if key in self.forbidden:
+                return True
+            v, argi, ov, op = key
+            p = self._arg_prod.get(v, {}).get(argi)
+            if p is None:
+                return False  # producer-less arg: 0-cost dummy, never infinite
+            comm, _trans = self._edge_cost(v, argi, ov, op, p)
+            return not math.isfinite(comm)
         return key in self.forbidden or key not in self.opt.decision_vars
 
     def _surviving_dv(self, v, argi, o):
@@ -595,6 +830,8 @@ class ApproximateShardingSolver:
             group.choices = [group.choices[ci] for ci in sorted(keep)]
 
     def _choice_lower_bound(self, v, node, o):
+        if self._lazy:
+            return self._choice_lower_bound_lazy(v, node, o)
         opt = self.opt
         strat = opt.strats[node].strategies[o]
         mult = self.node_mult[v]
@@ -661,7 +898,12 @@ class ApproximateShardingSolver:
         }
 
     def _param_ratio(self, v, node, o):
-        spec = self._surviving_dv(v, 0, o).input_spec
+        if self._lazy:
+            # input_specs[0] is the param's own (redistributed) spec, identical to
+            # the eager _surviving_dv(v, 0, o).input_spec but without decision_vars.
+            spec = self.opt.strats[node].strategies[o].input_specs[0]
+        else:
+            spec = self._surviving_dv(v, 0, o).input_spec
         new_shape, _ = _get_sharded_shape_stride(spec)
         return math.prod(new_shape) / math.prod(spec.tensor_meta.shape)
 
@@ -714,9 +956,125 @@ class ApproximateShardingSolver:
         self.nbrs = [sorted(s) for s in nbr_set]
 
     # ------------------------------------------------------------------ #
+    # Lazy cost provider (build_costs=False): compute on demand, memoized.
+    # These mirror the eager readers below but call the cost estimators
+    # directly instead of reading opt.decision_vars (which is empty).
+    # ------------------------------------------------------------------ #
+    def _compute_cost(self, m, o):
+        """Per-arg compute cost of node m at output strategy o, matching the
+        eager per_arg_compute = estimate_strategy_runtime_cost / num_args."""
+        ck = (m, o)
+        c = self._compute_cache.get(ck)
+        if c is not None:
+            return c
+        node = self.opt.nodes[m]
+        strats = self.opt.strats[node].strategies
+        num_args = max(len(strats[0].input_specs), 1)
+        c = estimate_strategy_runtime_cost(node, strats[o]) / num_args
+        self._compute_cache[ck] = c
+        return c
+
+    def _edge_cost(self, v, argi, ov, op, p):
+        """(comm_cost, transition_cost) for the edge feeding consumer v's arg
+        argi from producer p, with v at output ov and p at output op. Computed
+        via the same estimator the eager build uses (opt._compute_edge_costs) and
+        memoized. comm is INF for an infeasible redistribution or one forbidden
+        because v precedes a downcasting dtype_cast (lazy analogue of the eager
+        per-key dtype/inf pruning)."""
+        ck = (v, argi, ov, op)
+        cached = self._edge_cache.get(ck)
+        if cached is not None:
+            return cached
+        opt = self.opt
+        node = opt.nodes[v]
+        strat = opt.strats[node].strategies[ov]
+        redist = strat.redistribute_cost[argi]
+        default = redist[op] if op < len(redist) else 0.0
+        prod_strat = opt.strats[opt.nodes[p]]
+        comm, trans = opt._compute_edge_costs(
+            node, strat, argi, op, default, prod_strat
+        )
+        if comm > 0 and v in self._pre_cast_nodes:
+            comm = INF
+        result = (comm, trans)
+        self._edge_cache[ck] = result
+        return result
+
+    def _self_cost_vec_lazy(self, m, out_indices):
+        node = self.opt.nodes[m]
+        strats = self.opt.strats[node].strategies
+        out = np.empty(len(out_indices))
+        for i, o in enumerate(out_indices):
+            # Producer-less args contribute 0 comm/transition in the fast build
+            # (their redistribute_cost is the 0.0 enumeration dummy), so the self
+            # cost is just the per-strategy compute over all args.
+            out[i] = self._compute_cost(m, o) * len(strats[o].redistribute_cost)
+        return out
+
+    def _edge_matrix_lazy(self, v, argi, p):
+        opt = self.opt
+        Kv = len(opt.strats[opt.nodes[v]].strategies)
+        Kp = len(opt.strats[opt.nodes[p]].strategies)
+        R = np.full((Kv, Kp), BIG)
+        gv = self.node_to_group[v]
+        gp = self.node_to_group[p]
+        ov_vals = sorted({c[v] for c in self.groups[gv].choices})
+        op_vals = sorted({c[p] for c in self.groups[gp].choices})
+        for ov in ov_vals:
+            for op in op_vals:
+                if (v, argi, ov, op) in self.forbidden:
+                    continue  # constraint-forbidden; infinite-cost => finite check
+                comm, trans = self._edge_cost(v, argi, ov, op, p)
+                if math.isfinite(comm):
+                    R[ov, op] = comm + trans
+        return R
+
+    def _choice_lower_bound_lazy(self, v, node, o):
+        strat = self.opt.strats[node].strategies[o]
+        mult = self.node_mult[v]
+        lb = self._compute_cost(v, o) * len(strat.redistribute_cost) * mult
+        # Include the cheapest feasible comm+transition per producer arg so lazy
+        # candidate ranking is identical to eager ranking.
+        for argi, p in self.input_edges.get(v, []):
+            best = INF
+            for op in range(len(strat.redistribute_cost[argi])):
+                if self._is_forbidden((v, argi, o, op)):
+                    continue
+                comm, trans = self._edge_cost(v, argi, o, op, p)
+                if math.isfinite(comm):
+                    best = min(best, comm + trans)
+            if math.isfinite(best):
+                lb += mult * best
+        return lb
+
+    def _total_objective_lazy(self):
+        total = 0.0
+        for v in self.cost_bearing:
+            node = self.opt.nodes[v]
+            o = self.cur_out[v]
+            strat = self.opt.strats[node].strategies[o]
+            prod = self._arg_prod.get(v, {})
+            n_args = len(strat.redistribute_cost)
+            c = self._compute_cost(v, o) * n_args
+            for argi in range(n_args):
+                p = prod.get(argi)
+                if p is None:
+                    continue  # producer-less arg: 0 comm/transition (fast build)
+                inp = self.cur_out[p]
+                if self._is_forbidden((v, argi, o, inp)):
+                    return INF
+                comm, trans = self._edge_cost(v, argi, o, inp, p)
+                if not math.isfinite(comm):
+                    return INF
+                c += comm + trans
+            total += self.node_mult[v] * c
+        return total
+
     def _self_cost_vec(self, m, out_indices):
         """Vectorized self-cost (compute + producer-less arg costs) for node m
         over an array of out_idx."""
+        if self._lazy:
+            return self._self_cost_vec_lazy(m, out_indices)
         opt = self.opt
         node = opt.nodes[m]
         prod = self._arg_prod.get(m, {})
@@ -747,6 +1105,8 @@ class ApproximateShardingSolver:
         """Raw (Kv, Kp) edge cost matrix R[o_v][o_p] = comm + transition, BIG when
         the (o_v, o_p) combination is forbidden. Only entries that can actually be
         indexed by the group choices are filled; the rest are BIG."""
+        if self._lazy:
+            return self._edge_matrix_lazy(v, argi, p)
         opt = self.opt
         Kv = len(opt.strats[opt.nodes[v]].strategies)
         Kp = len(opt.strats[opt.nodes[p]].strategies)
@@ -1236,6 +1596,8 @@ class ApproximateShardingSolver:
     def total_objective(self):
         """Exact objective of the current assignment via decision_vars (for
         verification); equals pulp.value(prob.objective) after write-back."""
+        if self._lazy:
+            return self._total_objective_lazy()
         total = 0.0
         for v in self.cost_bearing:
             node = self.opt.nodes[v]
@@ -1256,8 +1618,10 @@ class ApproximateShardingSolver:
 
     def _write_back(self):
         opt = self.opt
-        for var in opt.pulp_variables.values():
-            var.varValue = 0
+        has_pulp = bool(opt.pulp_variables)
+        if has_pulp:
+            for var in opt.pulp_variables.values():
+                var.varValue = 0
         selected = []
         feasible = True
         for v in self.cost_bearing:
@@ -1271,20 +1635,29 @@ class ApproximateShardingSolver:
                 key = (v, argi, o, inp)
                 if self._is_forbidden(key):
                     feasible = False
-                if key in opt.pulp_variables:
+                # A pruned key has no PuLP variable; the infeasible flag above
+                # already records it (and raises in _solve).
+                if has_pulp and key in opt.pulp_variables:
                     opt.pulp_variables[key].varValue = 1
                 selected.append(key)
         opt.selected_keys = list(selected)
         for rk in selected:
             opt.selected_keys.extend(opt._linked_option_keys(rk))
-        opt._set_objective()
-        self._violated_constraints = [
-            name
-            for name, constraint in opt.prob.constraints.items()
-            if not constraint.valid(1e-6)
-        ]
-        feasible = feasible and not self._violated_constraints
-        if feasible:
-            opt.prob.status = pulp.LpStatusNotSolved
-            opt.prob.sol_status = pulp.LpSolutionIntegerFeasible
+        # Populate prob.objective (when a PuLP problem exists) so callers can also
+        # score via pulp.value(prob.objective); the returned value uses the
+        # equivalent but cheaper total_objective(). In the lite (no-PuLP) build,
+        # there is no problem to populate.
+        if opt.prob is not None:
+            opt._set_objective()
+            self._violated_constraints = [
+                name
+                for name, constraint in opt.prob.constraints.items()
+                if not constraint.valid(1e-6)
+            ]
+            feasible = feasible and not self._violated_constraints
+            if feasible:
+                opt.prob.status = pulp.LpStatusNotSolved
+                opt.prob.sol_status = pulp.LpSolutionIntegerFeasible
+        else:
+            self._violated_constraints = []
         return INF if not feasible else self.total_objective()

--- a/autoparallel/approximate_sharding.py
+++ b/autoparallel/approximate_sharding.py
@@ -5,11 +5,10 @@
 
 """Approximate sharding solver.
 
-Reduces the sharding ILP (see :mod:`optimize_sharding`) to a pairwise MRF over the
-per-node output-strategy indices and solves it with tree-reweighted message passing
-(TRW-S) plus local-search polish, replacing only the CBC/ILP *solve*. It reuses the
-strategies / decision variables / constraints built by ``ShardingOptimizer`` and writes
-its assignment back into the PuLP variables, so it is scored by ``pulp.value(prob.objective)``.
+Reduces the sharding problem to a pairwise MRF over per-node output-strategy
+indices and solves it with tree-reweighted message passing (TRW-S) plus
+local-search polish. It can either reuse eagerly built costs and PuLP constraints
+or derive constraint topology and compute costs on demand without building PuLP.
 """
 
 import logging
@@ -486,7 +485,7 @@ class ApproximateShardingSolver:
 
         # 1. inf-cost forbidden (== add_inf_cost_constraint).
         for key, dv in opt.decision_vars.items():
-            if not math.isfinite(dv.cost) or dv.cost == 10000.0:
+            if not math.isfinite(dv.cost) or dv.cost == _INVALID_COST:
                 self.forbidden.add(key)
 
         # 2a. forward param-dtype forbidden (== add_grad_reduce_dtype_constraints

--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -1463,7 +1463,10 @@ class ShardingOptimizer:
         unconstrained optimum."""
         memory_names = {"memory_constraint_high", "memory_constraint_low"}
         for name in names:
-            del self.prob.constraints[name]
+            if self.prob is not None:
+                del self.prob.constraints[name]
+            elif name not in memory_names:
+                raise RuntimeError("Named constraint removal requires an ILP/LP build")
             self._node_constraint_names.pop(name, None)
             if name in memory_names:
                 self._memory_constraint = None
@@ -2132,7 +2135,7 @@ class ShardingOptimizer:
         if self._memory_constraint is None:
             return
         if self.prob is None:
-            return  # approx (lite) build reads the factors from _constraint_log
+            return  # approx-only builds read the active memory state directly
         memory_factor_low, memory_factor_high = self._memory_constraint
 
         # Remove previous memory constraints before rebuilding

--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -272,9 +272,25 @@ class ShardingOptimizer:
         force_grad_reduce_in_higher_precision=False,
         repeated_subgraphs=False,
         fast_build=True,
+        build_pulp=True,
+        build_costs=True,
     ):
         self.orig_gm = gm
         self.fast_build = fast_build
+        # When False, skip building the per-edge decision-var costs (Phase A of
+        # _build_decision_vars, the comm-cost estimate over millions of edges that
+        # dominates build). Strategies + cluster_links are still built; the
+        # approximate solver computes the costs it needs on demand (lazy build),
+        # only for the branches TRW-S actually touches. Implies build_pulp=False
+        # (a PuLP problem needs the costs in its objective).
+        self.build_costs = build_costs
+        # When False, skip creating PuLP variables and constraints entirely.
+        # decision_var costs + strategies + cluster_links are still built, which
+        # is all the approximate solver needs (it derives the constraint topology
+        # directly). This avoids constructing millions of PuLP objects on large /
+        # 3D meshes, where that dominates build time.
+        self.build_pulp = build_pulp and build_costs
+        self.prob = None
         # The optimizer works on a concretized copy of the graph where all
         # symbolic shapes are replaced with their concrete hint values. This
         # centralizes dynamic-shape handling: the optimization pipeline
@@ -333,8 +349,9 @@ class ShardingOptimizer:
         t1 = time.perf_counter()
         self.validate()
         t2 = time.perf_counter()
-        self.prob = pulp.LpProblem("AutoParallel", pulp.LpMinimize)
-        self.add_default_constraints()
+        if self.build_pulp:
+            self.prob = pulp.LpProblem("AutoParallel", pulp.LpMinimize)
+            self.add_default_constraints()
         t3 = time.perf_counter()
         self.profile["timings"].update(
             {
@@ -344,7 +361,7 @@ class ShardingOptimizer:
                 "init_total_s": t3 - t_init_start,
             }
         )
-        n_constraints = len(self.prob.constraints)
+        n_constraints = len(self.prob.constraints) if self.prob is not None else 0
         logger.info(
             "ShardingOptimizer: build done in %.3fs (%d unique vars, %d decision "
             "vars, %d constraints)",
@@ -599,7 +616,14 @@ class ShardingOptimizer:
         the optimum unchanged while removing ~30% of the variables and the
         corresponding ~80% of constraints that are pure ``var == 0`` bounds.
 
+        When ``build_pulp`` is False (approximate solver only) no PuLP variables
+        are created (``DecisionVar.var`` is None); the valid-key set is still
+        built so the approximate solver can treat a key absent from
+        ``decision_vars`` as forbidden.
         """
+        if not self.build_costs:
+            return self._build_decision_vars_lazy()
+
         # Precompute which node indices are cluster-linked so we can
         # copy costs from the root instead of recomputing them.
         self._cluster_linked_node_idxs = set(self.cluster_links)
@@ -654,12 +678,15 @@ class ShardingOptimizer:
                             continue
 
                         key = (node_idx, argi, out_idx, inp_idx)
-                        var = pulp.LpVariable(
-                            f"n={node},s={node_idx},arg={argi},"
-                            f"output_p={out_idx},input_p={inp_idx}",
-                            cat=pulp.LpBinary,
-                        )
-                        self.pulp_variables[key] = var
+                        if self.build_pulp:
+                            var = pulp.LpVariable(
+                                f"n={node},s={node_idx},arg={argi},"
+                                f"output_p={out_idx},input_p={inp_idx}",
+                                cat=pulp.LpBinary,
+                            )
+                            self.pulp_variables[key] = var
+                        else:
+                            var = None
                         self._valid_keys.add(key)
                         decision_vars[key] = DecisionVar(
                             var=var,
@@ -711,6 +738,25 @@ class ShardingOptimizer:
         self.profile["timings"]["cost_estimation_s"] = t_compute + t_edge
         return decision_vars
 
+    def _build_decision_vars_lazy(self):
+        """Lazy build (build_costs=False): skip the expensive per-edge cost
+        estimation (Phase A) and the DecisionVar/PuLP materialization (Phase B).
+
+        Strategies, cluster_links and the redistribute_cost *shape* (the
+        enumeration dummies) are preserved, which is all the approximate solver
+        needs to derive the topology; it computes the comm/compute costs it
+        actually uses on demand. Returns an empty decision_vars dict — callers
+        that read it (the approx solver) must route through their lazy provider.
+        """
+        self._cluster_linked_node_idxs = set(self.cluster_links)
+        self.pulp_variables = {}
+        self._valid_keys = None
+        self._root_to_copies = defaultdict(list)
+        for copy_idx, root_idx in self.cluster_links.items():
+            self._root_to_copies[root_idx].append(copy_idx)
+        self.profile["timings"]["cost_estimation_s"] = 0.0
+        return {}
+
     def _compute_node_edge_costs(self, node_idx):
         """Compute per-edge costs for one root node."""
         node = self.nodes[node_idx]
@@ -754,9 +800,24 @@ class ShardingOptimizer:
         node_idx, argi, out_idx, _ = key
         strategy = self.strats[self.nodes[node_idx]].strategies[out_idx]
         root_key = self._cluster_root_key(key)
-        root_dv = self.decision_vars[root_key]
+        root_dv = self.decision_vars.get(root_key)
+        if root_dv is None:
+            # Lazy build (build_costs=False): no DecisionVars were materialized.
+            # The approximate solver scores via its own lazy cost provider; here
+            # only .strategy / specs are needed (solution extraction), so the
+            # cost fields are zero placeholders.
+            return DecisionVar(
+                var=None,
+                cost=0.0,
+                compute_cost=0.0,
+                comm_cost=0.0,
+                sharding_transition_cost=0.0,
+                strategy=strategy,
+                output_spec=strategy.output_specs,
+                input_spec=strategy.input_specs[argi],
+            )
         return DecisionVar(
-            var=self._get_pulp_variable(key),
+            var=self._get_pulp_variable(key) if self.pulp_variables else None,
             cost=root_dv.cost,
             compute_cost=root_dv.compute_cost,
             comm_cost=root_dv.comm_cost,
@@ -1541,6 +1602,8 @@ class ShardingOptimizer:
     # ---- Logging ----
 
     def get_violated_constraints_log(self):
+        if self.prob is None:
+            return "Violated constraints: [] (no PuLP problem; lite build)"
         violated_constraints = [
             (k, c) for k, c in self.prob.constraints.items() if not c.valid()
         ]
@@ -2068,6 +2131,8 @@ class ShardingOptimizer:
         """
         if self._memory_constraint is None:
             return
+        if self.prob is None:
+            return  # approx (lite) build reads the factors from _constraint_log
         memory_factor_low, memory_factor_high = self._memory_constraint
 
         # Remove previous memory constraints before rebuilding
@@ -2144,6 +2209,8 @@ class ShardingOptimizer:
             raise RuntimeError(
                 f"Couldn't find appropriate constraint {node} {constraint_name} {placement}"
             )
+        if self.prob is None:
+            return []  # approx (lite) build replays this from _constraint_log
         names = self._add_node_constraint(
             node,
             output_constraint_indices=output_constraint_indices,

--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -1676,7 +1676,7 @@ class ShardingOptimizer:
     # ---- Serialization ----
 
     def save(self, path):
-        """Save the full optimizer state for later interactive exploration."""
+        """Save the full ILP/LP optimizer state for interactive exploration."""
         from autoparallel.serialization import save_optimizer
 
         save_optimizer(self, path)

--- a/autoparallel/serialization.py
+++ b/autoparallel/serialization.py
@@ -102,13 +102,20 @@ _SAVE_META_KEYS = {
 
 
 def save_optimizer(opt, path):
-    """Save the full optimizer state for later interactive exploration.
+    """Save a full ILP/LP optimizer state for later interactive exploration.
 
     The saved file contains everything needed to rebuild the ILP and
     re-solve without the original model code, DeviceMesh, or process group.
     Can be called before or after solving — if unsolved, the loaded
     optimizer can be solved in a notebook via get_solution() or resolve().
+    Approximate-only builds should use save_placements() instead.
     """
+    if opt.prob is None:
+        raise RuntimeError(
+            "Full optimizer serialization requires an ILP/LP build; "
+            "use save_placements() for an approximate-only optimizer."
+        )
+
     import copy
 
     import numpy as np

--- a/tests/search_profile.py
+++ b/tests/search_profile.py
@@ -76,6 +76,7 @@ def parse_args(argv=None):
     parser.add_argument("--mesh", help="Comma-separated LLaMA mesh dimensions")
     parser.add_argument("--moe-layout", choices=("2d",))
     parser.add_argument("--solver", choices=AutoParallel.SOLVER_CHOICES, required=True)
+    parser.add_argument("--lazy-costs", choices=("true", "false"))
     parser.add_argument("--revision-label", required=True)
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--detailed-solution", action="store_true")
@@ -312,6 +313,8 @@ def cpu_model():
 
 
 def validate_args(args):
+    if args.lazy_costs is not None and args.solver != "approx":
+        raise ValueError("--lazy-costs is supported only with --solver approx")
     if args.model == "dsv3":
         if args.moe_layout != "2d" or args.mesh is not None:
             raise ValueError("dsv3 requires --moe-layout 2d and no --mesh")
@@ -398,6 +401,9 @@ def main(argv=None):
                 repeated_subgraphs=True,
                 dynamic=args.model == "dsv3",
                 solver=args.solver,
+                lazy_costs=(
+                    None if args.lazy_costs is None else args.lazy_costs == "true"
+                ),
             )
             enter_started = time.perf_counter()
             stack.enter_context(autop)
@@ -447,17 +453,28 @@ def main(argv=None):
             )
 
             fingerprint, solution_nodes = solution_fingerprint(solution)
-            objective = finite(pulp.value(opt.prob.objective))
-            violations = [
-                name
-                for name, constraint in opt.prob.constraints.items()
-                if not constraint.valid(1e-6)
-            ]
-            pulp_status = pulp.LpStatus.get(opt.prob.status, str(opt.prob.status))
-            solution_status = pulp.LpSolution.get(
-                getattr(opt.prob, "sol_status", None),
-                str(getattr(opt.prob, "sol_status", None)),
-            )
+            objective = finite(solver_profile["objective"])
+            violations = []
+            pulp_status = None
+            solution_status = None
+            if opt.prob is not None:
+                objective = finite(pulp.value(opt.prob.objective))
+                violations = [
+                    name
+                    for name, constraint in opt.prob.constraints.items()
+                    if not constraint.valid(1e-6)
+                ]
+                pulp_status = pulp.LpStatus.get(opt.prob.status, str(opt.prob.status))
+                solution_status = pulp.LpSolution.get(
+                    getattr(opt.prob, "sol_status", None),
+                    str(getattr(opt.prob, "sol_status", None)),
+                )
+            elif args.solver == "approx":
+                solution_status = (
+                    "Solution Found"
+                    if solver_profile["status"] == "Heuristic"
+                    else "No Solution Found"
+                )
             validation = {
                 "solver_status": solver_profile["status"],
                 "pulp_status": pulp_status,
@@ -477,7 +494,9 @@ def main(argv=None):
                         "strategy_nodes": len(opt.strats),
                         "decision_vars": len(opt.decision_vars),
                         "pulp_variables": len(opt.pulp_variables),
-                        "constraints": len(opt.prob.constraints),
+                        "constraints": (
+                            len(opt.prob.constraints) if opt.prob is not None else 0
+                        ),
                         "selected_keys": len(opt.selected_keys),
                     },
                 }
@@ -492,12 +511,13 @@ def main(argv=None):
             )
 
             if args.detailed_solution:
-                contributions = cost_contributions(opt)
                 result["solution_detail"] = solution_details(solution, autop.gm.graph)
-                result["cost_contributions"] = contributions
-                result["cost_contribution_sum"] = sum(
-                    row["total"] for row in contributions
-                )
+                if opt.decision_vars:
+                    contributions = cost_contributions(opt)
+                    result["cost_contributions"] = contributions
+                    result["cost_contribution_sum"] = sum(
+                        row["total"] for row in contributions
+                    )
             result["status"] = "success"
     except Exception as error:
         result["error"] = {

--- a/tests/search_profile.py
+++ b/tests/search_profile.py
@@ -111,8 +111,12 @@ def fake_cuda_context(stack):
 def make_llama(model_name, mesh_shape):
     from autoparallel._testing.models.llama3 import Transformer, TransformerModelArgs
 
-    if len(mesh_shape) != 2:
-        raise ValueError(f"PR521 LLaMA profiles require a 2D mesh, got {mesh_shape}")
+    names = {
+        2: ("dp", "tp"),
+        3: ("dp", "cp", "tp"),
+    }.get(len(mesh_shape))
+    if names is None:
+        raise ValueError(f"LLaMA profiles require a 2D or 3D mesh, got {mesh_shape}")
     seq_len = 2048
     vocab_size = 128256
     config = {
@@ -123,17 +127,16 @@ def make_llama(model_name, mesh_shape):
     }
     with torch.device("meta"):
         model = Transformer(TransformerModelArgs(**config))
-    names = ("dp", "tp")
     mesh = torch.distributed.device_mesh.init_device_mesh(
         "cuda", mesh_shape, mesh_dim_names=names
     )
-    batch_size = 2 * mesh_shape[0]
+    batch_size = 16
 
     def input_fn():
         return torch.randint(0, vocab_size, (batch_size, seq_len), device="cuda")
 
-    input_placement = (Shard(0), Replicate())
-    output_placement = (Shard(0), Shard(2))
+    input_placement = (Shard(0),) + (Replicate(),) * (len(mesh_shape) - 1)
+    output_placement = (Shard(0), Shard(2)) if len(mesh_shape) == 2 else input_placement
     expanded = {
         "family": "llama3",
         "config": config,
@@ -322,6 +325,8 @@ def validate_args(args):
     if args.mesh is None or args.moe_layout is not None:
         raise ValueError("LLaMA requires --mesh and no --moe-layout")
     mesh_shape = tuple(int(part) for part in args.mesh.split(","))
+    if len(mesh_shape) not in (2, 3):
+        raise ValueError(f"LLaMA requires a 2D or 3D mesh, got {mesh_shape}")
     world_size = math.prod(mesh_shape)
     if world_size != 64:
         raise ValueError(f"world size must be 64, got {world_size}")

--- a/tests/test_optimize_placement.py
+++ b/tests/test_optimize_placement.py
@@ -993,3 +993,93 @@ def test_approx_uses_active_cost_and_memory_state(device_mesh_2d):
         assert solution
         assert solver._memory is None
         assert all(name not in opt.prob.constraints for name in memory_names)
+
+
+@apply_cuda_patches
+def test_approx_lazy_build_matches_eager_example(device_mesh_2d, tmp_path):
+    mesh = device_mesh_2d
+
+    def solve(lazy_costs):
+        reset_placement_options_cache()
+        model_fn, input_fn = _make_model_and_input_fn(mesh, "transformer_block")
+        with torch.device("meta"):
+            model = model_fn()
+
+        with AutoParallel(
+            model,
+            input_fn,
+            mesh,
+            solver="approx",
+            lazy_costs=lazy_costs,
+        ) as autop:
+            autop.add_input_constraints([(Shard(0), Replicate())])
+            autop.add_output_constraints([(Shard(0), Replicate())])
+            autop.add_parameter_memory_constraint(low=None, high=None)
+            opt = autop.sharding_optimizer
+
+            if not lazy_costs:
+                baseline = ApproximateShardingSolver(opt)
+                baseline._build_problem()
+                key = next(
+                    key
+                    for key in opt.decision_vars
+                    if key not in baseline.forbidden
+                    and key[2] in baseline.allowed_out[key[0]]
+                )
+                original_cost = opt.decision_vars[key].cost
+                opt.decision_vars[key].cost = 10000.0
+                valid_solver = ApproximateShardingSolver(opt)
+                valid_solver._build_problem()
+                assert key not in valid_solver.forbidden
+                opt.decision_vars[key].cost = original_cost
+
+            solution = autop.optimize_placement(verbose=False)
+
+            assert solution
+            assert opt.prob is None
+            assert not opt.pulp_variables
+            assert bool(opt.decision_vars) is not lazy_costs
+
+            selected_keys = set(opt.selected_keys)
+            objective = opt.profile["approximate"]["objective"]
+
+            if lazy_costs:
+                opt.remove_constraints(
+                    ["memory_constraint_high", "memory_constraint_low"]
+                )
+                no_memory_solver = ApproximateShardingSolver(opt)
+                assert no_memory_solver.get_solution(verbose=False)
+                assert no_memory_solver._memory is None
+
+                with pytest.raises(RuntimeError, match="requires an ILP/LP build"):
+                    opt.save(tmp_path / "optimizer.ap")
+                placements = tmp_path / "placements.json"
+                opt.save_placements(placements)
+                assert opt.load_placements(placements)
+
+            return selected_keys, objective
+
+    try:
+        eager_keys, eager_objective = solve(False)
+        lazy_keys, lazy_objective = solve(True)
+        assert lazy_keys == eager_keys
+        assert lazy_objective == pytest.approx(eager_objective, rel=1e-9)
+    finally:
+        reset_placement_options_cache()
+
+
+@apply_cuda_patches
+@pytest.mark.parametrize("solver", ["ilp", "lp"])
+def test_lazy_costs_requires_approx_solver(device_mesh_2d, solver):
+    model_fn, input_fn = _make_model_and_input_fn(device_mesh_2d, "transformer_block")
+    with torch.device("meta"):
+        model = model_fn()
+
+    with pytest.raises(ValueError, match="lazy_costs=True requires solver='approx'"):
+        AutoParallel(
+            model,
+            input_fn,
+            device_mesh_2d,
+            solver=solver,
+            lazy_costs=True,
+        )

--- a/tests/test_search_profile.py
+++ b/tests/test_search_profile.py
@@ -78,6 +78,27 @@ def test_validate_search_profile_args_rejects_invalid_combinations(values):
         validate_args(_args(*values))
 
 
+def test_validate_search_profile_args_rejects_lazy_non_approx():
+    args = parse_args(
+        [
+            "--model",
+            "llama1b",
+            "--mesh",
+            "8,8",
+            "--solver",
+            "ilp",
+            "--lazy-costs",
+            "true",
+            "--revision-label",
+            "test",
+            "--output",
+            "unused.json",
+        ]
+    )
+    with pytest.raises(ValueError, match="only with --solver approx"):
+        validate_args(args)
+
+
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -161,6 +182,9 @@ def test_llama1b_approx_search_e2e(tmp_path):
     assert math.isfinite(result["objective"])
     assert result["solution_nodes"] > 0
     assert len(result["placement_sha256"]) == 64
+    assert result["counts"]["decision_vars"] == 0
+    assert result["counts"]["pulp_variables"] == 0
+    assert result["counts"]["constraints"] == 0
     for name in (
         "graph_trace_s",
         "optimizer_init_s",

--- a/tests/test_search_profile.py
+++ b/tests/test_search_profile.py
@@ -307,17 +307,30 @@ class TestRealDsv3SolverE2E(DTensorTestBase):
             )
 
         fingerprint, solution_nodes = solution_fingerprint(solution)
-        objective = finite(pulp.value(opt.prob.objective))
-        violations = [
-            name
-            for name, constraint in opt.prob.constraints.items()
-            if not constraint.valid(1e-6)
-        ]
-        pulp_status = pulp.LpStatus.get(opt.prob.status, str(opt.prob.status))
-        solution_status = pulp.LpSolution.get(
-            getattr(opt.prob, "sol_status", None),
-            str(getattr(opt.prob, "sol_status", None)),
-        )
+        profile_key = "approximate" if solver == "approx" else solver
+        solver_profile = opt.profile[profile_key]
+        objective = finite(solver_profile["objective"])
+        violations = []
+        pulp_status = None
+        solution_status = None
+        if opt.prob is not None:
+            objective = finite(pulp.value(opt.prob.objective))
+            violations = [
+                name
+                for name, constraint in opt.prob.constraints.items()
+                if not constraint.valid(1e-6)
+            ]
+            pulp_status = pulp.LpStatus.get(opt.prob.status, str(opt.prob.status))
+            solution_status = pulp.LpSolution.get(
+                getattr(opt.prob, "sol_status", None),
+                str(getattr(opt.prob, "sol_status", None)),
+            )
+        elif solver == "approx":
+            solution_status = (
+                "Solution Found"
+                if solver_profile["status"] == "Heuristic"
+                else "No Solution Found"
+            )
         validate_solution(
             solver,
             objective,
@@ -326,8 +339,6 @@ class TestRealDsv3SolverE2E(DTensorTestBase):
             pulp_status,
             solution_status,
         )
-        profile_key = "approximate" if solver == "approx" else solver
-        solver_profile = opt.profile[profile_key]
         result = {
             "solver": solver,
             "objective": objective,

--- a/tests/test_search_profile.py
+++ b/tests/test_search_profile.py
@@ -57,6 +57,7 @@ def _args(*values):
     ("values", "expected"),
     [
         (("--model", "llama1b", "--mesh", "8,8"), (64, (8, 8))),
+        (("--model", "llama1b", "--mesh", "2,4,8"), (64, (2, 4, 8))),
         (("--model", "dsv3", "--moe-layout", "2d"), (64, None)),
     ],
 )
@@ -69,6 +70,7 @@ def test_validate_search_profile_args(values, expected):
     [
         ("--model", "llama1b"),
         ("--model", "llama1b", "--mesh", "4,4"),
+        ("--model", "llama1b", "--mesh", "1,1,1,64"),
         ("--model", "llama1b", "--mesh", "8,8", "--moe-layout", "2d"),
         ("--model", "dsv3", "--moe-layout", "2d", "--mesh", "8,8"),
     ],


### PR DESCRIPTION
## Summary

Third PR in the PR519 review stack. For `solver="approx"`, it avoids eager per-edge cost and `DecisionVar` materialization, derives the constraint topology directly, and memoizes complete factor costs on demand. Factor ranking still includes compute, communication, and transition costs. ILP and LP construction remain eager and unchanged.

## Interface

```python
autop = AutoParallel(
    model,
    input_fn,
    mesh,
    solver="approx",
    lazy_costs=None,
)
```

- `solver="approx"`, `lazy_costs=None` or `True`: lazy approximate build with no PuLP problem and no eager decision variables.
- `solver="approx"`, `lazy_costs=False`: eager approximate cost construction for A/B correctness checks; it still does not construct a PuLP problem.
- `solver="ilp"` or `"lp"`: the existing eager PuLP-backed build.
- `lazy_costs=True` with ILP/LP is rejected at construction. Full optimizer serialization also requires an ILP/LP build; approximate-only placements can still be serialized.

The approximate solver reports `Heuristic` / `Solution Found`; it does not misreport global optimality. Removing active memory constraints clears their state in both eager and no-PuLP builds, while the default memory budget remains unchanged when the caller does not remove it.

## Reproduction

The checked-in `tests/search_profile.py` supports the 3D LLaMA configuration used below. It uses the repository LLaMA example, meta tensors, a fake process group, and explicit H100 properties; it measures placement search, not distributed model execution.

```bash
mkdir -p results

# Eager approximate reference
PYTHONPATH=. PYTHONHASHSEED=0 /usr/bin/time -v -o results/eager.time.txt \
  timeout --signal=TERM --kill-after=30s 20m \
  python tests/search_profile.py --model llama1b --mesh 2,4,8 \
  --solver approx --lazy-costs false --detailed-solution \
  --revision-label "$(git rev-parse --short HEAD)" \
  --output results/eager.json

# Default lazy approximate path
PYTHONPATH=. PYTHONHASHSEED=0 /usr/bin/time -v -o results/lazy.time.txt \
  timeout --signal=TERM --kill-after=30s 20m \
  python tests/search_profile.py --model llama1b --mesh 2,4,8 \
  --solver approx --lazy-costs true --detailed-solution \
  --revision-label "$(git rev-parse --short HEAD)" \
  --output results/lazy.json
```

Each JSON records the expanded model/mesh config, environment, Git revision and status, objective, placement hash, optimizer counts, phase timings, and process peak RSS. Lazy mode has no PuLP constraint list; feasibility is represented by the approximate solver status rather than a post-hoc PuLP constraint scan.

## Historical performance

The following is the previously collected single-run result at `829b11720bed03673aefce33161f8912908a3863`. It was not rerun after the stack rebase. The current harness exposes the same model, mesh, and eager/lazy modes, but these numbers should be read as pinned historical evidence, not a current-head benchmark.

Environment: Python 3.12.13, PyTorch `2.14.0.dev20260629+cu130`, CUDA 13.0, PuLP 3.3.2, AMD EPYC 9654 host. The model is LLaMA1B with dim 2048, 16 layers, 32 heads, 8 KV heads, FFN multiplier 1.5, vocab 128256, sequence length 2048, batch 16, parameter `bfloat16`, reduction `float32`, and mesh `(2,4,8)` named `(dp,cp,tp)`. Peak RSS is GNU `time -v` maximum resident set size. Timeout was 20 minutes. There was one deterministic run per mode, so variance is unavailable.

| Mode | Optimizer init | Factor build | TRW-S solve | Search total | Peak RSS |
|---|---:|---:|---:|---:|---:|
| eager | 169.932s | 10.805s | 17.242s | 205.475s | 6.166 GiB |
| lazy | 19.715s | 112.190s | 17.667s | 156.058s | 4.579 GiB |

Observed component deltas were `-150.217s` optimizer initialization, `+101.385s` factor construction, and `+0.425s` TRW-S solve. Search total was 49.417s lower (1.32x), and peak RSS was 1.587 GiB lower (25.7%). Both modes are approximate/no-PuLP builds; the observed difference comes from avoiding eager edge-cost and `DecisionVar` materialization, with required cost work moving into lazy factor construction. No throughput, training latency, or distributed runtime claim is made.

Both historical modes recorded objective `49282.70137059267`, placement SHA-256 `b23e62433fe08ccba75fce1103cd47302987c5a75c0dc5e3ba6bf5391bffb742`, and identical placements for all 4,299 nodes. The 3D LP baseline exceeded the 20-minute cap, so this establishes equality to eager TRW-S, not a certified global optimality gap.

## Correctness validation

At the rebased implementation head, focused coverage compares lazy and eager approximate builds on the existing transformer example, requires equal objectives and selected keys, verifies that valid cost `10000.0` is not treated as forbidden, verifies removal of active memory constraints, checks placement serialization, and rejects lazy ILP/LP construction.

```bash
# Current-head eager/lazy build-state regressions.
PYTHONPATH=. PYTHONHASHSEED=0 python -m pytest -q \
  tests/test_optimize_placement.py::test_approx_lazy_build_matches_eager_example \
  tests/test_optimize_placement.py::test_lazy_costs_requires_approx_solver

# Broad approximate, serialization, profile, and placement coverage.
PYTHONPATH=. PYTHONHASHSEED=0 python -m pytest -q \
  tests/test_approximate_sharding.py tests/test_serialization.py \
  tests/test_search_profile.py tests/test_optimize_placement.py \
  -k "not ilp_and_approx_match"

# Profile harness and its 3D argument subset.
PYTHONPATH=. PYTHONHASHSEED=0 python -m pytest -q \
  tests/test_search_profile.py -k "not ilp_and_approx_match"
PYTHONPATH=. PYTHONHASHSEED=0 python -m pytest -q \
  tests/test_search_profile.py -k validate_search_profile_args
```

Current restacked head: focused build-state regressions `3 passed`. At the pre-restack implementation head `e403a490158e8c519758b11ab70285216950ec7b`, whose PR522 range-diff is unchanged: broad coverage `63 passed, 1 deselected`, profile-harness coverage `17 passed, 1 deselected`, and 3D argument coverage `9 passed, 9 deselected`. Changed-file Black, isort, flake8, mypy, and `git diff --check` passed.

The existing four-GPU DeepSeekV3 ILP-vs-approximate E2E now reads no-PuLP approximate results correctly. It was not executable on the local host and is left to the GitHub multi-GPU job. Repository-wide mypy remains red on the same two pre-existing errors in `autoparallel/tools/overlap_simulator/run.py` as the PR base; changed-file mypy passes.

Authored with Claude.

## Stack

- 1/4: #520
- 2/4: #521
- **3/4: this PR**
- 4/4: #523
- Aggregate index only: #519

