### PR TITLE
Add corrected split-dimension seed search

### DIFF
--- a/autoparallel/__init__.py
+++ b/autoparallel/__init__.py
@@ -7,7 +7,6 @@ from autoparallel.api import AutoParallel, auto_parallel
 from autoparallel.collectives import with_sharding_constraint
 from autoparallel.compile import autoparallel_backend
 from autoparallel.input_validation import ForwardInputs
-from autoparallel.mesh_search import build_split_dim_seed
 from autoparallel.moe import (
     MoEMeshRoles,
     build_moe_local_map_placements,
@@ -23,5 +22,4 @@ __all__ = [
     "build_moe_local_map_placements",
     "build_moe_mesh",
     "with_sharding_constraint",
-    "build_split_dim_seed",
 ]

--- a/autoparallel/__init__.py
+++ b/autoparallel/__init__.py
@@ -7,6 +7,7 @@ from autoparallel.api import AutoParallel, auto_parallel
 from autoparallel.collectives import with_sharding_constraint
 from autoparallel.compile import autoparallel_backend
 from autoparallel.input_validation import ForwardInputs
+from autoparallel.mesh_search import build_split_dim_seed
 from autoparallel.moe import (
     MoEMeshRoles,
     build_moe_local_map_placements,
@@ -22,4 +23,5 @@ __all__ = [
     "build_moe_local_map_placements",
     "build_moe_mesh",
     "with_sharding_constraint",
+    "build_split_dim_seed",
 ]

--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -24,6 +24,7 @@ from torch._logging import trace_structured
 from torch._subclasses import FakeTensorMode
 from torch.distributed.fsdp import MixedPrecisionPolicy
 from torch.distributed.tensor import DeviceMesh
+from torch.distributed.tensor.placement_types import Placement
 from torch.export._trace import _restore_state_dict
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
@@ -256,6 +257,8 @@ class AutoParallel:
         repeated_subgraphs: bool = True,
         fast_build: bool = True,
         solver: str = "ilp",
+        strategy_radius: Optional[int] = None,
+        seed_input_placements: Optional[tuple[Placement, ...]] = None,
         lazy_costs: Optional[bool] = None,
     ):
         self.stack = ExitStack()
@@ -283,6 +286,8 @@ class AutoParallel:
         self.cost_model = cost_model
         self.repeated_subgraphs = repeated_subgraphs
         self.fast_build = fast_build
+        self.strategy_radius = strategy_radius
+        self.seed_input_placements = seed_input_placements
         # None => default per solver: approx builds lazy (no eager per-edge cost
         # estimation; the TRW-S solver computes costs on demand), ilp/lp build
         # eager (a PuLP objective needs the costs). True/False forces lazy/eager.
@@ -348,6 +353,23 @@ class AutoParallel:
                 and self.mp_policy.reduce_dtype.itemsize
                 > self.mp_policy.param_dtype.itemsize
             )
+            strategy_seed = None
+            if self.strategy_radius is not None:
+                assert self.seed_input_placements is not None, (
+                    "strategy_radius requires seed_input_placements "
+                    "(one input placement per mesh dim)"
+                )
+                from .mesh_search import build_split_dim_seed
+
+                strategy_seed = build_split_dim_seed(
+                    self.gm,
+                    tuple(self.mesh.shape),
+                    self.seed_input_placements,
+                    cost_model=self.cost_model,
+                    force_grad_reduce_in_higher_precision=force_grad_reduce_in_higher_precision,
+                    repeated_subgraphs=self.repeated_subgraphs,
+                    fast_build=self.fast_build,
+                )
             sharding_optimizer = ShardingOptimizer(
                 self.gm,
                 self.mesh,
@@ -360,6 +382,8 @@ class AutoParallel:
                     if self.lazy_costs is None
                     else (not self.lazy_costs)
                 ),
+                strategy_seed=strategy_seed,
+                strategy_radius=self.strategy_radius,
             )
 
             self.sharding_optimizer = sharding_optimizer

--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -9,6 +9,7 @@ import logging
 import math
 import operator
 import time
+import warnings
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from functools import partial
@@ -24,7 +25,6 @@ from torch._logging import trace_structured
 from torch._subclasses import FakeTensorMode
 from torch.distributed.fsdp import MixedPrecisionPolicy
 from torch.distributed.tensor import DeviceMesh
-from torch.distributed.tensor.placement_types import Placement
 from torch.export._trace import _restore_state_dict
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
@@ -238,10 +238,11 @@ class AutoParallel:
         fast_build: Skip DTensor enumeration costs that AutoParallel recomputes.
         lazy_costs: Compute approximate-solver costs on demand. Only supported
             with ``solver="approx"``; ``False`` retains eager costs for A/B checks.
-        strategy_radius: Restrict final strategy enumeration to a best-effort
+        strategy_radius: For approximate search on meshes with more than two
+            dimensions, restrict final strategy enumeration to a best-effort
             Hamming ball around independently solved per-dimension placements.
-        seed_input_placements: Input placement used by the per-dimension seed
-            solves. Required with strategy_radius, with one entry per mesh dim.
+            Defaults to 2. Use 0 or None to retain unrestricted search. Values
+            greater than 2 are not recommended because they may be slow.
     """
 
     # Selectable solvers. "ilp": exact PuLP/CBC. "approx": heuristic TRW-S
@@ -261,8 +262,7 @@ class AutoParallel:
         repeated_subgraphs: bool = True,
         fast_build: bool = True,
         solver: str = "ilp",
-        strategy_radius: Optional[int] = None,
-        seed_input_placements: Optional[tuple[Placement, ...]] = None,
+        strategy_radius: Optional[int] = 2,
         lazy_costs: Optional[bool] = None,
     ):
         self.stack = ExitStack()
@@ -278,19 +278,6 @@ class AutoParallel:
             )
         if lazy_costs is True and solver != "approx":
             raise ValueError("lazy_costs=True requires solver='approx'")
-        if (strategy_radius is None) != (seed_input_placements is None):
-            raise ValueError(
-                "strategy_radius and seed_input_placements must be provided together"
-            )
-        if strategy_radius is not None and strategy_radius < 0:
-            raise ValueError("strategy_radius must be non-negative")
-        if (
-            seed_input_placements is not None
-            and len(seed_input_placements) != mesh.ndim
-        ):
-            raise ValueError(
-                "seed_input_placements must contain one placement per mesh dim"
-            )
         self.solver = solver
         self.fake_mode = (
             FakeTensorMode()
@@ -303,8 +290,9 @@ class AutoParallel:
         self.cost_model = cost_model
         self.repeated_subgraphs = repeated_subgraphs
         self.fast_build = fast_build
+        self.mesh = mesh
         self.strategy_radius = strategy_radius
-        self.seed_input_placements = seed_input_placements
+        self._split_dim_search = self._validate_strategy_radius()
         # None => default per solver: approx builds lazy (no eager per-edge cost
         # estimation; the TRW-S solver computes costs on demand), ilp/lp build
         # eager (a PuLP objective needs the costs). True/False forces lazy/eager.
@@ -318,7 +306,6 @@ class AutoParallel:
 
         self.model = move_to_fake(model, self.fake_mode, device)
         self.input_fn = input_fn
-        self.mesh = mesh
         self.compiler_fn = _boxed_nop_preserve_node_meta  # type: ignore[assignment]
         self.reshard_after_forward = reshard_after_forward
 
@@ -328,6 +315,74 @@ class AutoParallel:
 
         # NB: rest of the construction happens in __enter__
         self.active = False
+
+    def _validate_strategy_radius(self) -> bool:
+        if self.solver != "approx" or self.mesh.ndim <= 2:
+            return False
+        radius = self.strategy_radius
+        if radius is None:
+            return False
+        if isinstance(radius, bool) or not isinstance(radius, int):
+            raise ValueError("strategy_radius must be an integer, 0, or None")
+        if radius == 0:
+            return False
+        if radius < 0:
+            raise ValueError("strategy_radius must be non-negative")
+        if radius >= self.mesh.ndim:
+            raise ValueError(
+                "strategy_radius must be smaller than the mesh dimensionality"
+            )
+        if radius > 2:
+            warnings.warn(
+                "strategy_radius values greater than 2 may make approximate "
+                "search slow",
+                UserWarning,
+                stacklevel=2,
+            )
+        return True
+
+    def _new_sharding_optimizer(self, strategy_seed=None):
+        return ShardingOptimizer(
+            self.gm,
+            self.mesh,
+            self.force_grad_reduce_in_higher_precision,
+            repeated_subgraphs=self.repeated_subgraphs,
+            fast_build=self.fast_build,
+            build_pulp=self.solver in ("ilp", "lp"),
+            build_costs=(
+                (self.solver != "approx")
+                if self.lazy_costs is None
+                else (not self.lazy_costs)
+            ),
+            strategy_seed=strategy_seed,
+            strategy_radius=self.strategy_radius if strategy_seed is not None else None,
+        )
+
+    def _build_split_dim_optimizer(self):
+        from .mesh_search import _build_split_dim_seed
+
+        strategy_seed = _build_split_dim_seed(
+            self.gm,
+            tuple(self.mesh.shape),
+            input_constraints=self.input_constraints,
+            output_constraints=self.output_constraints,
+            cost_model=self.cost_model,
+            force_grad_reduce_in_higher_precision=self.force_grad_reduce_in_higher_precision,
+            repeated_subgraphs=self.repeated_subgraphs,
+            fast_build=self.fast_build,
+            device_type=self.mesh.device_type,
+        )
+        self.sharding_optimizer = self._new_sharding_optimizer(strategy_seed)
+        for kind, args in self._pending_constraints:
+            if kind == "parameter_memory":
+                self.sharding_optimizer.add_parameter_memory_constraint(*args)
+            elif kind == "input":
+                self.sharding_optimizer.add_sharded_input_constraint(*args)
+            elif kind == "output":
+                self.sharding_optimizer.add_sharded_output_constraint(*args)
+            else:
+                raise AssertionError(f"Unknown pending constraint kind: {kind}")
+        self._pending_constraints.clear()
 
     def __enter__(self):
         assert self.active is False
@@ -363,50 +418,19 @@ class AutoParallel:
             )
             torch._inductor.config.comprehensive_padding = False
 
-            force_grad_reduce_in_higher_precision = (
+            self.force_grad_reduce_in_higher_precision = (
                 self.mp_policy is not None
                 and self.mp_policy.reduce_dtype is not None
                 and self.mp_policy.param_dtype is not None
                 and self.mp_policy.reduce_dtype.itemsize
                 > self.mp_policy.param_dtype.itemsize
             )
-            strategy_seed = None
-            if (
-                self.strategy_radius is not None
-                and self.seed_input_placements is not None
-            ):
-                from .mesh_search import build_split_dim_seed
-
-                strategy_seed = build_split_dim_seed(
-                    self.gm,
-                    tuple(self.mesh.shape),
-                    self.seed_input_placements,
-                    cost_model=self.cost_model,
-                    force_grad_reduce_in_higher_precision=force_grad_reduce_in_higher_precision,
-                    repeated_subgraphs=self.repeated_subgraphs,
-                    fast_build=self.fast_build,
-                    device_type=self.mesh.device_type,
-                )
-            sharding_optimizer = ShardingOptimizer(
-                self.gm,
-                self.mesh,
-                force_grad_reduce_in_higher_precision,
-                repeated_subgraphs=self.repeated_subgraphs,
-                fast_build=self.fast_build,
-                build_pulp=self.solver in ("ilp", "lp"),
-                build_costs=(
-                    (self.solver != "approx")
-                    if self.lazy_costs is None
-                    else (not self.lazy_costs)
-                ),
-                strategy_seed=strategy_seed,
-                strategy_radius=self.strategy_radius,
-            )
-
-            self.sharding_optimizer = sharding_optimizer
-
             self.input_constraints = None
             self.output_constraints = None
+            self._pending_constraints = []
+            self.sharding_optimizer = (
+                None if self._split_dim_search else self._new_sharding_optimizer()
+            )
 
             self.active = True
 
@@ -457,14 +481,20 @@ class AutoParallel:
 
         assert low <= high, f"low should be <= high, got low{low}, high={high}"
 
-        self.sharding_optimizer.add_parameter_memory_constraint(low, high)
+        if self.sharding_optimizer is None:
+            self._pending_constraints.append(("parameter_memory", (low, high)))
+        else:
+            self.sharding_optimizer.add_parameter_memory_constraint(low, high)
 
     def add_input_constraints(self, constraints):
         self._assert_entered()
 
         assert self.input_constraints is None, "Input constraints have already been set"
-        self.sharding_optimizer.add_sharded_input_constraint(constraints)
         self.input_constraints = constraints
+        if self.sharding_optimizer is None:
+            self._pending_constraints.append(("input", (constraints,)))
+        else:
+            self.sharding_optimizer.add_sharded_input_constraint(constraints)
 
     def add_output_constraints(self, constraints):
         self._assert_entered()
@@ -473,8 +503,11 @@ class AutoParallel:
             self.output_constraints is None
         ), "Output constraints have already been set"
         # forces sharding of fwd output to be S(0) on first dimension and R on others
-        self.sharding_optimizer.add_sharded_output_constraint(constraints)
         self.output_constraints = constraints
+        if self.sharding_optimizer is None:
+            self._pending_constraints.append(("output", (constraints,)))
+        else:
+            self.sharding_optimizer.add_sharded_output_constraint(constraints)
 
     def optimize_placement(
         self,
@@ -509,6 +542,9 @@ class AutoParallel:
             raise ValueError(
                 f"Unknown solver={solver!r}; expected one of {self.SOLVER_CHOICES}"
             )
+
+        if self.sharding_optimizer is None:
+            self._build_split_dim_optimizer()
 
         opt = self.sharding_optimizer
         if solver == "approx":

--- a/autoparallel/api.py
+++ b/autoparallel/api.py
@@ -238,6 +238,10 @@ class AutoParallel:
         fast_build: Skip DTensor enumeration costs that AutoParallel recomputes.
         lazy_costs: Compute approximate-solver costs on demand. Only supported
             with ``solver="approx"``; ``False`` retains eager costs for A/B checks.
+        strategy_radius: Restrict final strategy enumeration to a best-effort
+            Hamming ball around independently solved per-dimension placements.
+        seed_input_placements: Input placement used by the per-dimension seed
+            solves. Required with strategy_radius, with one entry per mesh dim.
     """
 
     # Selectable solvers. "ilp": exact PuLP/CBC. "approx": heuristic TRW-S
@@ -274,6 +278,19 @@ class AutoParallel:
             )
         if lazy_costs is True and solver != "approx":
             raise ValueError("lazy_costs=True requires solver='approx'")
+        if (strategy_radius is None) != (seed_input_placements is None):
+            raise ValueError(
+                "strategy_radius and seed_input_placements must be provided together"
+            )
+        if strategy_radius is not None and strategy_radius < 0:
+            raise ValueError("strategy_radius must be non-negative")
+        if (
+            seed_input_placements is not None
+            and len(seed_input_placements) != mesh.ndim
+        ):
+            raise ValueError(
+                "seed_input_placements must contain one placement per mesh dim"
+            )
         self.solver = solver
         self.fake_mode = (
             FakeTensorMode()
@@ -354,11 +371,10 @@ class AutoParallel:
                 > self.mp_policy.param_dtype.itemsize
             )
             strategy_seed = None
-            if self.strategy_radius is not None:
-                assert self.seed_input_placements is not None, (
-                    "strategy_radius requires seed_input_placements "
-                    "(one input placement per mesh dim)"
-                )
+            if (
+                self.strategy_radius is not None
+                and self.seed_input_placements is not None
+            ):
                 from .mesh_search import build_split_dim_seed
 
                 strategy_seed = build_split_dim_seed(
@@ -369,6 +385,7 @@ class AutoParallel:
                     force_grad_reduce_in_higher_precision=force_grad_reduce_in_higher_precision,
                     repeated_subgraphs=self.repeated_subgraphs,
                     fast_build=self.fast_build,
+                    device_type=self.mesh.device_type,
                 )
             sharding_optimizer = ShardingOptimizer(
                 self.gm,

--- a/autoparallel/approximate_sharding.py
+++ b/autoparallel/approximate_sharding.py
@@ -101,7 +101,7 @@ class ApproximateShardingSolver:
     def __init__(
         self,
         optimizer,
-        candidate_limit: Optional[int] = 64,
+        candidate_limit: Optional[int] = 128,
         bp_iters: int = 400,
         bp_tol: float = 1e-3,
         max_sweeps: int = 12,

--- a/autoparallel/cost_models/nccl_cost_model.py
+++ b/autoparallel/cost_models/nccl_cost_model.py
@@ -80,6 +80,7 @@ class NCCLTopoConfig:
     has_collnet: bool = False  # Enables CollNet Direct/Chain (SHARP)
     # Additional network latency beyond base hw latency (us)
     net_latency: float = 0.0
+    mesh_dim_topo_override: "MeshDimTopo | None" = None
 
 
 @dataclass
@@ -1005,6 +1006,15 @@ def derive_mesh_dim_topo(
 ) -> MeshDimTopo:
     """Derive per-mesh-dimension NCCL topology parameters."""
     dim_size = mesh_shape[dim_idx]
+    if config.mesh_dim_topo_override is not None:
+        if len(mesh_shape) != 1 or dim_idx != 0:
+            raise ValueError("mesh_dim_topo_override can only be used for 1D dim0")
+        if config.mesh_dim_topo_override.n_ranks != dim_size:
+            raise ValueError(
+                "mesh_dim_topo_override.n_ranks must match the 1D mesh size"
+            )
+        return config.mesh_dim_topo_override
+
     inner_product = math.prod(mesh_shape[dim_idx + 1 :])
     ppn = max(1, min(config.gpus_per_node // inner_product, dim_size))
     n_nodes = dim_size // ppn

--- a/autoparallel/mesh_search.py
+++ b/autoparallel/mesh_search.py
@@ -28,6 +28,7 @@ from .cost_models.nccl_cost_model import (
 )
 from .optimize_sharding import ShardingOptimizer
 from .shardings.placement_options import reset_placement_options_cache
+from .shardings.propagation_rules import DTensorSpecSeed, OpSpecSeed, StrategySeed
 
 
 def reset_mesh_search_caches() -> None:
@@ -113,14 +114,110 @@ def _split_dim_seed_cache_key(
     )
 
 
-def _first_output_placements(output_specs) -> tuple[Placement, ...] | None:
+def _spec_to_seed(spec: DTensorSpec | None) -> DTensorSpecSeed | None:
+    if spec is None:
+        return None
+    return DTensorSpecSeed(tuple(spec.placements), spec.tensor_meta)
+
+
+def _op_spec_to_seed(strategy) -> OpSpecSeed:
+    output_specs = strategy.output_specs
+    seeded_outputs: DTensorSpecSeed | tuple[DTensorSpecSeed | None, ...] | None
     if isinstance(output_specs, DTensorSpec):
-        return output_specs.placements
-    if isinstance(output_specs, (tuple, list)):
-        for output_spec in output_specs:
-            if isinstance(output_spec, DTensorSpec):
-                return output_spec.placements
+        seeded_outputs = _spec_to_seed(output_specs)
+    elif isinstance(output_specs, (tuple, list)):
+        seeded_outputs = tuple(_spec_to_seed(spec) for spec in output_specs)
+    else:
+        seeded_outputs = None
+
+    input_specs = strategy.input_specs
+    return OpSpecSeed(
+        output_specs=seeded_outputs,
+        input_specs=(
+            None
+            if input_specs is None
+            else tuple(_spec_to_seed(spec) for spec in input_specs)
+        ),
+    )
+
+
+def _first_seeded_output(seed: OpSpecSeed) -> DTensorSpecSeed | None:
+    output_specs = seed.output_specs
+    if isinstance(output_specs, DTensorSpecSeed):
+        return output_specs
+    if isinstance(output_specs, tuple):
+        return next(
+            (spec for spec in output_specs if isinstance(spec, DTensorSpecSeed)), None
+        )
     return None
+
+
+def _combine_spec_seeds(
+    per_dim: list[DTensorSpecSeed | None],
+) -> tuple[bool, DTensorSpecSeed | None]:
+    if all(spec is None for spec in per_dim):
+        return True, None
+    if any(spec is None for spec in per_dim):
+        return False, None
+
+    specs = [spec for spec in per_dim if spec is not None]
+    if any(len(spec.placements) != 1 for spec in specs):
+        return False, None
+    tensor_meta = specs[0].tensor_meta
+    if any(spec.tensor_meta != tensor_meta for spec in specs[1:]):
+        return False, None
+    return True, DTensorSpecSeed(
+        tuple(spec.placements[0] for spec in specs), tensor_meta
+    )
+
+
+def _combine_output_seeds(
+    per_dim: list[DTensorSpecSeed | tuple[DTensorSpecSeed | None, ...] | None],
+):
+    if all(output is None for output in per_dim):
+        return True, None
+    if all(isinstance(output, DTensorSpecSeed) for output in per_dim):
+        return _combine_spec_seeds(per_dim)  # type: ignore[arg-type]
+    if not all(isinstance(output, tuple) for output in per_dim):
+        return False, None
+
+    outputs = [output for output in per_dim if isinstance(output, tuple)]
+    if not outputs or any(len(output) != len(outputs[0]) for output in outputs[1:]):
+        return False, None
+    combined = []
+    for index in range(len(outputs[0])):
+        valid, spec = _combine_spec_seeds([output[index] for output in outputs])
+        if not valid:
+            return False, None
+        combined.append(spec)
+    return True, tuple(combined)
+
+
+def _combine_op_spec_seeds(per_dim: list[OpSpecSeed]) -> OpSpecSeed | None:
+    valid, output_specs = _combine_output_seeds(
+        [strategy.output_specs for strategy in per_dim]
+    )
+    if not valid:
+        return None
+
+    input_specs = [strategy.input_specs for strategy in per_dim]
+    if all(specs is None for specs in input_specs):
+        combined_inputs = None
+    elif any(specs is None for specs in input_specs):
+        return None
+    else:
+        inputs = [specs for specs in input_specs if specs is not None]
+        if any(len(specs) != len(inputs[0]) for specs in inputs[1:]):
+            return None
+        combined = []
+        for index in range(len(inputs[0])):
+            slot_valid, spec = _combine_spec_seeds([specs[index] for specs in inputs])
+            if not slot_valid:
+                return None
+            combined.append(spec)
+        combined_inputs = tuple(combined)
+
+    return OpSpecSeed(output_specs=output_specs, input_specs=combined_inputs)
 
 
 def _project_placements_to_dim(
@@ -213,11 +310,11 @@ def _build_split_dim_seed(
     repeated_subgraphs: bool = True,
     fast_build: bool = True,
     memory_high_fn: Callable[[int], float] | None = None,
-    one_d_cache: dict[tuple[Any, ...], dict[str, Placement]] | None = None,
+    one_d_cache: dict[tuple[Any, ...], dict[str, OpSpecSeed]] | None = None,
     device_type: str = "cuda",
     fabric_aware: bool = True,
-) -> dict[str, tuple[Placement, ...]]:
-    """Return a per-node placement seed for a target mesh shape.
+) -> dict[str, StrategySeed]:
+    """Return per-node placement centers and complete strategy witnesses.
 
     Args:
         gm: Joint graph to optimize.
@@ -236,7 +333,7 @@ def _build_split_dim_seed(
         fabric_aware: Whether one-dimensional solves use per-dim fabric topology.
 
     Returns:
-        A mapping from FX node name to placement tuple.
+        A mapping from FX node name to its placement center and optional witness.
     """
 
     ndim = len(mesh_shape)
@@ -254,7 +351,7 @@ def _build_split_dim_seed(
             )
         seed_cost_model = detect_nccl_topo_config(full_mesh)
 
-    per_dim: list[dict[str, Placement]] = []
+    per_dim: list[dict[str, OpSpecSeed]] = []
     for dim_idx, size in enumerate(mesh_shape):
         dim_inputs = _project_constraints_to_dim(input_constraints, dim_idx, ndim)
         dim_outputs = _project_constraints_to_dim(output_constraints, dim_idx, ndim)
@@ -300,20 +397,34 @@ def _build_split_dim_seed(
             finally:
                 set_nccl_topo_config(prev)
 
-            node_placements: dict[str, Placement] = {}
+            node_strategies: dict[str, OpSpecSeed] = {}
             for node, strategy in solution.items():
-                placements = _first_output_placements(strategy.output_specs)
-                if placements is not None:
-                    node_placements[node.name] = placements[0]
-            cache[key] = node_placements
+                node_strategies[node.name] = _op_spec_to_seed(strategy)
+            cache[key] = node_strategies
         per_dim.append(cache[key])
 
-    seed: dict[str, tuple[Placement, ...]] = {}
+    seed: dict[str, StrategySeed] = {}
     for node in gm.graph.nodes:
         if node.op == "output":
             continue
-        seed[node.name] = tuple(
-            per_dim[i].get(node.name, Replicate()) for i in range(ndim)
+        output_placements = tuple(
+            (
+                first_output.placements[0]
+                if (strategy := per_dim[i].get(node.name)) is not None
+                and (first_output := _first_seeded_output(strategy)) is not None
+                and len(first_output.placements) == 1
+                else Replicate()
+            )
+            for i in range(ndim)
         )
+        per_dim_witnesses = [
+            strategies[node.name] for strategies in per_dim if node.name in strategies
+        ]
+        witness = (
+            _combine_op_spec_seeds(per_dim_witnesses)
+            if len(per_dim_witnesses) == ndim
+            else None
+        )
+        seed[node.name] = StrategySeed(output_placements, witness)
 
     return seed

--- a/autoparallel/mesh_search.py
+++ b/autoparallel/mesh_search.py
@@ -1,0 +1,295 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import replace
+from typing import Any, Callable, Iterator, cast
+
+import torch
+from torch._subclasses.fake_tensor import unset_fake_temporarily
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor._dtensor_spec import DTensorSpec
+from torch.distributed.tensor.placement_types import Placement, Replicate, Shard
+
+from .cost_models.collective_runtime_estimation import (
+    get_nccl_topo_config,
+    reset_comms_cost_cache,
+    set_nccl_topo_config,
+)
+from .cost_models.compute_estimation import reset_compute_cost_cache
+from .cost_models.nccl_cost_model import (
+    NCCLTopoConfig,
+    derive_mesh_dim_topo,
+    detect_nccl_topo_config,
+)
+from .optimize_sharding import ShardingOptimizer
+from .shardings.placement_options import reset_placement_options_cache
+
+
+def reset_mesh_search_caches() -> None:
+    """Clear mesh-dependent strategy and cost caches."""
+
+    reset_placement_options_cache()
+    reset_comms_cost_cache()
+    reset_compute_cost_cache()
+
+
+def _set_cost_model_for_mesh(mesh, cost_model: Any) -> None:
+    if isinstance(cost_model, NCCLTopoConfig):
+        set_nccl_topo_config(cost_model)
+    elif cost_model == "nccl":
+        set_nccl_topo_config(detect_nccl_topo_config(mesh))
+    else:
+        set_nccl_topo_config(None)
+
+
+def _placement_code(p: Placement) -> str:
+    if isinstance(p, Shard):
+        return f"S{p.dim}"
+    if isinstance(p, Replicate):
+        return "R"
+    return type(p).__name__
+
+
+def _split_dim_seed_dim_cost_model(
+    cost_model: Any,
+    mesh_shape: tuple[int, ...],
+    dim_idx: int,
+    *,
+    fabric_aware: bool,
+) -> Any:
+    if not fabric_aware or not isinstance(cost_model, NCCLTopoConfig):
+        return cost_model
+
+    topo = derive_mesh_dim_topo(cost_model, mesh_shape, dim_idx)
+    return replace(cost_model, mesh_dim_topo_override=topo)
+
+
+def _split_dim_seed_cache_key(
+    size: int,
+    input_placement: Placement,
+    cost_model: Any,
+    mesh_shape: tuple[int, ...],
+    dim_idx: int,
+    *,
+    fabric_aware: bool,
+) -> tuple[Any, ...]:
+    placement = _placement_code(input_placement)
+    if isinstance(cost_model, NCCLTopoConfig):
+        dim_cost_model = _split_dim_seed_dim_cost_model(
+            cost_model, mesh_shape, dim_idx, fabric_aware=fabric_aware
+        )
+        topo = derive_mesh_dim_topo(dim_cost_model, (int(size),), 0)
+        return (
+            "nccl",
+            int(size),
+            placement,
+            tuple(mesh_shape),
+            dim_idx,
+            cost_model.arch.name,
+            cost_model.num_nodes,
+            cost_model.gpus_per_node,
+            cost_model.bw_intra,
+            cost_model.bw_inter,
+            cost_model.num_channels,
+            topo.n_nodes,
+            topo.ppn,
+            topo.bw_intra,
+            topo.bw_inter,
+            topo.n_channels,
+            dim_cost_model.has_nvswitch,
+            dim_cost_model.has_collnet,
+            dim_cost_model.net_latency,
+        )
+    return (str(cost_model), int(size), placement, tuple(mesh_shape), dim_idx)
+
+
+def _first_output_placements(output_specs) -> tuple[Placement, ...] | None:
+    if isinstance(output_specs, DTensorSpec):
+        return output_specs.placements
+    if isinstance(output_specs, (tuple, list)):
+        for output_spec in output_specs:
+            if isinstance(output_spec, DTensorSpec):
+                return output_spec.placements
+    return None
+
+
+def _project_placements_to_dim(
+    placements, dim_idx: int, ndim: int
+) -> tuple[tuple[Placement, ...] | None, ...]:
+    projected: list[tuple[Placement, ...] | None] = []
+    for placement in placements:
+        if placement is None:
+            projected.append(None)
+            continue
+        if isinstance(placement, Placement):
+            if ndim != 1:
+                raise ValueError(
+                    "A scalar local_map placement is only valid for a 1D mesh"
+                )
+            projected.append((placement,))
+            continue
+        if len(placement) != ndim:
+            raise ValueError(
+                f"local_map placement has {len(placement)} entries, expected {ndim}"
+            )
+        projected.append((placement[dim_idx],))
+    return tuple(projected)
+
+
+@contextmanager
+def _project_local_map_to_dim(
+    gm: torch.fx.GraphModule, mesh_1d, dim_idx: int, ndim: int
+) -> Iterator[None]:
+    originals = []
+    try:
+        for node in gm.graph.nodes:
+            local_map_kwargs = node.meta.get("local_map_kwargs")
+            if local_map_kwargs is None:
+                continue
+            projected = dict(local_map_kwargs)
+            projected["in_placements"] = _project_placements_to_dim(
+                local_map_kwargs["in_placements"], dim_idx, ndim
+            )
+            projected["out_placements"] = _project_placements_to_dim(
+                local_map_kwargs["out_placements"], dim_idx, ndim
+            )
+            projected["device_mesh"] = mesh_1d
+            originals.append((node, local_map_kwargs))
+            node.meta["local_map_kwargs"] = projected
+        yield
+    finally:
+        for node, local_map_kwargs in originals:
+            node.meta["local_map_kwargs"] = local_map_kwargs
+
+
+def build_split_dim_seed(
+    gm: torch.fx.GraphModule,
+    mesh_shape: tuple[int, ...],
+    input_placements: tuple[Placement, ...],
+    *,
+    cost_model: Any = "nccl",
+    force_grad_reduce_in_higher_precision: bool = False,
+    repeated_subgraphs: bool = True,
+    fast_build: bool = True,
+    memory_high_fn: Callable[[int], float] | None = None,
+    one_d_cache: dict[tuple[Any, ...], dict[str, Placement]] | None = None,
+    device_type: str = "cuda",
+    fabric_aware: bool = True,
+) -> dict[str, tuple[Placement, ...]]:
+    """Return a per-node placement seed for a target mesh shape.
+
+    Args:
+        gm: Joint graph to optimize.
+        mesh_shape: Target mesh shape.
+        input_placements: Required input placement for each target mesh dim.
+        cost_model: Cost model identifier or NCCL topology config.
+        force_grad_reduce_in_higher_precision: Whether gradient reductions use
+            higher precision costs.
+        repeated_subgraphs: Whether repeated graph regions share decisions.
+        fast_build: Whether one-dimensional solves skip redundant enumeration costs.
+        memory_high_fn: Function returning the parameter memory upper bound for
+            a one-dimensional solve size.
+        one_d_cache: Optional cache reused across calls.
+        device_type: Device mesh type.
+        fabric_aware: Whether one-dimensional solves use per-dim fabric topology.
+
+    Returns:
+        A mapping from FX node name to placement tuple.
+    """
+
+    ndim = len(mesh_shape)
+    if len(input_placements) != ndim:
+        raise ValueError(
+            f"input_placements has {len(input_placements)} entries, expected {ndim}"
+        )
+    if memory_high_fn is None:
+        memory_high_fn = lambda size: 1.0 / size  # noqa: E731
+
+    cache = one_d_cache if one_d_cache is not None else {}
+    seed_cost_model = cost_model
+    if fabric_aware and cost_model == "nccl":
+        with unset_fake_temporarily():
+            full_mesh = init_device_mesh(
+                device_type,
+                mesh_shape,
+                mesh_dim_names=tuple(f"d{i}" for i in range(ndim)),
+            )
+        seed_cost_model = detect_nccl_topo_config(full_mesh)
+
+    per_dim: list[dict[str, Placement]] = []
+    for dim_idx, size in enumerate(mesh_shape):
+        input_placement = input_placements[dim_idx]
+        key = _split_dim_seed_cache_key(
+            int(size),
+            input_placement,
+            seed_cost_model,
+            mesh_shape,
+            dim_idx,
+            fabric_aware=fabric_aware,
+        )
+        if key not in cache:
+            with unset_fake_temporarily():
+                mesh_1d = init_device_mesh(
+                    device_type,
+                    (int(size),),
+                    mesh_dim_names=("d",),
+                )
+            prev = get_nccl_topo_config()
+            try:
+                dim_cost_model = _split_dim_seed_dim_cost_model(
+                    seed_cost_model,
+                    mesh_shape,
+                    dim_idx,
+                    fabric_aware=fabric_aware,
+                )
+                _set_cost_model_for_mesh(mesh_1d, dim_cost_model)
+                reset_mesh_search_caches()
+                with _project_local_map_to_dim(gm, mesh_1d, dim_idx, ndim):
+                    opt = ShardingOptimizer(
+                        gm,
+                        mesh_1d,
+                        force_grad_reduce_in_higher_precision,
+                        repeated_subgraphs=repeated_subgraphs,
+                        fast_build=fast_build,
+                    )
+                    opt.add_sharded_input_constraint([(input_placement,)])
+                    opt.add_sharded_output_constraint([(input_placement,)])
+                    opt.add_parameter_memory_constraint(0.0, memory_high_fn(int(size)))
+                    solution = opt.get_solution()
+            finally:
+                set_nccl_topo_config(prev)
+
+            node_placements: dict[str, Placement] = {}
+            for node, strategy in solution.items():
+                placements = _first_output_placements(strategy.output_specs)
+                if placements is not None:
+                    node_placements[node.name] = placements[0]
+            cache[key] = node_placements
+        per_dim.append(cache[key])
+
+    seed: dict[str, tuple[Placement, ...]] = {}
+    for node in gm.graph.nodes:
+        if node.op == "output":
+            continue
+        seed[node.name] = tuple(
+            per_dim[i].get(node.name, Replicate()) for i in range(ndim)
+        )
+
+    from torch._functorch._aot_autograd.fx_utils import (
+        get_plain_input_and_grad_nodes,
+        get_plain_output_and_tangent_nodes,
+    )
+
+    input_tuple = tuple(input_placements)
+    for getter in (get_plain_input_and_grad_nodes, get_plain_output_and_tangent_nodes):
+        for _desc, (node, companion) in cast(Any, getter(gm.graph)).items():
+            seed[node.name] = input_tuple
+            if companion is not None:
+                seed[companion.name] = input_tuple
+
+    return seed

--- a/autoparallel/mesh_search.py
+++ b/autoparallel/mesh_search.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from dataclasses import replace
-from typing import Any, Callable, Iterator, cast
+from typing import Any, Callable, Iterator
 
 import torch
 from torch._subclasses.fake_tensor import unset_fake_temporarily
@@ -71,14 +71,13 @@ def _split_dim_seed_dim_cost_model(
 
 def _split_dim_seed_cache_key(
     size: int,
-    input_placement: Placement,
+    boundary_placements: tuple[Any, ...],
     cost_model: Any,
     mesh_shape: tuple[int, ...],
     dim_idx: int,
     *,
     fabric_aware: bool,
 ) -> tuple[Any, ...]:
-    placement = _placement_code(input_placement)
     if isinstance(cost_model, NCCLTopoConfig):
         dim_cost_model = _split_dim_seed_dim_cost_model(
             cost_model, mesh_shape, dim_idx, fabric_aware=fabric_aware
@@ -87,7 +86,7 @@ def _split_dim_seed_cache_key(
         return (
             "nccl",
             int(size),
-            placement,
+            boundary_placements,
             tuple(mesh_shape),
             dim_idx,
             cost_model.arch.name,
@@ -105,7 +104,13 @@ def _split_dim_seed_cache_key(
             dim_cost_model.has_collnet,
             dim_cost_model.net_latency,
         )
-    return (str(cost_model), int(size), placement, tuple(mesh_shape), dim_idx)
+    return (
+        str(cost_model),
+        int(size),
+        boundary_placements,
+        tuple(mesh_shape),
+        dim_idx,
+    )
 
 
 def _first_output_placements(output_specs) -> tuple[Placement, ...] | None:
@@ -141,6 +146,36 @@ def _project_placements_to_dim(
     return tuple(projected)
 
 
+def _project_constraints_to_dim(constraints, dim_idx: int, ndim: int):
+    if constraints is None:
+        return None
+    projected: list[tuple[Placement, ...] | None] = []
+    for placements in constraints:
+        if placements is None:
+            projected.append(None)
+            continue
+        if len(placements) != ndim:
+            raise ValueError(
+                f"placement constraint has {len(placements)} entries, expected {ndim}"
+            )
+        projected.append((placements[dim_idx],))
+    return projected
+
+
+def _constraint_cache_key(input_constraints, output_constraints) -> tuple[Any, ...]:
+    def placements_key(constraints):
+        if constraints is None:
+            return None
+        return tuple(
+            None
+            if placements is None
+            else tuple(_placement_code(placement) for placement in placements)
+            for placements in constraints
+        )
+
+    return placements_key(input_constraints), placements_key(output_constraints)
+
+
 @contextmanager
 def _project_local_map_to_dim(
     gm: torch.fx.GraphModule, mesh_1d, dim_idx: int, ndim: int
@@ -167,11 +202,12 @@ def _project_local_map_to_dim(
             node.meta["local_map_kwargs"] = local_map_kwargs
 
 
-def build_split_dim_seed(
+def _build_split_dim_seed(
     gm: torch.fx.GraphModule,
     mesh_shape: tuple[int, ...],
-    input_placements: tuple[Placement, ...],
     *,
+    input_constraints=None,
+    output_constraints=None,
     cost_model: Any = "nccl",
     force_grad_reduce_in_higher_precision: bool = False,
     repeated_subgraphs: bool = True,
@@ -186,7 +222,8 @@ def build_split_dim_seed(
     Args:
         gm: Joint graph to optimize.
         mesh_shape: Target mesh shape.
-        input_placements: Required input placement for each target mesh dim.
+        input_constraints: Optional user input placement constraints.
+        output_constraints: Optional user output placement constraints.
         cost_model: Cost model identifier or NCCL topology config.
         force_grad_reduce_in_higher_precision: Whether gradient reductions use
             higher precision costs.
@@ -203,10 +240,6 @@ def build_split_dim_seed(
     """
 
     ndim = len(mesh_shape)
-    if len(input_placements) != ndim:
-        raise ValueError(
-            f"input_placements has {len(input_placements)} entries, expected {ndim}"
-        )
     if memory_high_fn is None:
         memory_high_fn = lambda size: 1.0 / size  # noqa: E731
 
@@ -223,10 +256,11 @@ def build_split_dim_seed(
 
     per_dim: list[dict[str, Placement]] = []
     for dim_idx, size in enumerate(mesh_shape):
-        input_placement = input_placements[dim_idx]
+        dim_inputs = _project_constraints_to_dim(input_constraints, dim_idx, ndim)
+        dim_outputs = _project_constraints_to_dim(output_constraints, dim_idx, ndim)
         key = _split_dim_seed_cache_key(
             int(size),
-            input_placement,
+            _constraint_cache_key(dim_inputs, dim_outputs),
             seed_cost_model,
             mesh_shape,
             dim_idx,
@@ -257,8 +291,10 @@ def build_split_dim_seed(
                         repeated_subgraphs=repeated_subgraphs,
                         fast_build=fast_build,
                     )
-                    opt.add_sharded_input_constraint([(input_placement,)])
-                    opt.add_sharded_output_constraint([(input_placement,)])
+                    if dim_inputs is not None:
+                        opt.add_sharded_input_constraint(dim_inputs)
+                    if dim_outputs is not None:
+                        opt.add_sharded_output_constraint(dim_outputs)
                     opt.add_parameter_memory_constraint(0.0, memory_high_fn(int(size)))
                     solution = opt.get_solution()
             finally:
@@ -279,17 +315,5 @@ def build_split_dim_seed(
         seed[node.name] = tuple(
             per_dim[i].get(node.name, Replicate()) for i in range(ndim)
         )
-
-    from torch._functorch._aot_autograd.fx_utils import (
-        get_plain_input_and_grad_nodes,
-        get_plain_output_and_tangent_nodes,
-    )
-
-    input_tuple = tuple(input_placements)
-    for getter in (get_plain_input_and_grad_nodes, get_plain_output_and_tangent_nodes):
-        for _desc, (node, companion) in cast(Any, getter(gm.graph)).items():
-            seed[node.name] = input_tuple
-            if companion is not None:
-                seed[companion.name] = input_tuple
 
     return seed

--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -103,8 +103,11 @@ from .graph_passes.graph_utils import (
     build_param_derived_set,
     build_terminal_derived_set,
 )
-from .shardings.placement_options import get_placement_options_for_node
-from .shardings.propagation_rules import _create_all_options
+from .shardings.placement_options import (
+    get_placement_options_for_node,
+    reset_placement_options_cache,
+)
+from .shardings.propagation_rules import _create_all_options, set_current_seed_node
 
 logger = logging.getLogger(__name__)
 
@@ -274,6 +277,8 @@ class ShardingOptimizer:
         fast_build=True,
         build_pulp=True,
         build_costs=True,
+        strategy_seed=None,
+        strategy_radius=None,
     ):
         self.orig_gm = gm
         self.fast_build = fast_build
@@ -304,6 +309,8 @@ class ShardingOptimizer:
         self.force_grad_reduce_in_higher_precision = (
             force_grad_reduce_in_higher_precision
         )
+        self.strategy_seed = strategy_seed
+        self.strategy_radius = strategy_radius
         self._constraint_log: list[tuple[str, dict]] = []
         self._memory_constraint: tuple[float, float] | None = None
         # Maps ILP constraint name → node_name for active node constraints,
@@ -318,7 +325,21 @@ class ShardingOptimizer:
         self.profile: dict[str, Any] = {"timings": {}}
         t_init_start = time.perf_counter()
         t0 = time.perf_counter()
-        self.strats = self.build_sharding_metadata()
+        if self.strategy_seed is None:
+            self.strats = self.build_sharding_metadata()
+        else:
+            from .shardings import propagation_rules as _propagation_rules
+
+            _propagation_rules.set_strategy_seed(
+                self.strategy_seed, self.strategy_radius
+            )
+            reset_placement_options_cache()
+            try:
+                self.strats = self.build_sharding_metadata()
+            finally:
+                _propagation_rules.set_strategy_seed(None, None)
+                set_current_seed_node(None)
+                reset_placement_options_cache()
         t_strategy = time.perf_counter() - t0
         self.profile["timings"]["strategy_enumeration_s"] = t_strategy
         logger.info("ShardingOptimizer: strategy enumeration took %.3fs", t_strategy)
@@ -398,6 +419,7 @@ class ShardingOptimizer:
         # _skip_enumeration_redistribute_cost).
         with _skip_enumeration_redistribute_cost(self.fast_build):
             for node in self.graph.nodes:
+                set_current_seed_node(node.name)
                 if node.op in ("placeholder", "get_attr"):
                     val = node.meta.get("val")
                     if isinstance(val, torch.Tensor):
@@ -445,6 +467,7 @@ class ShardingOptimizer:
                     strats[node] = user_strats
                 else:
                     raise ValueError(f"Unexpected node op: {node.op}")
+        set_current_seed_node(None)
         return strats
 
     def create_cluster_links(self, clusters):

--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -89,6 +89,7 @@ from torch._functorch._aot_autograd.fx_utils import (
     get_plain_output_and_tangent_nodes,
 )
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
+from torch.distributed.tensor._op_schema import OpSpec, OpStrategy
 from torch.distributed.tensor.placement_types import Placement, Replicate, Shard
 from torch.utils._pytree import tree_map_only
 
@@ -107,7 +108,13 @@ from .shardings.placement_options import (
     get_placement_options_for_node,
     reset_placement_options_cache,
 )
-from .shardings.propagation_rules import _create_all_options, set_current_seed_node
+from .shardings.propagation_rules import (
+    DTensorSpecSeed,
+    OpSpecSeed,
+    _create_all_options,
+    remove_invalid_configs,
+    set_current_seed_node,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -194,6 +201,55 @@ def _produces_tensor(val):
     if isinstance(val, (tuple, list)):
         return any(_produces_tensor(v) for v in val)
     return False
+
+
+def _materialize_seed_spec(spec, mesh):
+    if spec is None:
+        return None
+    if isinstance(spec, DTensorSpecSeed):
+        return DTensorSpec(mesh, spec.placements, tensor_meta=spec.tensor_meta)
+    return tuple(_materialize_seed_spec(item, mesh) for item in spec)
+
+
+def _spec_matches_seed(spec, seed) -> bool:
+    if seed is None:
+        return spec is None
+    if isinstance(seed, DTensorSpecSeed):
+        return isinstance(spec, DTensorSpec) and spec.placements == seed.placements
+    return (
+        isinstance(spec, (tuple, list))
+        and len(spec) == len(seed)
+        and all(
+            _spec_matches_seed(actual, expected) for actual, expected in zip(spec, seed)
+        )
+    )
+
+
+def _strategy_matches_seed(strategy: OpSpec, seed: OpSpecSeed) -> bool:
+    return _spec_matches_seed(
+        strategy.output_specs, seed.output_specs
+    ) and _spec_matches_seed(strategy.input_specs, seed.input_specs)
+
+
+def _first_seed_output(seed: OpSpecSeed) -> DTensorSpecSeed | None:
+    if isinstance(seed.output_specs, DTensorSpecSeed):
+        return seed.output_specs
+    if isinstance(seed.output_specs, tuple):
+        return next(
+            (spec for spec in seed.output_specs if isinstance(spec, DTensorSpecSeed)),
+            None,
+        )
+    return None
+
+
+def _seed_spec_is_well_formed(spec: DTensorSpecSeed, mesh_ndim: int) -> bool:
+    if len(spec.placements) != mesh_ndim or spec.tensor_meta is None:
+        return False
+    rank = len(spec.tensor_meta.shape)
+    return all(
+        not isinstance(placement, Shard) or -rank <= placement.dim < rank
+        for placement in spec.placements
+    )
 
 
 def concretize_gm(gm):
@@ -412,6 +468,83 @@ class ShardingOptimizer:
         """
         return self._orig_to_concrete.get(node, node)
 
+    def _built_input_nodes(self, node, strats):
+        result = []
+        for input_node in all_input_nodes(node):
+            if input_node in strats:
+                result.append(input_node)
+            elif input_node.op != "get_attr":
+                value = input_node.meta.get("val")
+                assert not isinstance(value, torch.Tensor), (
+                    f"Tensor-producing node {input_node} (op={input_node.op}) "
+                    "unexpectedly missing from strats"
+                )
+        return result
+
+    def _ensure_seed_witness(self, node, op_strategy, strats):
+        if self.strategy_seed is None:
+            return op_strategy
+        node_seed = self.strategy_seed.get(node.name)
+        if node_seed is None or node_seed.witness is None:
+            return op_strategy
+        witness = node_seed.witness
+        if any(
+            _strategy_matches_seed(strategy, witness)
+            for strategy in op_strategy.strategies
+        ):
+            return op_strategy
+
+        first_output = _first_seed_output(witness)
+        if (
+            first_output is None
+            or first_output.placements != node_seed.output_placements
+            or not all(
+                _seed_spec_is_well_formed(spec, self.mesh.ndim)
+                for spec in self._seeded_specs(witness)
+            )
+        ):
+            logger.debug("Skipping structurally invalid strategy seed for %s", node)
+            return op_strategy
+
+        input_nodes = self._built_input_nodes(node, strats)
+        input_specs = witness.input_specs
+        if input_nodes:
+            if input_specs is None or len(input_specs) != len(input_nodes):
+                logger.debug("Skipping input-incompatible strategy seed for %s", node)
+                return op_strategy
+            redistribute_cost = [
+                [0.0] * len(strats[input_node].strategies) for input_node in input_nodes
+            ]
+        elif input_specs:
+            if len(input_specs) != 1:
+                logger.debug("Skipping input-incompatible strategy seed for %s", node)
+                return op_strategy
+            redistribute_cost = [[0.0]]
+        else:
+            redistribute_cost = []
+
+        candidate = OpSpec(
+            output_specs=_materialize_seed_spec(witness.output_specs, self.mesh),
+            input_specs=_materialize_seed_spec(input_specs, self.mesh),
+            redistribute_cost=redistribute_cost,
+        )
+        valid = remove_invalid_configs(OpStrategy([candidate]), self.mesh)
+        if not valid.strategies:
+            logger.debug("Skipping unshardable strategy seed for %s", node)
+            return op_strategy
+        op_strategy.strategies.append(candidate)
+        return op_strategy
+
+    @staticmethod
+    def _seeded_specs(witness):
+        output_specs = witness.output_specs
+        if isinstance(output_specs, DTensorSpecSeed):
+            yield output_specs
+        elif isinstance(output_specs, tuple):
+            yield from (spec for spec in output_specs if spec is not None)
+        if witness.input_specs is not None:
+            yield from (spec for spec in witness.input_specs if spec is not None)
+
     def build_sharding_metadata(self):
         strats = {}
         # Enumeration's redistribute_cost matrices are overwritten with real
@@ -467,6 +600,8 @@ class ShardingOptimizer:
                     strats[node] = user_strats
                 else:
                     raise ValueError(f"Unexpected node op: {node.op}")
+                if node in strats and node.op != "output":
+                    strats[node] = self._ensure_seed_witness(node, strats[node], strats)
         set_current_seed_node(None)
         return strats
 
@@ -514,17 +649,7 @@ class ShardingOptimizer:
         - call_function producing non-tensors: shape-computation nodes
           (sym_size, operator.mul, etc.)
         """
-        result = []
-        for x in all_input_nodes(node):
-            if x in self.strats:
-                result.append(x)
-            elif x.op != "get_attr":
-                val = x.meta.get("val")
-                assert not isinstance(val, torch.Tensor), (
-                    f"Tensor-producing node {x} (op={x.op}) unexpectedly "
-                    f"missing from strats"
-                )
-        return result
+        return self._built_input_nodes(node, self.strats)
 
     def walk_over_options(self, node, constrain_arg=None):
         """Yield (argi, out_idx, inp_idx) for all valid strategy combinations."""

--- a/autoparallel/shardings/placement_options.py
+++ b/autoparallel/shardings/placement_options.py
@@ -31,7 +31,14 @@ from torch.utils._pytree import tree_flatten, tree_map_only
 from autoparallel.shardings.propagation_rules import generate_dummy_redistribute_costs
 
 from .dtensor_sharding_helpers import get_op_strategy, with_implicit_strategies
-from .propagation_rules import _op_rules, remove_invalid_configs
+from .propagation_rules import (
+    _op_rules,
+    get_current_seed_node,
+    get_strategy_radius,
+    get_strategy_seed,
+    remove_invalid_configs,
+    within_strategy_seed_ball,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -277,19 +284,57 @@ def reset_placement_options_timer():
     _placement_options_timer = PlacementOptionsTimer()
 
 
+def _seed_cache_key():
+    seed = get_strategy_seed()
+    if seed is None:
+        return None
+    node_name = get_current_seed_node()
+    placements = seed.get(node_name) if node_name is not None else None
+    placement_key = None if placements is None else tuple(str(p) for p in placements)
+    # Key on the seed PLACEMENT (not node_name): the seed-filtered result depends only
+    # on (op, input specs, seed placement, radius), so repeated ops across layers with
+    # the same seed placement share the placement-options cache instead of missing
+    # per node (which re-runs get_op_strategy for every node).
+    return placement_key, get_strategy_radius()
+
+
+def _filter_by_strategy_seed(out_strat):
+    if get_strategy_seed() is None:
+        return out_strat
+
+    kept = []
+    for strategy in out_strat.strategies:
+        specs = strategy.output_specs
+        placements = None
+        if isinstance(specs, DTensorSpec):
+            placements = specs.placements
+        elif isinstance(specs, (tuple, list)):
+            for spec in specs:
+                if isinstance(spec, DTensorSpec):
+                    placements = spec.placements
+                    break
+        if placements is None or within_strategy_seed_ball(placements):
+            kept.append(strategy)
+
+    return out_strat if not kept else OpStrategy(kept)
+
+
 def get_placement_options(mesh, op, specs, user_args, user_kwargs):
     assert len(specs) == len(user_args)
     timer = _placement_options_timer
     t_start = time.perf_counter()
 
     try:
+        mesh_key = (id(mesh), mesh.device_type, tuple(mesh.shape), mesh.ndim)
         cache_key = (
+            mesh_key,
             op,
             tuple(_fingerprint_arg(s) for s in specs),
             tuple(_fingerprint_arg(a) for a in user_args),
             tuple(_fingerprint_arg(v) for v in user_kwargs.values())
             if user_kwargs
             else (),
+            _seed_cache_key(),
         )
         hash(cache_key)  # fail fast if key contains unhashable types (e.g. SymInts)
     except TypeError:
@@ -331,6 +376,7 @@ def get_placement_options(mesh, op, specs, user_args, user_kwargs):
     else:
         with with_implicit_strategies():
             out_strat = get_op_strategy(op, op_schema)
+    out_strat = _filter_by_strategy_seed(out_strat)
     t1 = time.perf_counter()
 
     # operator.getitem is self-contained: its input is a tuple of tensors

--- a/autoparallel/shardings/placement_options.py
+++ b/autoparallel/shardings/placement_options.py
@@ -316,6 +316,8 @@ def _filter_by_strategy_seed(out_strat):
         if placements is None or within_strategy_seed_ball(placements):
             kept.append(strategy)
 
+    # Some operator rules cannot produce any strategy inside the requested ball.
+    # Keep their original domain so the best-effort restriction stays feasible.
     return out_strat if not kept else OpStrategy(kept)
 
 

--- a/autoparallel/shardings/placement_options.py
+++ b/autoparallel/shardings/placement_options.py
@@ -289,7 +289,8 @@ def _seed_cache_key():
     if seed is None:
         return None
     node_name = get_current_seed_node()
-    placements = seed.get(node_name) if node_name is not None else None
+    node_seed = seed.get(node_name) if node_name is not None else None
+    placements = None if node_seed is None else node_seed.output_placements
     placement_key = None if placements is None else tuple(str(p) for p in placements)
     # Key on the seed PLACEMENT (not node_name): the seed-filtered result depends only
     # on (op, input specs, seed placement, radius), so repeated ops across layers with

--- a/autoparallel/shardings/propagation_rules.py
+++ b/autoparallel/shardings/propagation_rules.py
@@ -53,6 +53,55 @@ from torch.distributed.tensor.placement_types import (
 from ..cast_parametrization import dtype_cast  # noqa
 from .dtensor_sharding_helpers import _try_single_dim_strategy, get_op_strategy
 
+_strategy_seed: "dict[str, tuple[Placement, ...]] | None" = None
+_strategy_radius: "int | dict[str, int] | None" = None
+_current_seed_node: "str | None" = None
+
+
+def set_strategy_seed(seed, radius):
+    global _strategy_seed, _strategy_radius
+    _strategy_seed = seed
+    _strategy_radius = radius
+
+
+def get_strategy_seed():
+    return _strategy_seed
+
+
+def get_strategy_radius():
+    return _strategy_radius
+
+
+def set_current_seed_node(name):
+    global _current_seed_node
+    _current_seed_node = name
+
+
+def get_current_seed_node():
+    return _current_seed_node
+
+
+def within_strategy_seed_ball(placements) -> bool:
+    if _strategy_seed is None:
+        return True
+    node_name = _current_seed_node
+    if node_name is None:
+        return True
+    seed_placements = _strategy_seed.get(node_name)
+    if seed_placements is None:
+        return True
+
+    radius = _strategy_radius
+    if isinstance(radius, dict):
+        radius = radius.get(node_name, 0)
+    if radius is None:
+        radius = 0
+
+    distance = abs(len(placements) - len(seed_placements))
+    distance += sum(1 for a, b in zip(placements, seed_placements) if a != b)
+    return distance <= radius
+
+
 _op_rules = {}
 
 
@@ -194,6 +243,8 @@ def _create_all_options(mesh, shape, tensor_meta=None, tensor=None):
     all_options = list(itertools.product(*[possible_options for _ in range(mesh.ndim)]))
     strats = []
     for placement in all_options:
+        if not within_strategy_seed_ball(placement):
+            continue
         spec = DTensorSpec(mesh, placement, tensor_meta=tensor_meta)
         strats.append(OpSpec(spec, input_specs=[spec], redistribute_cost=[[0.0]]))
     out_strats = OpStrategy(strats)

--- a/autoparallel/shardings/propagation_rules.py
+++ b/autoparallel/shardings/propagation_rules.py
@@ -21,6 +21,7 @@ import collections
 import itertools
 import math
 import operator
+from dataclasses import dataclass
 from typing import cast
 
 import torch
@@ -53,7 +54,26 @@ from torch.distributed.tensor.placement_types import (
 from ..cast_parametrization import dtype_cast  # noqa
 from .dtensor_sharding_helpers import _try_single_dim_strategy, get_op_strategy
 
-_strategy_seed: "dict[str, tuple[Placement, ...]] | None" = None
+
+@dataclass(frozen=True)
+class DTensorSpecSeed:
+    placements: tuple[Placement, ...]
+    tensor_meta: TensorMeta | None
+
+
+@dataclass(frozen=True)
+class OpSpecSeed:
+    output_specs: (DTensorSpecSeed | tuple[DTensorSpecSeed | None, ...] | None)
+    input_specs: tuple[DTensorSpecSeed | None, ...] | None
+
+
+@dataclass(frozen=True)
+class StrategySeed:
+    output_placements: tuple[Placement, ...]
+    witness: OpSpecSeed | None
+
+
+_strategy_seed: "dict[str, StrategySeed] | None" = None
 _strategy_radius: "int | dict[str, int] | None" = None
 _current_seed_node: "str | None" = None
 
@@ -87,9 +107,10 @@ def within_strategy_seed_ball(placements) -> bool:
     node_name = _current_seed_node
     if node_name is None:
         return True
-    seed_placements = _strategy_seed.get(node_name)
-    if seed_placements is None:
+    seed = _strategy_seed.get(node_name)
+    if seed is None:
         return True
+    seed_placements = seed.output_placements
 
     radius = _strategy_radius
     if isinstance(radius, dict):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ _CUDA_PATCHES = [
                 "name": "H100",
                 "total_memory": 80 * 1024**3,
                 "multi_processor_count": 132,
+                "L2_cache_size": 50 * 1024**2,
             },
         )(),
     ),
@@ -42,6 +43,8 @@ def apply_cuda_patches(func):
 
 @pytest.fixture(autouse=True)
 def _reset_placement_options_cache():
+    """The placement-options cache is a process-global; clear it before each test
+    so optimizer builds never reuse stale strategies from a prior test's model."""
     from autoparallel.shardings.placement_options import reset_placement_options_cache
 
     reset_placement_options_cache()

--- a/tests/profiling/run_search_profiles.sh
+++ b/tests/profiling/run_search_profiles.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -u
+
+if [[ $# -lt 2 ]]; then
+    printf 'usage: %s [heuristic|lp] results-dir\n' "$0" >&2
+    exit 2
+fi
+
+mode=$1
+results=$2
+python=${PYTHON:-python}
+revision=$(git rev-parse --short HEAD)
+runner=tests/search_profile.py
+failed=0
+
+run_profile() {
+    label=$1
+    timeout_value=$2
+    shift 2
+    output="$results/$label"
+    mkdir -p "$output"
+    command=(
+        env PYTHONPATH=. PYTHONHASHSEED=0 "$python" "$runner" "$@"
+        --revision-label "$revision" --detailed-solution
+        --output "$output/result.json"
+    )
+    printf '%q ' "${command[@]}" >"$output/command.txt"
+    printf '\n' >>"$output/command.txt"
+    if [[ -n "$timeout_value" ]]; then
+        timed_command=(timeout --signal=TERM --kill-after=30s "$timeout_value")
+    else
+        timed_command=()
+    fi
+    /usr/bin/time -v -o "$output/time.txt" \
+        "${timed_command[@]}" "${command[@]}" \
+        >"$output/stdout.log" 2>"$output/stderr.log"
+    status=$?
+    printf '%s\n' "$status" >"$output/status.txt"
+    if [[ $status -ne 0 ]]; then
+        failed=1
+    fi
+}
+
+if [[ "$mode" == heuristic ]]; then
+    run_profile llama1b_full 20m \
+        --model llama1b --mesh 2,4,8 --solver approx --lazy-costs true
+    run_profile llama1b_split 20m \
+        --model llama1b --mesh 2,4,8 --solver approx --lazy-costs true --seeded
+    run_profile llama8b_full 20m \
+        --model llama8b --mesh 2,4,8 --solver approx --lazy-costs true
+    run_profile llama8b_split 20m \
+        --model llama8b --mesh 2,4,8 --solver approx --lazy-costs true --seeded
+    run_profile dsv3_3d_full 20m \
+        --model dsv3 --moe-layout 3d --solver approx --lazy-costs true
+    run_profile dsv3_3d_split 20m \
+        --model dsv3 --moe-layout 3d --solver approx --lazy-costs true --seeded
+    run_profile dsv3_4d_split 20m \
+        --model dsv3 --moe-layout 4d --solver approx --lazy-costs true --seeded
+elif [[ "$mode" == lp ]]; then
+    run_profile llama1b_3d_lp "" \
+        --model llama1b --mesh 2,4,8 --solver lp
+    run_profile llama8b_3d_lp "" \
+        --model llama8b --mesh 2,4,8 --solver lp
+    run_profile dsv3_3d_lp "" \
+        --model dsv3 --moe-layout 3d --solver lp
+else
+    printf 'usage: %s [heuristic|lp] results-dir\n' "$0" >&2
+    exit 2
+fi
+
+exit "$failed"

--- a/tests/search_profile.py
+++ b/tests/search_profile.py
@@ -51,11 +51,9 @@ LLAMA_CONFIGS = {
 }
 
 DSV3_DEGREES = {
-    "dp_replicate": 8,
-    "dp_shard": 8,
-    "cp": 1,
-    "tp": 1,
-    "ep": 8,
+    "2d": {"dp_replicate": 8, "dp_shard": 8, "cp": 1, "tp": 1, "ep": 8},
+    "3d": {"dp_replicate": 1, "dp_shard": 8, "cp": 1, "tp": 8, "ep": 32},
+    "4d": {"dp_replicate": 1, "dp_shard": 16, "cp": 2, "tp": 2, "ep": 8},
 }
 
 
@@ -74,9 +72,10 @@ def parse_args(argv=None):
     )
     parser.add_argument("--model", choices=(*LLAMA_CONFIGS, "dsv3"), required=True)
     parser.add_argument("--mesh", help="Comma-separated LLaMA mesh dimensions")
-    parser.add_argument("--moe-layout", choices=("2d",))
+    parser.add_argument("--moe-layout", choices=tuple(DSV3_DEGREES))
     parser.add_argument("--solver", choices=AutoParallel.SOLVER_CHOICES, required=True)
     parser.add_argument("--lazy-costs", choices=("true", "false"))
+    parser.add_argument("--seeded", action="store_true")
     parser.add_argument("--revision-label", required=True)
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--detailed-solution", action="store_true")
@@ -148,14 +147,15 @@ def make_llama(model_name, mesh_shape):
     return model, input_fn, mesh, input_placement, output_placement, expanded
 
 
-def make_dsv3():
+def make_dsv3(layout):
     from autoparallel._testing.models.dsv3 import (
         DeepSeekV3Model,
         build_moe_mesh,
         make_dsv3_config,
     )
 
-    mesh, roles = build_moe_mesh(**DSV3_DEGREES)
+    degrees = DSV3_DEGREES[layout]
+    mesh, roles = build_moe_mesh(**degrees)
     config = make_dsv3_config(num_experts=64, max_seq_len=2048)
     with torch.device("meta"):
         model = DeepSeekV3Model(
@@ -178,7 +178,7 @@ def make_dsv3():
             "sequence_length": 2048,
             "batch_size": batch_size,
         },
-        "degrees": DSV3_DEGREES,
+        "degrees": degrees,
         "mesh_shape": list(mesh.shape),
         "mesh_dim_names": list(mesh.mesh_dim_names),
         "ep_axis_names": list(roles.ep_axis_names),
@@ -297,6 +297,8 @@ def run_git(*args):
 
 def git_metadata():
     status = run_git("status", "--short")
+    if status:
+        raise RuntimeError(f"profiling requires a clean Git worktree:\n{status}")
     return {
         "commit": run_git("rev-parse", "HEAD"),
         "branch": run_git("branch", "--show-current"),
@@ -318,10 +320,16 @@ def cpu_model():
 def validate_args(args):
     if args.lazy_costs is not None and args.solver != "approx":
         raise ValueError("--lazy-costs is supported only with --solver approx")
+    if args.seeded and args.solver != "approx":
+        raise ValueError("--seeded is supported only with --solver approx")
     if args.model == "dsv3":
-        if args.moe_layout != "2d" or args.mesh is not None:
-            raise ValueError("dsv3 requires --moe-layout 2d and no --mesh")
-        return 64, None
+        if args.moe_layout is None or args.mesh is not None:
+            raise ValueError("dsv3 requires --moe-layout and no --mesh")
+        degrees = DSV3_DEGREES[args.moe_layout]
+        world_size = math.prod(
+            degrees[name] for name in ("dp_replicate", "dp_shard", "cp", "tp")
+        )
+        return world_size, None
     if args.mesh is None or args.moe_layout is not None:
         raise ValueError("LLaMA requires --mesh and no --moe-layout")
     mesh_shape = tuple(int(part) for part in args.mesh.split(","))
@@ -386,7 +394,7 @@ def main(argv=None):
 
             model_started = time.perf_counter()
             built = (
-                make_dsv3()
+                make_dsv3(args.moe_layout)
                 if args.model == "dsv3"
                 else make_llama(args.model, mesh_shape)
             )
@@ -409,13 +417,12 @@ def main(argv=None):
                 lazy_costs=(
                     None if args.lazy_costs is None else args.lazy_costs == "true"
                 ),
+                strategy_radius=2 if args.seeded else None,
             )
             enter_started = time.perf_counter()
             stack.enter_context(autop)
             enter_elapsed = time.perf_counter() - enter_started
-            opt = autop.sharding_optimizer
             graph_trace_s = autop.profile_graph_trace_s
-            optimizer_init_s = opt.profile["timings"]["init_total_s"]
 
             constraint_started = time.perf_counter()
             autop.add_parameter_memory_constraint(low=None, high=None)
@@ -427,20 +434,27 @@ def main(argv=None):
             solution = autop.optimize_placement(verbose=False)
             solve_call_s = time.perf_counter() - solve_started
             search_total_s = time.perf_counter() - enter_started
-            unaccounted_s = max(
-                search_total_s
-                - graph_trace_s
-                - optimizer_init_s
-                - constraint_s
-                - solve_call_s,
-                0.0,
-            )
+            opt = autop.sharding_optimizer
+            optimizer_init_s = opt.profile["timings"]["init_total_s"]
             profile_key = {
                 "approx": "approximate",
                 "ilp": "ilp",
                 "lp": "lp_relaxation",
             }[args.solver]
             solver_profile = opt.profile[profile_key]
+            factor_build_s = solver_profile.get("build_s")
+            solver_core_s = solver_profile.get(
+                "solve_s", solver_profile.get("solve_time")
+            )
+            unaccounted_s = max(
+                search_total_s
+                - graph_trace_s
+                - optimizer_init_s
+                - constraint_s
+                - (factor_build_s or 0.0)
+                - (solver_core_s or 0.0),
+                0.0,
+            )
             result["timings"].update(
                 {
                     "enter_total_s": enter_elapsed,
@@ -448,10 +462,8 @@ def main(argv=None):
                     "optimizer_init_s": optimizer_init_s,
                     "user_constraints_s": constraint_s,
                     "solve_call_s": solve_call_s,
-                    "factor_build_s": solver_profile.get("build_s"),
-                    "solver_core_s": solver_profile.get(
-                        "solve_s", solver_profile.get("solve_time")
-                    ),
+                    "factor_build_s": factor_build_s,
+                    "solver_core_s": solver_core_s,
                     "search_total_s": search_total_s,
                     "unaccounted_s": unaccounted_s,
                 }

--- a/tests/test_ds3_local_map_numerics.py
+++ b/tests/test_ds3_local_map_numerics.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Compare 4-GPU AutoParallel DeepSeek-V3 numerics with a single-GPU model."""
+"""Compare distributed AutoParallel DeepSeek-V3 numerics with a single-GPU model."""
 
 import argparse
 import gc
@@ -15,12 +15,15 @@ import torch
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.fsdp import MixedPrecisionPolicy
 from torch.distributed.tensor import DTensor
-from torch.distributed.tensor.placement_types import Shard
+from torch.distributed.tensor.placement_types import Partial, Shard
 
 from autoparallel import AutoParallel, MoEMeshRoles, build_moe_mesh
 from autoparallel._testing.models.dsv3 import DeepSeekV3Model, make_dsv3_config
+from autoparallel.cost_models.collective_runtime_estimation import (
+    estimate_strategy_comms_cost,
+)
+from autoparallel.optimize_sharding import _strategy_matches_seed
 
-_WORLD_SIZE = 4
 _SEQ_LEN = 2048
 _LOCAL_BATCH_SIZE = 1
 _SEED = 0
@@ -35,6 +38,7 @@ _CASES: dict[str, dict[str, int]] = {
     "efsdp_boundary": dict(dp_replicate=1, dp_shard=4, cp=1, tp=1, ep=2),
     "legacy_2d": dict(dp_replicate=2, dp_shard=2, cp=1, tp=1, ep=2),
     "flattened_ep": dict(dp_replicate=1, dp_shard=2, cp=2, tp=1, ep=4),
+    "split_dim_3d": dict(dp_replicate=1, dp_shard=4, cp=1, tp=2, ep=4),
 }
 
 
@@ -62,6 +66,71 @@ def _gather_state_dict(model: torch.nn.Module, rank: int) -> dict[str, torch.Ten
         if rank == 0:
             state_dict[name] = full_value.detach().cpu()
     return state_dict
+
+
+def _validate_split_dim_witnesses(optimizer) -> dict[str, Any]:
+    missing = []
+    witnessed = 0
+    for node, strategies in optimizer.strats.items():
+        if node.op == "output":
+            continue
+        node_seed = optimizer.strategy_seed.get(node.name)
+        if node_seed is None or node_seed.witness is None:
+            continue
+        witnessed += 1
+        if not any(
+            _strategy_matches_seed(strategy, node_seed.witness)
+            for strategy in strategies.strategies
+        ):
+            missing.append(node.name)
+    assert not missing, f"Missing complete strategy witnesses: {missing[:20]}"
+
+    sss = (Shard(0),) * optimizer.mesh.ndim
+    ppp = (Partial("sum"),) * optimizer.mesh.ndim
+    for dtype_node in optimizer.graph.nodes:
+        if dtype_node.target != torch.ops.autoparallel.dtype_cast.default:
+            continue
+        input_nodes = optimizer._all_input_nodes(dtype_node)
+        if len(input_nodes) != 1:
+            continue
+        sum_node = input_nodes[0]
+        if sum_node.target != torch.ops.aten.sum.dim_IntList:
+            continue
+        sum_seed = optimizer.strategy_seed.get(sum_node.name)
+        dtype_seed = optimizer.strategy_seed.get(dtype_node.name)
+        if (
+            sum_seed is None
+            or dtype_seed is None
+            or sum_seed.output_placements != ppp
+            or dtype_seed.output_placements != sss
+        ):
+            continue
+        assert sum_seed.witness is not None
+        assert dtype_seed.witness is not None
+        sum_strategy = next(
+            strategy
+            for strategy in optimizer.strats[sum_node].strategies
+            if _strategy_matches_seed(strategy, sum_seed.witness)
+        )
+        dtype_strategy = next(
+            strategy
+            for strategy in optimizer.strats[dtype_node].strategies
+            if _strategy_matches_seed(strategy, dtype_seed.witness)
+        )
+        edge_cost = estimate_strategy_comms_cost(
+            sum_strategy.output_spec, dtype_strategy.input_specs[0]
+        )
+        assert torch.isfinite(torch.tensor(edge_cost))
+        return {
+            "witnessed_nodes": witnessed,
+            "missing_witnesses": 0,
+            "sum_node": sum_node.name,
+            "dtype_node": dtype_node.name,
+            "producer_placements": [repr(p) for p in ppp],
+            "consumer_input_placements": [repr(p) for p in sss],
+            "edge_cost": edge_cost,
+        }
+    raise AssertionError("Could not find the RMSNorm split-dim seeded edge")
 
 
 def _run_reference(
@@ -105,6 +174,9 @@ def run_numerics_test(case: str, dtype_name: str) -> None:
     device = torch.device("cuda", local_rank)
     compute_dtype = _DTYPES[dtype_name]
     degrees = _CASES[case]
+    world_size = (
+        degrees["dp_replicate"] * degrees["dp_shard"] * degrees["cp"] * degrees["tp"]
+    )
     mesh, roles = build_moe_mesh(
         dp_replicate=degrees["dp_replicate"],
         dp_shard=degrees["dp_shard"],
@@ -113,7 +185,7 @@ def run_numerics_test(case: str, dtype_name: str) -> None:
         ep=degrees["ep"],
     )
     config = make_dsv3_config(num_experts=8, max_seq_len=_SEQ_LEN)
-    global_batch_size = _LOCAL_BATCH_SIZE * _WORLD_SIZE
+    global_batch_size = _LOCAL_BATCH_SIZE * world_size
 
     with torch.device("meta"):
         model = DeepSeekV3Model(
@@ -134,14 +206,27 @@ def run_numerics_test(case: str, dtype_name: str) -> None:
         param_dtype=compute_dtype,
         reduce_dtype=torch.float32,
     )
+    split_dim = case == "split_dim_3d"
     with AutoParallel(
-        model, input_fn, mesh, mp_policy=mp_policy, dynamic=True
+        model,
+        input_fn,
+        mesh,
+        mp_policy=mp_policy,
+        dynamic=True,
+        solver="approx" if split_dim else "ilp",
+        lazy_costs=True if split_dim else None,
+        strategy_radius=2,
     ) as autop:
         autop.add_parameter_memory_constraint(low=None, high=None)
         input_placements = (Shard(0),) * mesh.ndim
         autop.add_input_constraints([input_placements])
         autop.add_output_constraints([input_placements])
         placement = autop.optimize_placement(verbose=False)
+        witness_validation = (
+            _validate_split_dim_witnesses(autop.sharding_optimizer)
+            if split_dim
+            else None
+        )
         parallel_model = autop.apply_placement(placement)
 
     parallel_model.to_empty(device=device)
@@ -156,7 +241,7 @@ def run_numerics_test(case: str, dtype_name: str) -> None:
             (global_batch_size, _SEQ_LEN),
             device=device,
         )
-        scatter_list = list(global_tokens.chunk(_WORLD_SIZE))
+        scatter_list = list(global_tokens.chunk(world_size))
     else:
         global_tokens = None
         scatter_list = None
@@ -285,6 +370,7 @@ def run_numerics_test(case: str, dtype_name: str) -> None:
                 "name": worst_name,
                 "relative_error": worst_error,
             },
+            "witness_validation": witness_validation,
         }
         print(f"NUMERICS_RESULT={json.dumps(result, sort_keys=True)}", flush=True)
         failures = []
@@ -321,11 +407,15 @@ def main():
     parser.add_argument("--dtype", required=True, choices=_DTYPES)
     args = parser.parse_args()
 
+    degrees = _CASES[args.case]
+    world_size = (
+        degrees["dp_replicate"] * degrees["dp_shard"] * degrees["cp"] * degrees["tp"]
+    )
     if (
-        int(os.environ.get("WORLD_SIZE", "1")) != _WORLD_SIZE
-        or torch.cuda.device_count() < _WORLD_SIZE
+        int(os.environ.get("WORLD_SIZE", "1")) != world_size
+        or torch.cuda.device_count() < world_size
     ):
-        parser.error(f"run with torchrun --standalone --nproc-per-node {_WORLD_SIZE}")
+        parser.error(f"run with torchrun --standalone --nproc-per-node {world_size}")
     local_rank = int(os.environ["LOCAL_RANK"])
     device = torch.device("cuda", local_rank)
     torch.cuda.set_device(device)

--- a/tests/test_search_profile.py
+++ b/tests/test_search_profile.py
@@ -59,6 +59,8 @@ def _args(*values):
         (("--model", "llama1b", "--mesh", "8,8"), (64, (8, 8))),
         (("--model", "llama1b", "--mesh", "2,4,8"), (64, (2, 4, 8))),
         (("--model", "dsv3", "--moe-layout", "2d"), (64, None)),
+        (("--model", "dsv3", "--moe-layout", "3d"), (64, None)),
+        (("--model", "dsv3", "--moe-layout", "4d"), (64, None)),
     ],
 )
 def test_validate_search_profile_args(values, expected):
@@ -91,6 +93,26 @@ def test_validate_search_profile_args_rejects_lazy_non_approx():
             "ilp",
             "--lazy-costs",
             "true",
+            "--revision-label",
+            "test",
+            "--output",
+            "unused.json",
+        ]
+    )
+    with pytest.raises(ValueError, match="only with --solver approx"):
+        validate_args(args)
+
+
+def test_validate_search_profile_args_rejects_seeded_non_approx():
+    args = parse_args(
+        [
+            "--model",
+            "llama1b",
+            "--mesh",
+            "2,4,8",
+            "--solver",
+            "ilp",
+            "--seeded",
             "--revision-label",
             "test",
             "--output",

--- a/tests/test_split_dim_seed.py
+++ b/tests/test_split_dim_seed.py
@@ -11,20 +11,39 @@ import torch
 from conftest import apply_cuda_patches
 from torch._subclasses.fake_tensor import unset_fake_temporarily
 from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.fsdp import MixedPrecisionPolicy
+from torch.distributed.tensor._dtensor_spec import TensorMeta
 from torch.distributed.tensor.placement_types import Partial, Replicate, Shard
 
 from autoparallel._testing.models.dsv3 import (
+    DeepSeekV3Model,
     MoEMeshRoles,
     build_moe_local_map_placements,
+    build_moe_mesh,
+    make_dsv3_config,
 )
 from autoparallel.api import AutoParallel
+from autoparallel.approximate_sharding import ApproximateShardingSolver
+from autoparallel.cost_models.collective_runtime_estimation import (
+    estimate_strategy_comms_cost,
+)
 from autoparallel.cost_models.nccl_cost_model import h100_topo_config
 from autoparallel.mesh_search import (
     _build_split_dim_seed,
+    _combine_op_spec_seeds,
     _project_local_map_to_dim,
     _split_dim_seed_cache_key,
 )
-from autoparallel.optimize_sharding import ShardingOptimizer
+from autoparallel.optimize_sharding import (
+    ShardingOptimizer,
+    _seed_spec_is_well_formed,
+    _strategy_matches_seed,
+)
+from autoparallel.shardings.propagation_rules import (
+    DTensorSpecSeed,
+    OpSpecSeed,
+    StrategySeed,
+)
 
 pytestmark = [
     pytest.mark.filterwarnings("ignore:Constructing LpVariable.*:DeprecationWarning"),
@@ -46,6 +65,279 @@ class TinyMLP(torch.nn.Module):
 
 def _input_fn():
     return torch.randn(8, 16, device="cuda", requires_grad=True)
+
+
+def _tensor_meta(shape, dtype=torch.float32):
+    tensor = torch.empty(shape, dtype=dtype, device="meta")
+    return TensorMeta(tensor.shape, tensor.stride(), tensor.dtype)
+
+
+def _spec_seed(placements, tensor_meta):
+    return DTensorSpecSeed(tuple(placements), tensor_meta)
+
+
+def test_combine_split_dim_op_specs_preserves_rmsnorm_seeded_edge():
+    input_meta = _tensor_meta((8, 2048, 256))
+    output_meta = _tensor_meta((256,))
+    sum_per_dim = [
+        OpSpecSeed(
+            output_specs=_spec_seed((Partial("sum"),), output_meta),
+            input_specs=(_spec_seed((Shard(0),), input_meta),),
+        )
+        for _ in range(3)
+    ]
+    dtype_per_dim = [
+        OpSpecSeed(
+            output_specs=_spec_seed((Shard(0),), output_meta),
+            input_specs=(_spec_seed((Shard(0),), output_meta),),
+        )
+        for _ in range(3)
+    ]
+
+    sum_seed = _combine_op_spec_seeds(sum_per_dim)
+    dtype_seed = _combine_op_spec_seeds(dtype_per_dim)
+
+    assert sum_seed is not None
+    assert isinstance(sum_seed.output_specs, DTensorSpecSeed)
+    assert sum_seed.output_specs.placements == (Partial("sum"),) * 3
+    assert sum_seed.input_specs is not None
+    assert sum_seed.input_specs[0].placements == (Shard(0),) * 3
+    assert dtype_seed is not None
+    assert isinstance(dtype_seed.output_specs, DTensorSpecSeed)
+    assert dtype_seed.output_specs.placements == (Shard(0),) * 3
+    assert dtype_seed.input_specs is not None
+    assert dtype_seed.input_specs[0].placements == (Shard(0),) * 3
+
+
+def test_combine_split_dim_op_specs_preserves_optional_outputs():
+    tensor_meta = _tensor_meta((8, 2048, 256))
+    per_dim = [
+        OpSpecSeed(
+            output_specs=(_spec_seed((Shard(0),), tensor_meta), None),
+            input_specs=(_spec_seed((Replicate(),), tensor_meta),),
+        )
+        for _ in range(3)
+    ]
+
+    combined = _combine_op_spec_seeds(per_dim)
+
+    assert combined is not None
+    assert isinstance(combined.output_specs, tuple)
+    assert combined.output_specs[0].placements == (Shard(0),) * 3
+    assert combined.output_specs[1] is None
+
+
+def test_combine_split_dim_op_specs_rejects_structural_mismatch():
+    tensor_meta = _tensor_meta((256,))
+    single = OpSpecSeed(
+        output_specs=_spec_seed((Shard(0),), tensor_meta),
+        input_specs=(_spec_seed((Shard(0),), tensor_meta),),
+    )
+    multiple = OpSpecSeed(
+        output_specs=(_spec_seed((Shard(0),), tensor_meta), None),
+        input_specs=(_spec_seed((Shard(0),), tensor_meta),),
+    )
+
+    assert _combine_op_spec_seeds([single, single, multiple]) is None
+
+
+def test_seed_spec_validation_rejects_invalid_target_mesh_specs():
+    tensor_meta = _tensor_meta((256,))
+
+    assert not _seed_spec_is_well_formed(
+        _spec_seed((Shard(0), Shard(0)), tensor_meta), 3
+    )
+    assert not _seed_spec_is_well_formed(_spec_seed((Shard(1),) * 3, tensor_meta), 3)
+    assert not _seed_spec_is_well_formed(DTensorSpecSeed((Replicate(),) * 3, None), 3)
+
+
+@apply_cuda_patches
+def test_split_dim_preserves_complete_rmsnorm_seeded_edge():
+    with unset_fake_temporarily():
+        mesh = init_device_mesh(
+            "cuda", (2, 2, 2), mesh_dim_names=("outer", "middle", "inner")
+        )
+
+    input_value = torch.empty((8, 2048, 256), device="meta")
+    output_value = torch.empty((256,), device="meta")
+    graph = torch.fx.Graph()
+    input_node = graph.placeholder("input")
+    sum_node = graph.call_function(torch.ops.aten.sum.dim_IntList, (input_node, [0, 1]))
+    dtype_node = graph.call_function(
+        torch.ops.autoparallel.dtype_cast.default, (sum_node, torch.float32)
+    )
+    alias_node = graph.call_function(torch.ops.aten.alias.default, (dtype_node,))
+    output_node = graph.output(alias_node)
+    input_node.meta["val"] = input_value
+    sum_node.meta["val"] = output_value
+    dtype_node.meta["val"] = output_value
+    alias_node.meta["val"] = output_value
+    output_node.meta["val"] = output_value
+    gm = torch.fx.GraphModule({}, graph)
+
+    sss = (Shard(0),) * 3
+    ppp = (Partial("sum"),) * 3
+    input_meta = _tensor_meta(input_value.shape)
+    output_meta = _tensor_meta(output_value.shape)
+    input_spec = _spec_seed(sss, input_meta)
+    output_spec = _spec_seed(sss, output_meta)
+    seed = {
+        input_node.name: StrategySeed(
+            sss, OpSpecSeed(output_specs=input_spec, input_specs=(input_spec,))
+        ),
+        sum_node.name: StrategySeed(
+            ppp,
+            OpSpecSeed(
+                output_specs=_spec_seed(ppp, output_meta),
+                input_specs=(input_spec,),
+            ),
+        ),
+        dtype_node.name: StrategySeed(
+            sss,
+            OpSpecSeed(output_specs=output_spec, input_specs=(output_spec,)),
+        ),
+        alias_node.name: StrategySeed(
+            sss,
+            OpSpecSeed(output_specs=output_spec, input_specs=(output_spec,)),
+        ),
+    }
+
+    optimizer = ShardingOptimizer(
+        gm,
+        mesh,
+        repeated_subgraphs=False,
+        build_pulp=False,
+        build_costs=True,
+        strategy_seed=seed,
+        strategy_radius=2,
+    )
+    nodes = {node.name: node for node in optimizer.graph.nodes}
+    sum_strategies = optimizer.strats[nodes[sum_node.name]].strategies
+    dtype_strategies = optimizer.strats[nodes[dtype_node.name]].strategies
+
+    assert all(strategy.output_spec.placements != sss for strategy in sum_strategies)
+    sum_seed_index = next(
+        index
+        for index, strategy in enumerate(sum_strategies)
+        if strategy.output_spec.placements == ppp
+        and strategy.input_specs[0].placements == sss
+    )
+    dtype_seed = next(
+        strategy
+        for strategy in dtype_strategies
+        if strategy.output_spec.placements == sss
+        and strategy.input_specs[0].placements == sss
+    )
+    assert len(dtype_seed.redistribute_cost[0]) == len(sum_strategies)
+    assert math.isfinite(dtype_seed.redistribute_cost[0][sum_seed_index])
+
+
+@apply_cuda_patches
+def test_real_dsv3_split_dim_search_preserves_all_complete_witnesses():
+    mesh, roles = build_moe_mesh(
+        dp_replicate=1,
+        dp_shard=4,
+        cp=1,
+        tp=2,
+        ep=4,
+    )
+    config = make_dsv3_config(num_experts=8, max_seq_len=2048)
+    with torch.device("meta"):
+        model = DeepSeekV3Model(
+            config,
+            mesh=mesh,
+            roles=roles,
+            compute_dtype=torch.float32,
+        )
+
+    def input_fn():
+        return torch.empty(8, 2048, dtype=torch.int64, device="cuda")
+
+    placements = (Shard(0),) * mesh.ndim
+    with AutoParallel(
+        model,
+        input_fn,
+        mesh,
+        mp_policy=MixedPrecisionPolicy(
+            param_dtype=torch.float32,
+            reduce_dtype=torch.float32,
+        ),
+        dynamic=True,
+        solver="approx",
+        lazy_costs=True,
+        strategy_radius=2,
+    ) as autop:
+        autop.add_parameter_memory_constraint(low=None, high=None)
+        autop.add_input_constraints([placements])
+        autop.add_output_constraints([placements])
+        autop._build_split_dim_optimizer()
+        optimizer = autop.sharding_optimizer
+        assert optimizer is not None
+        approximate = ApproximateShardingSolver(optimizer)
+        solution = approximate.get_solution(verbose=False)
+
+    assert solution
+    assert math.isfinite(optimizer.profile["approximate"]["objective"])
+
+    missing = []
+    for node, strategies in optimizer.strats.items():
+        if node.op == "output":
+            continue
+        node_seed = optimizer.strategy_seed.get(node.name)
+        if node_seed is None or node_seed.witness is None:
+            continue
+        if not any(
+            _strategy_matches_seed(strategy, node_seed.witness)
+            for strategy in strategies.strategies
+        ):
+            missing.append(node.name)
+    assert not missing
+
+    sss = (Shard(0),) * mesh.ndim
+    ppp = (Partial("sum"),) * mesh.ndim
+    seeded_chain = None
+    for dtype_node in optimizer.graph.nodes:
+        if dtype_node.target != torch.ops.autoparallel.dtype_cast.default:
+            continue
+        input_nodes = optimizer._all_input_nodes(dtype_node)
+        if len(input_nodes) != 1:
+            continue
+        sum_node = input_nodes[0]
+        if sum_node.target != torch.ops.aten.sum.dim_IntList:
+            continue
+        sum_seed = optimizer.strategy_seed.get(sum_node.name)
+        dtype_seed = optimizer.strategy_seed.get(dtype_node.name)
+        if (
+            sum_seed is not None
+            and dtype_seed is not None
+            and sum_seed.output_placements == ppp
+            and dtype_seed.output_placements == sss
+        ):
+            seeded_chain = sum_node, dtype_node, sum_seed, dtype_seed
+            break
+    assert seeded_chain is not None
+
+    sum_node, dtype_node, sum_seed, dtype_seed = seeded_chain
+    assert sum_seed.witness is not None
+    assert dtype_seed.witness is not None
+    sum_strategy = next(
+        strategy
+        for strategy in optimizer.strats[sum_node].strategies
+        if _strategy_matches_seed(strategy, sum_seed.witness)
+    )
+    dtype_strategy = next(
+        strategy
+        for strategy in optimizer.strats[dtype_node].strategies
+        if _strategy_matches_seed(strategy, dtype_seed.witness)
+    )
+    assert sum_strategy.output_spec.placements == ppp
+    assert dtype_strategy.input_specs[0].placements == sss
+    assert dtype_strategy.output_spec.placements == sss
+    assert math.isfinite(
+        estimate_strategy_comms_cost(
+            sum_strategy.output_spec, dtype_strategy.input_specs[0]
+        )
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_split_dim_seed.py
+++ b/tests/test_split_dim_seed.py
@@ -48,6 +48,58 @@ def _input_fn():
     return torch.randn(8, 16, device="cuda", requires_grad=True)
 
 
+@pytest.mark.parametrize(
+    ("strategy_radius", "seed_input_placements", "message"),
+    (
+        (2, None, "must be provided together"),
+        (None, (Shard(0), Replicate(), Replicate()), "must be provided together"),
+        (-1, (Shard(0), Replicate(), Replicate()), "must be non-negative"),
+        (2, (Shard(0), Replicate()), "one placement per mesh dim"),
+    ),
+)
+@apply_cuda_patches
+def test_split_dim_public_options_validate(
+    device_mesh_3d, strategy_radius, seed_input_placements, message
+):
+    with torch.device("meta"):
+        model = TinyMLP()
+
+    with pytest.raises(ValueError, match=message):
+        AutoParallel(
+            model,
+            _input_fn,
+            device_mesh_3d,
+            strategy_radius=strategy_radius,
+            seed_input_placements=seed_input_placements,
+        )
+
+
+@apply_cuda_patches
+def test_auto_parallel_split_dim_search(device_mesh_3d):
+    with torch.device("meta"):
+        model = TinyMLP()
+
+    placement = (Shard(0), Replicate(), Replicate())
+    with AutoParallel(
+        model,
+        _input_fn,
+        device_mesh_3d,
+        repeated_subgraphs=False,
+        solver="approx",
+        strategy_radius=2,
+        seed_input_placements=placement,
+    ) as autop:
+        autop.add_parameter_memory_constraint(low=None, high=None)
+        autop.add_input_constraints([placement])
+        autop.add_output_constraints([placement])
+        solution = autop.optimize_placement()
+
+    assert solution
+    profile = autop.sharding_optimizer.profile["approximate"]
+    assert profile["status"] == "Heuristic"
+    assert math.isfinite(profile["objective"])
+
+
 def test_split_dim_projects_local_map_placements(device_mesh_3d):
     dim_names = device_mesh_3d.mesh_dim_names
     assert dim_names is not None

--- a/tests/test_split_dim_seed.py
+++ b/tests/test_split_dim_seed.py
@@ -1,0 +1,142 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+
+import pulp
+import pytest
+import torch
+from conftest import apply_cuda_patches
+from torch._subclasses.fake_tensor import unset_fake_temporarily
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor.placement_types import Partial, Replicate, Shard
+
+from autoparallel._testing.models.dsv3 import (
+    MoEMeshRoles,
+    build_moe_local_map_placements,
+)
+from autoparallel.api import AutoParallel
+from autoparallel.cost_models.nccl_cost_model import h100_topo_config
+from autoparallel.mesh_search import (
+    _project_local_map_to_dim,
+    _split_dim_seed_cache_key,
+    build_split_dim_seed,
+)
+from autoparallel.optimize_sharding import ShardingOptimizer
+
+pytestmark = [
+    pytest.mark.filterwarnings("ignore:Constructing LpVariable.*:DeprecationWarning"),
+    pytest.mark.filterwarnings(
+        "ignore:Using LpProblem.constraints.*:DeprecationWarning"
+    ),
+]
+
+
+class TinyMLP(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.in_proj = torch.nn.Linear(16, 32)
+        self.out_proj = torch.nn.Linear(32, 16)
+
+    def forward(self, x):
+        return self.out_proj(torch.relu(self.in_proj(x)))
+
+
+def _input_fn():
+    return torch.randn(8, 16, device="cuda", requires_grad=True)
+
+
+def test_split_dim_projects_local_map_placements(device_mesh_3d):
+    dim_names = device_mesh_3d.mesh_dim_names
+    assert dim_names is not None
+    roles = MoEMeshRoles(ep_axis_names=(dim_names[1], dim_names[2]), ep_group_name="ep")
+    token, weight, count = build_moe_local_map_placements(dim_names, roles)
+
+    graph = torch.fx.Graph()
+    node = graph.placeholder("x")
+    graph.output(node)
+    gm = torch.fx.GraphModule({}, graph)
+    local_map_kwargs = {
+        "in_placements": (token, weight, None),
+        "out_placements": (token, count),
+        "device_mesh": device_mesh_3d,
+    }
+    node.meta["local_map_kwargs"] = local_map_kwargs
+
+    for dim_idx, dim_name in enumerate(dim_names):
+        mesh_1d = device_mesh_3d[dim_name]
+        with _project_local_map_to_dim(gm, mesh_1d, dim_idx, len(dim_names)):
+            projected = node.meta["local_map_kwargs"]
+            assert projected["device_mesh"] == mesh_1d
+            assert projected["in_placements"] == (
+                (Shard(0),),
+                ((Replicate(),) if dim_idx == 0 else (Shard(0),)),
+                None,
+            )
+            assert projected["out_placements"] == (
+                (Shard(0),),
+                (Partial("sum"),),
+            )
+        assert node.meta["local_map_kwargs"] is local_map_kwargs
+
+    shape = tuple(device_mesh_3d.shape)
+    assert _split_dim_seed_cache_key(
+        shape[0], Replicate(), "roofline", shape, 0, fabric_aware=False
+    ) != _split_dim_seed_cache_key(
+        shape[1], Replicate(), "roofline", shape, 1, fabric_aware=False
+    )
+
+
+@apply_cuda_patches
+def test_split_dim_seed_hamming_space_solves_with_ilp_and_lp():
+    config = h100_topo_config(num_nodes=2, gpus_per_node=4)
+    with unset_fake_temporarily():
+        mesh = init_device_mesh(
+            "cuda",
+            (2, 2, 2),
+            mesh_dim_names=("dp", "mid", "inner"),
+        )
+
+    with torch.device("meta"):
+        model = TinyMLP()
+
+    input_placement = (Shard(0), Replicate(), Replicate())
+    one_d_cache = {}
+
+    with AutoParallel(
+        model,
+        _input_fn,
+        mesh,
+        cost_model=config,
+        repeated_subgraphs=False,
+    ) as autop:
+        seed = build_split_dim_seed(
+            autop.gm,
+            tuple(mesh.shape),
+            input_placement,
+            cost_model=config,
+            repeated_subgraphs=False,
+            one_d_cache=one_d_cache,
+        )
+
+        opt = ShardingOptimizer(
+            autop.gm,
+            mesh,
+            repeated_subgraphs=False,
+            strategy_seed=seed,
+            strategy_radius=2,
+        )
+        opt.add_sharded_input_constraint([input_placement])
+        opt.add_sharded_output_constraint([input_placement])
+        opt.add_parameter_memory_constraint(0.0, 1.0)
+
+        lp_result = opt.solve_lp_relaxation(extract=True)
+        assert lp_result["status"] == "Optimal"
+        assert math.isfinite(lp_result["objective"])
+
+        solution = opt.get_solution(verbose=False)
+        assert solution
+        assert pulp.LpStatus[opt.prob.status] == "Optimal"
+        assert math.isfinite(pulp.value(opt.prob.objective))

--- a/tests/test_split_dim_seed.py
+++ b/tests/test_split_dim_seed.py
@@ -20,9 +20,9 @@ from autoparallel._testing.models.dsv3 import (
 from autoparallel.api import AutoParallel
 from autoparallel.cost_models.nccl_cost_model import h100_topo_config
 from autoparallel.mesh_search import (
+    _build_split_dim_seed,
     _project_local_map_to_dim,
     _split_dim_seed_cache_key,
-    build_split_dim_seed,
 )
 from autoparallel.optimize_sharding import ShardingOptimizer
 
@@ -49,18 +49,16 @@ def _input_fn():
 
 
 @pytest.mark.parametrize(
-    ("strategy_radius", "seed_input_placements", "message"),
+    ("strategy_radius", "message"),
     (
-        (2, None, "must be provided together"),
-        (None, (Shard(0), Replicate(), Replicate()), "must be provided together"),
-        (-1, (Shard(0), Replicate(), Replicate()), "must be non-negative"),
-        (2, (Shard(0), Replicate()), "one placement per mesh dim"),
+        (-1, "must be non-negative"),
+        (3, "smaller than the mesh dimensionality"),
+        (1.5, "must be an integer"),
+        (True, "must be an integer"),
     ),
 )
 @apply_cuda_patches
-def test_split_dim_public_options_validate(
-    device_mesh_3d, strategy_radius, seed_input_placements, message
-):
+def test_split_dim_public_options_validate(device_mesh_3d, strategy_radius, message):
     with torch.device("meta"):
         model = TinyMLP()
 
@@ -69,9 +67,53 @@ def test_split_dim_public_options_validate(
             model,
             _input_fn,
             device_mesh_3d,
+            solver="approx",
             strategy_radius=strategy_radius,
-            seed_input_placements=seed_input_placements,
         )
+
+
+@apply_cuda_patches
+def test_split_dim_large_radius_warns():
+    with unset_fake_temporarily():
+        mesh = init_device_mesh(
+            "cuda", (2, 2, 2, 2), mesh_dim_names=("d0", "d1", "d2", "d3")
+        )
+    with torch.device("meta"):
+        model = TinyMLP()
+
+    with pytest.warns(UserWarning, match="greater than 2"):
+        AutoParallel(model, _input_fn, mesh, solver="approx", strategy_radius=3)
+
+
+@pytest.mark.parametrize("strategy_radius", (None, 0))
+@apply_cuda_patches
+def test_split_dim_can_be_disabled(device_mesh_3d, strategy_radius):
+    with torch.device("meta"):
+        model = TinyMLP()
+
+    with AutoParallel(
+        model,
+        _input_fn,
+        device_mesh_3d,
+        repeated_subgraphs=False,
+        solver="approx",
+        strategy_radius=strategy_radius,
+    ) as autop:
+        placement = (Shard(0), Replicate(), Replicate())
+        autop.add_input_constraints([placement])
+        autop.add_output_constraints([placement])
+        solution = autop.optimize_placement(verbose=False)
+
+    assert solution
+
+
+@apply_cuda_patches
+def test_split_dim_radius_ignored_for_non_approx_and_2d(device_mesh_2d, device_mesh_3d):
+    with torch.device("meta"):
+        model = TinyMLP()
+
+    AutoParallel(model, _input_fn, device_mesh_3d, solver="ilp", strategy_radius=-1)
+    AutoParallel(model, _input_fn, device_mesh_2d, solver="approx", strategy_radius=2)
 
 
 @apply_cuda_patches
@@ -86,8 +128,6 @@ def test_auto_parallel_split_dim_search(device_mesh_3d):
         device_mesh_3d,
         repeated_subgraphs=False,
         solver="approx",
-        strategy_radius=2,
-        seed_input_placements=placement,
     ) as autop:
         autop.add_parameter_memory_constraint(low=None, high=None)
         autop.add_input_constraints([placement])
@@ -134,10 +174,11 @@ def test_split_dim_projects_local_map_placements(device_mesh_3d):
         assert node.meta["local_map_kwargs"] is local_map_kwargs
 
     shape = tuple(device_mesh_3d.shape)
+    constraints = ((("R",),), (("R",),))
     assert _split_dim_seed_cache_key(
-        shape[0], Replicate(), "roofline", shape, 0, fabric_aware=False
+        shape[0], constraints, "roofline", shape, 0, fabric_aware=False
     ) != _split_dim_seed_cache_key(
-        shape[1], Replicate(), "roofline", shape, 1, fabric_aware=False
+        shape[1], constraints, "roofline", shape, 1, fabric_aware=False
     )
 
 
@@ -164,10 +205,11 @@ def test_split_dim_seed_hamming_space_solves_with_ilp_and_lp():
         cost_model=config,
         repeated_subgraphs=False,
     ) as autop:
-        seed = build_split_dim_seed(
+        seed = _build_split_dim_seed(
             autop.gm,
             tuple(mesh.shape),
-            input_placement,
+            input_constraints=[input_placement],
+            output_constraints=[input_placement],
             cost_model=config,
             repeated_subgraphs=False,
             one_d_cache=one_d_cache,


### PR DESCRIPTION
## Summary

Fourth PR in the PR519 review stack. It adds split-dimension seed search on top of lazy TRW-S. Each active 1D seed solve projects the existing user input/output constraints, `local_map` placements, and fabric topology to that dimension; final N-D strategy enumeration uses a Hamming ball around the composed seed.

The composed seed now retains the complete selected `OpSpec` witness, including input and output specs. If upstream filtering prevents an input-conditioned rule from enumerating that exact legal witness, final enumeration validates and restores it without requiring the producer to expose the consumer placement. The output-placement radius and empty-ball feasibility fallback are unchanged.

The only new user-facing control is `AutoParallel(strategy_radius=2)`. For `solver="approx"` on meshes with more than two dimensions, radius 1 or 2 enables split search; 0 or `None` retains unrestricted lazy TRW-S. Values greater than 2 warn, and a radius at least as large as the mesh dimensionality is rejected. ILP/LP and 1D/2D meshes retain their original behavior. Seed construction is internal.

## Reproduction

The existing `tests/search_profile.py` covers 2D/3D LLaMA and 2D/3D/4D DSv3. `tests/profiling/run_search_profiles.sh` contains the exact row matrix, requires an explicit result directory, records every row's command/status, and returns nonzero if any row fails. Use a clean worktree and place results outside the source checkout:

```bash
: "${RESULTS_DIR:?set RESULTS_DIR to an output directory}"
PYTHON=python tests/profiling/run_search_profiles.sh heuristic "$RESULTS_DIR"
```

The harness uses repository example models, meta tensors, a fake process group, and explicit H100 properties. It measures placement search only, not distributed model execution. Each JSON records the expanded config, environment, Git state, solver status, objective, placement hash, phase timings, and process peak RSS. Lazy approximate rows have no PuLP constraint list; feasibility is represented by `Heuristic` / `Solution Found`, not a post-hoc PuLP constraint scan.

## Current performance

The following single-run observations were collected at `946f0643bea1e40165a63696b3e18982aea07838`. Environment: Python 3.12.13, PyTorch `2.14.0.dev20260629+cu130`, CUDA 13.0, PuLP 3.3.2, AMD EPYC 9654 host. Each row used a deterministic fresh process with `PYTHONHASHSEED=0`, `torch.manual_seed(0)`, parameter bf16, reduction fp32, repeated subgraphs, lazy approximate costs, candidate limit 128, and radius 2 for split rows. Peak RSS is GNU `time -v` maximum resident set size. Heuristic timeout was 20 minutes. Variance is unavailable.

| Workload | Mode | Trace | Seed/other | Optimizer init | Factor build | TRW-S/polish | Search total | Peak RSS | Objective | Split vs full search | Objective vs full |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| LLaMA1B 3D | full | 6.944s | 1.351s | 22.081s | 165.991s | 25.991s | 222.360s | 5.868 GiB | 79097.930376 | baseline | baseline |
| LLaMA1B 3D | split | 7.271s | 10.265s | 8.900s | 29.388s | 9.747s | 65.571s | 2.005 GiB | 79164.311583 | 3.39x (70.5% less) | +0.0839% |
| LLaMA8B 3D | full | 13.911s | 0.495s | 38.532s | 169.638s | 26.304s | 248.881s | 9.123 GiB | 238878.989278 | baseline | baseline |
| LLaMA8B 3D | split | 14.260s | 17.959s | 17.548s | 29.197s | 9.361s | 88.325s | 3.339 GiB | 245903.373465 | 2.82x (64.5% less) | +2.9406% |
| DSv3 3D | full | 47.194s | 1.913s | 16.308s | 207.976s | 30.403s | 303.795s | 5.252 GiB | 43521.386770 | baseline | baseline |
| DSv3 3D | split | 46.781s | 13.272s | 8.805s | 42.625s | 15.584s | 127.067s | 1.959 GiB | 43521.386770 | 2.39x (58.2% less) | +0.0000% |
| DSv3 4D | split | 17.878s | 15.967s | 48.521s | 165.459s | 27.168s | 274.993s | 4.391 GiB | 46853.715738 | n/a | n/a |

`Seed/other` is search time not attributed to graph trace, final optimizer initialization, factor build, solver, or user constraint calls; split rows include the 1D seed solves. `Split vs full search` reports full/split speedup and the split row's reduction in total search time. `Objective vs full` reports `(split / full - 1) * 100`; lower is better. These are single observations, not stable performance claims.

| Workload | Split minus full objective | Changed placements |
|---|---:|---:|
| LLaMA1B 3D | +66.381208 (+0.0839%) | 1298/4299 |
| LLaMA8B 3D | +7024.384187 (+2.9406%) | 2312/8539 |
| DSv3 3D | +0.000000 (+0.0000%) | 0/2288 |

These compare two heuristic searches, not certified optimality gaps. DSv3 3D full and split now have identical objectives and placement hashes. The 4D row is a standalone feasibility result because no unrestricted 4D result was recorded.

## LP probe status

The serial no-timeout LP matrix remains available as:

```bash
: "${RESULTS_DIR:?set RESULTS_DIR to an output directory}"
PYTHON=python tests/profiling/run_search_profiles.sh lp "$RESULTS_DIR"
```

LP probes were not rerun because they do not use split seeds and their search space is unaffected by this correction. Historical probes produced no accepted 3D LP objective: LLaMA1B reached CBC output after 67 minutes but PuLP could not parse the solution file; LLaMA8B returned after 64 minutes but its rounded assignment violated constraints; no accepted DSv3 3D result was recorded. This PR makes no global-optimality or certified suboptimality-gap claim.

## Current validation

```text
Split/API/profile coverage: 70 passed, 1 real-GPU case deselected
Approximate/LP/placement/serialization coverage: 49 passed
Heuristic profile matrix: 7/7 rows succeeded at 946f064
LLaMA1B (2,4,8) seeded smoke: success, 4,299 solution nodes,
  objective 79164.31158306613
Real 8-GPU DSv3 3D float32 E2E: success, 2,047 complete witnesses,
  output relative error 1.786856e-07, worst of 83 gradient
  relative errors 1.281611e-06
Changed-file Black, isort, flake8, mypy, shell syntax, and diff check: passed
```

The real E2E used the repository DSv3 model with a `(2, 2, 2)` physical mesh, applied the selected placement, and compared distributed forward/backward results with a single-GPU reference. All outputs and gradients were finite; the complete seed-witness scan had zero missing nodes and included the intended `PPP -> SSS` redistribution from `sum_2` to `dtype_cast_73`. Limits were 0.005 for output relative error and 0.02 for gradient relative error.

The full repository suite was not run locally. Repository-wide mypy remains red on the same two pre-existing `autoparallel/tools/overlap_simulator/run.py` errors as the PR base; changed-file mypy passes.

Authored with Claude.

## Stack

- 1/4: #520
- 2/4: #521
- 3/4: #522
- **4/4: this PR**
- Aggregate index only: #519

