### PR TITLE
Estimate flex_local_map alternative costs automatically

### DIFF
--- a/autoparallel/_flex_local_map.py
+++ b/autoparallel/_flex_local_map.py
@@ -4,9 +4,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import operator
+from contextlib import ExitStack
 
 import torch
 from torch._dynamo.functional_export import _dynamo_graph_capture_for_export
+from torch._functorch.aot_autograd import aot_export_joint_with_descriptors
 from torch._subclasses.fake_tensor import FakeTensor, unset_fake_temporarily
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from torch.distributed.tensor._op_schema import OpSpec
@@ -14,8 +16,13 @@ from torch.distributed.tensor.placement_types import Replicate
 
 from .cast_parametrization import set_dtype_cast
 from .collectives import get_flex_local_map_alternatives, local_map
+from .graph_passes.graph_utils import (
+    _add_alias,
+    _replace_view_mm_view_with_einsum,
+    cleanup_graph,
+)
 from .shardings.placement_options import _concretize_tensor_meta
-from .tracing import enable_local_map_wrapping
+from .tracing import _get_decomp_table, enable_local_map_wrapping
 
 _TRACE_INFO = "_autoparallel_flex_trace_info"
 
@@ -151,6 +158,20 @@ def _as_tuple(value):
     return tuple(value) if isinstance(value, (tuple, list)) else (value,)
 
 
+def _selected_kwargs(kwargs, alternative, mesh):
+    selected = {
+        key: value
+        for key, value in kwargs.items()
+        if key not in ("alternatives", _TRACE_INFO)
+    }
+    selected.update(
+        in_placements=alternative["in_placements"],
+        out_placements=alternative["out_placements"],
+        device_mesh=mesh,
+    )
+    return selected
+
+
 def _activation_spec(mesh, value):
     if not isinstance(value, torch.Tensor):
         return None
@@ -280,6 +301,99 @@ def _example_args(forward, trace_info):
     return tuple(args)
 
 
+def _trace_alternative_cost_graph(forward, alternative, mesh, stack):
+    from torch._higher_order_ops.local_map import redistribute_fw_inputs
+
+    trace_info = forward.meta["local_map_kwargs"][_TRACE_INFO]
+    example_args = _example_args(forward, trace_info)
+    selected_kwargs = _selected_kwargs(
+        forward.meta["local_map_kwargs"], alternative, mesh
+    )
+    selected_body, selected_output = _trace_body(
+        alternative["fn"], selected_kwargs, example_args
+    )
+    if len(_as_tuple(selected_output)) != len(selected_kwargs["out_placements"]):
+        raise RuntimeError(
+            f"flex_local_map node {forward.name} alternative "
+            f"{alternative['name']!r} changed its output arity"
+        )
+    grad_indices = {
+        index
+        for index, output in enumerate(_as_tuple(selected_output))
+        if isinstance(output, torch.Tensor) and output.requires_grad
+    }
+    if grad_indices != set(trace_info["grad_output_indices"]):
+        raise RuntimeError(
+            f"flex_local_map node {forward.name} alternative "
+            f"{alternative['name']!r} changed its differentiable outputs"
+        )
+
+    fake_mode = next(
+        value.fake_mode
+        for value in torch.utils._pytree.tree_leaves(example_args)
+        if isinstance(value, FakeTensor)
+    )
+    with unset_fake_temporarily(), fake_mode:
+        local_args = redistribute_fw_inputs(
+            example_args, selected_kwargs["in_placements"], mesh
+        )
+    joint = aot_export_joint_with_descriptors(
+        stack,
+        selected_body,
+        local_args,
+        decompositions=_get_decomp_table(),
+    ).graph_module
+    cleanup_graph(joint)
+    _replace_view_mm_view_with_einsum(joint)
+    _add_alias(joint, version="v2")
+    return joint
+
+
+def estimate_flex_local_map_costs(gm, strategies, mesh):
+    from .cost_models.compute_estimation import estimate_local_map_body_runtime_cost
+
+    costs = {}
+    with (
+        set_dtype_cast(True),
+        enable_local_map_wrapping(),
+        torch._dynamo.utils._disable_saved_tensors_hooks_during_tracing(),
+    ):
+        for forward, backward in flex_local_map_pairs(gm.graph.nodes):
+            kwargs = forward.meta["local_map_kwargs"]
+            alternatives = tuple(get_flex_local_map_alternatives(kwargs))
+            if len(strategies[forward].strategies) != len(alternatives):
+                raise RuntimeError(
+                    f"flex_local_map node {forward.name} has mismatched alternatives "
+                    "and strategies"
+                )
+            for index, alternative in enumerate(alternatives):
+                if "cost_hint" in alternative:
+                    cost = float(alternative["cost_hint"])
+                    costs[(forward, index)] = cost
+                    if backward is not None:
+                        costs[(backward, index)] = cost
+                    continue
+                try:
+                    with ExitStack() as stack:
+                        cost_graph = _trace_alternative_cost_graph(
+                            forward, alternative, mesh, stack
+                        )
+                        cost = estimate_local_map_body_runtime_cost(cost_graph, mesh)
+                    if backward is None:
+                        costs[(forward, index)] = cost
+                    else:
+                        pair_cost = cost / 2
+                        costs[(forward, index)] = pair_cost
+                        costs[(backward, index)] = pair_cost
+                except Exception as error:
+                    raise RuntimeError(
+                        f"Failed to estimate flex_local_map node {forward.name} "
+                        f"alternative {index} ({alternative['name']!r})"
+                    ) from error
+
+    return costs
+
+
 def finalize_flex_local_maps(gm, solution, mesh):
     from torch._higher_order_ops.local_map import create_hop_fw_bw
 
@@ -300,16 +414,7 @@ def finalize_flex_local_maps(gm, solution, mesh):
                     f"flex_local_map node {forward.name} has no selected alternative"
                 )
             alternative = alternatives[alternative_index]
-            selected_kwargs = {
-                key: value
-                for key, value in kwargs.items()
-                if key not in ("alternatives", _TRACE_INFO)
-            }
-            selected_kwargs.update(
-                in_placements=alternative["in_placements"],
-                out_placements=alternative["out_placements"],
-                device_mesh=mesh,
-            )
+            selected_kwargs = _selected_kwargs(kwargs, alternative, mesh)
 
             if alternative_index == 0:
                 forward.meta["local_map_kwargs"] = selected_kwargs

--- a/autoparallel/_flex_local_map.py
+++ b/autoparallel/_flex_local_map.py
@@ -9,10 +9,15 @@ from contextlib import ExitStack
 import torch
 from torch._dynamo.functional_export import _dynamo_graph_capture_for_export
 from torch._functorch.aot_autograd import aot_export_joint_with_descriptors
-from torch._subclasses.fake_tensor import FakeTensor, unset_fake_temporarily
+from torch._subclasses.fake_tensor import (
+    FakeTensor,
+    FakeTensorMode,
+    unset_fake_temporarily,
+)
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from torch.distributed.tensor._op_schema import OpSpec
 from torch.distributed.tensor.placement_types import Replicate
+from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
 from .cast_parametrization import set_dtype_cast
 from .collectives import get_flex_local_map_alternatives, local_map
@@ -302,10 +307,21 @@ def _example_args(forward, trace_info):
 
 
 def _trace_alternative_cost_graph(forward, alternative, mesh, stack):
-    from torch._higher_order_ops.local_map import redistribute_fw_inputs
-
     trace_info = forward.meta["local_map_kwargs"][_TRACE_INFO]
     example_args = _example_args(forward, trace_info)
+    fake_mode = FakeTensorMode(shape_env=ShapeEnv())
+    with unset_fake_temporarily(), fake_mode:
+        example_args = torch.utils._pytree.tree_map_only(
+            torch.Tensor,
+            lambda value: torch.empty_strided(
+                tuple(int(dim) for dim in value.shape),
+                tuple(int(stride) for stride in value.stride()),
+                dtype=value.dtype,
+                device=value.device,
+                requires_grad=value.requires_grad,
+            ),
+            example_args,
+        )
     selected_kwargs = _selected_kwargs(
         forward.meta["local_map_kwargs"], alternative, mesh
     )
@@ -328,21 +344,19 @@ def _trace_alternative_cost_graph(forward, alternative, mesh, stack):
             f"{alternative['name']!r} changed its differentiable outputs"
         )
 
-    fake_mode = next(
-        value.fake_mode
-        for value in torch.utils._pytree.tree_leaves(example_args)
-        if isinstance(value, FakeTensor)
+    local_args = tuple(
+        _value(node) for node in selected_body.graph.nodes if node.op == "placeholder"
     )
-    with unset_fake_temporarily(), fake_mode:
-        local_args = redistribute_fw_inputs(
-            example_args, selected_kwargs["in_placements"], mesh
-        )
-    joint = aot_export_joint_with_descriptors(
-        stack,
-        selected_body,
-        local_args,
-        decompositions=_get_decomp_table(),
-    ).graph_module
+    fake_mode = next(
+        value.fake_mode for value in local_args if isinstance(value, FakeTensor)
+    )
+    with fake_mode:
+        joint = aot_export_joint_with_descriptors(
+            stack,
+            selected_body,
+            local_args,
+            decompositions=_get_decomp_table(),
+        ).graph_module
     cleanup_graph(joint)
     _replace_view_mm_view_with_einsum(joint)
     _add_alias(joint, version="v2")

--- a/autoparallel/_testing/models/dsv3.py
+++ b/autoparallel/_testing/models/dsv3.py
@@ -703,6 +703,41 @@ def local_mapped_region(
     return out, total_tokens_per_expert
 
 
+def _local_mapped_region_no_ep(
+    x: torch.Tensor,
+    selected_experts_indices: torch.Tensor,
+    top_scores: torch.Tensor,
+    experts_w1: torch.Tensor,
+    experts_w3: torch.Tensor,
+    experts_w2: torch.Tensor,
+    out: torch.Tensor,
+    top_k: int,
+    num_experts: int,
+    score_before_experts: bool,
+    axis_name: str,
+) -> torch.Tensor:
+    routed_output = torch.zeros_like(x)
+    for expert_index in range(num_experts):
+        score = torch.where(
+            selected_experts_indices == expert_index,
+            top_scores,
+            torch.zeros_like(top_scores),
+        ).sum(dim=-1, keepdim=True)
+        expert_input = x
+        if score_before_experts:
+            expert_input = (x.to(torch.float32) * score).to(x.dtype)
+        expert_output = functional_feed_forward(
+            experts_w1[expert_index],
+            experts_w2[expert_index],
+            experts_w3[expert_index],
+            expert_input,
+        )
+        if not score_before_experts:
+            expert_output = (expert_output.to(torch.float32) * score).to(x.dtype)
+        routed_output = routed_output + expert_output
+    return out + routed_output
+
+
 # @local_mapped_region.register_fake
 def _(
     routed_input: torch.Tensor,

--- a/autoparallel/collectives.py
+++ b/autoparallel/collectives.py
@@ -15,27 +15,27 @@ from torch.distributed.device_mesh import DeviceMesh, _mesh_resources
 from torch.distributed.distributed_c10d import GroupName
 from torch.distributed.tensor.placement_types import Placement
 
-_FLEX_LOCAL_MAP_ALTERNATIVES_ATTR = "_autoparallel_flex_local_map_alternatives"
-
 
 # Dynamo's local_map HOP only preserves placement kwargs in FX metadata.
 # Carry flex metadata on out_placements so slicing in the HOP wrapper keeps it.
 class _FlexLocalMapOutPlacements(tuple):
+    alternatives: tuple[dict[str, Any], ...]
+
     def __new__(cls, values, alternatives):
         obj = super().__new__(cls, values)
-        setattr(obj, _FLEX_LOCAL_MAP_ALTERNATIVES_ATTR, alternatives)
+        obj.alternatives = alternatives
         return obj
 
     def __getnewargs__(self):
         # AutoParallel deep-copies the user model (api.py), which reconstructs
         # this tuple subclass via copyreg.__newobj__ -> __new__(cls, *args).
         # The two-arg __new__ requires we surface `alternatives` here too.
-        return (tuple(self), getattr(self, _FLEX_LOCAL_MAP_ALTERNATIVES_ATTR))
+        return (tuple(self), self.alternatives)
 
     def __getitem__(self, item):
         result = super().__getitem__(item)
         if isinstance(item, slice):
-            return type(self)(result, getattr(self, _FLEX_LOCAL_MAP_ALTERNATIVES_ATTR))
+            return type(self)(result, self.alternatives)
         return result
 
 
@@ -46,9 +46,8 @@ def get_flex_local_map_alternatives(local_map_kwargs):
 
     for key in ("out_placements", "in_placements"):
         placements = local_map_kwargs.get(key)
-        alternatives = getattr(placements, _FLEX_LOCAL_MAP_ALTERNATIVES_ATTR, None)
-        if alternatives is not None:
-            return alternatives
+        if isinstance(placements, _FlexLocalMapOutPlacements):
+            return placements.alternatives
 
     return None
 

--- a/autoparallel/collectives.py
+++ b/autoparallel/collectives.py
@@ -56,6 +56,7 @@ def get_flex_local_map_alternatives(local_map_kwargs):
 def _normalize_flex_local_map_alternatives(
     default_fn: Callable,
     alternatives: Sequence[dict[str, Any]],
+    auto_cost: bool,
 ):
     if not alternatives:
         raise ValueError("flex_local_map requires at least one alternative")
@@ -78,25 +79,27 @@ def _normalize_flex_local_map_alternatives(
         fn = alternative.get("fn", default_fn)
         if not callable(fn):
             raise TypeError(f"flex_local_map alternative {idx} fn must be callable")
-        try:
-            cost_hint = float(alternative.get("cost_hint", 0.0))
-        except (TypeError, ValueError) as error:
-            raise TypeError(
-                f"flex_local_map alternative {idx} cost_hint must be a number"
-            ) from error
-        if not math.isfinite(cost_hint) or cost_hint < 0:
-            raise ValueError(
-                f"flex_local_map alternative {idx} cost_hint must be finite and "
-                "non-negative"
-            )
-        normalized.append(
-            {
-                **alternative,
-                "fn": fn,
-                "cost_hint": cost_hint,
-                "name": alternative.get("name", getattr(fn, "__name__", f"alt_{idx}")),
-            }
-        )
+        normalized_alternative = {
+            **alternative,
+            "fn": fn,
+            "name": alternative.get("name", getattr(fn, "__name__", f"alt_{idx}")),
+        }
+        if "cost_hint" in alternative:
+            try:
+                cost_hint = float(alternative["cost_hint"])
+            except (TypeError, ValueError) as error:
+                raise TypeError(
+                    f"flex_local_map alternative {idx} cost_hint must be a number"
+                ) from error
+            if not math.isfinite(cost_hint) or cost_hint < 0:
+                raise ValueError(
+                    f"flex_local_map alternative {idx} cost_hint must be finite and "
+                    "non-negative"
+                )
+            normalized_alternative["cost_hint"] = cost_hint
+        elif not auto_cost:
+            normalized_alternative["cost_hint"] = 0.0
+        normalized.append(normalized_alternative)
 
     input_arity = len(normalized[0]["in_placements"])
     output_arity = len(normalized[0]["out_placements"])
@@ -120,13 +123,15 @@ def flex_local_map(
     device_mesh: DeviceMesh,
     in_grad_placements=None,
     redistribute_inputs: bool = False,
+    auto_cost: bool = True,
 ):
     """Like ``local_map``, but declares several placement alternatives for one region so
     the AutoParallel solver can choose among them (e.g. MoE DP->EP vs DP+TP->EP+ETP).
 
     Each entry of ``alternatives`` is a dict with ``in_placements`` and ``out_placements``
     (required) and optional ``fn`` (defaults to ``func``), ``name``, and ``cost_hint`` (a
-    non-negative solver cost hint, default 0.0). ``device_mesh`` must be explicit.
+    non-negative solver cost overriding automatic estimation). ``device_mesh`` must be
+    explicit. ``auto_cost`` estimates alternatives without a ``cost_hint`` by default.
     ``in_grad_placements`` is reserved for parity with ``local_map`` but is not yet
     supported by AutoParallel.
 
@@ -137,6 +142,8 @@ def flex_local_map(
         raise NotImplementedError(
             "flex_local_map does not yet support in_grad_placements"
         )
+    if not isinstance(auto_cost, bool):
+        raise TypeError("flex_local_map auto_cost must be a bool")
 
     if func is None:
         return functools.partial(
@@ -145,9 +152,12 @@ def flex_local_map(
             device_mesh=device_mesh,
             in_grad_placements=in_grad_placements,
             redistribute_inputs=redistribute_inputs,
+            auto_cost=auto_cost,
         )
 
-    normalized_alternatives = _normalize_flex_local_map_alternatives(func, alternatives)
+    normalized_alternatives = _normalize_flex_local_map_alternatives(
+        func, alternatives, auto_cost
+    )
     default_alternative = normalized_alternatives[0]
     out_placements = _FlexLocalMapOutPlacements(
         tuple(default_alternative["out_placements"]),

--- a/autoparallel/cost_models/collective_runtime_estimation.py
+++ b/autoparallel/cost_models/collective_runtime_estimation.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from typing import cast
 
+import torch
 import torch.distributed.tensor._dtensor_spec as dtensor_spec
 from torch._prims_common import check_contiguous_sizes_strides
 from torch.distributed.tensor._collective_utils import (
@@ -39,6 +40,80 @@ def set_nccl_topo_config(config: NCCLTopoConfig | None) -> None:
 
 def get_nccl_topo_config() -> NCCLTopoConfig | None:
     return _nccl_topo_config
+
+
+def _node_value(value):
+    if not isinstance(value, torch.fx.Node):
+        return value
+    for key in ("val", "example_value"):
+        if key in value.meta:
+            return value.meta[key]
+    raise RuntimeError(f"FX node {value.name} has no example value")
+
+
+def estimate_local_map_collective_cost(node, mesh) -> float | None:
+    if node.op != "call_function":
+        return None
+
+    if node.target == torch.ops._c10d_functional.wait_tensor.default:
+        return 0.0
+    elif node.target == torch.ops._c10d_functional.all_gather_into_tensor.default:
+        collective = "allgather"
+        group_index = 2
+        group_size_index = 1
+        tensor_value = node
+    elif node.target == torch.ops._c10d_functional.reduce_scatter_tensor.default:
+        collective = "reduce_scatter"
+        group_index = 3
+        group_size_index = 2
+        tensor_value = node.args[0]
+    elif node.target == torch.ops._c10d_functional.all_reduce.default:
+        collective = "allreduce"
+        group_index = 2
+        group_size_index = None
+        tensor_value = node.args[0]
+    elif node.target == torch.ops._c10d_functional.all_to_all_single.default:
+        collective = "all_to_all"
+        group_index = 3
+        group_size_index = None
+        tensor_value = node.args[0]
+    elif str(node.target).startswith("_c10d_functional."):
+        raise RuntimeError(f"Unsupported local_map collective {node.target}")
+    else:
+        return None
+
+    args = tuple(_node_value(arg) for arg in node.args)
+    group_name = args[group_index]
+    mesh_dims = [
+        mesh_dim
+        for mesh_dim in range(mesh.ndim)
+        if mesh.get_group(mesh_dim).group_name == group_name
+    ]
+    if len(mesh_dims) != 1:
+        raise RuntimeError(
+            f"Collective group {group_name!r} maps to {len(mesh_dims)} mesh dimensions"
+        )
+    mesh_dim = mesh_dims[0]
+
+    if group_size_index is not None:
+        group_size = args[group_size_index]
+        if group_size != mesh.size(mesh_dim):
+            raise RuntimeError(
+                f"Collective group size {group_size} does not match mesh dimension "
+                f"size {mesh.size(mesh_dim)}"
+            )
+
+    tensor = _node_value(tensor_value)
+    if not isinstance(tensor, torch.Tensor):
+        raise RuntimeError(f"Collective {node.target} has no tensor metadata")
+    comm_bytes = tensor.numel() * tensor.element_size()
+    return collective_comm_cost(
+        collective,
+        int(comm_bytes),
+        tuple(mesh.shape),
+        mesh_dim,
+        MeshTopoInfo.build_from_mesh(mesh),
+    )
 
 
 def _nccl_comm_cost(

--- a/autoparallel/cost_models/collective_runtime_estimation.py
+++ b/autoparallel/cost_models/collective_runtime_estimation.py
@@ -19,7 +19,7 @@ from torch.distributed.tensor._collective_utils import (
 )
 from torch.distributed.tensor.placement_types import Partial, Shard
 
-from .compute_estimation import compute_read_write_time
+from .compute_estimation import _concretize_unbacked_numel, compute_read_write_time
 from .nccl_cost_model import (
     NCCLTopoConfig,
     derive_mesh_dim_topo,
@@ -51,7 +51,9 @@ def _node_value(value):
     raise RuntimeError(f"FX node {value.name} has no example value")
 
 
-def estimate_local_map_collective_cost(node, mesh) -> float | None:
+def estimate_local_map_collective_cost(
+    node, mesh, balanced_tokens=None
+) -> float | None:
     if node.op != "call_function":
         return None
 
@@ -106,7 +108,12 @@ def estimate_local_map_collective_cost(node, mesh) -> float | None:
     tensor = _node_value(tensor_value)
     if not isinstance(tensor, torch.Tensor):
         raise RuntimeError(f"Collective {node.target} has no tensor metadata")
-    comm_bytes = tensor.numel() * tensor.element_size()
+    numel = (
+        tensor.numel()
+        if balanced_tokens is None
+        else _concretize_unbacked_numel(tensor, balanced_tokens)
+    )
+    comm_bytes = numel * tensor.element_size()
     return collective_comm_cost(
         collective,
         int(comm_bytes),

--- a/autoparallel/cost_models/compute_estimation.py
+++ b/autoparallel/cost_models/compute_estimation.py
@@ -331,9 +331,16 @@ def compute_memory_cost(op, args, outs):
     return read_bytes + write_bytes
 
 
+def _node_value(node):
+    for key in ("val", "example_value"):
+        if key in node.meta:
+            return node.meta[key]
+    raise RuntimeError(f"FX node {node.name} has no example value")
+
+
 def _shard_args_for_node(node, strategy=None, rand_init=False):
-    args = tree_map_only(torch.fx.Node, lambda x: x.meta["val"], node.args)
-    kwargs = tree_map_only(torch.fx.Node, lambda x: x.meta["val"], node.kwargs)
+    args = tree_map_only(torch.fx.Node, _node_value, node.args)
+    kwargs = tree_map_only(torch.fx.Node, _node_value, node.kwargs)
 
     if strategy is None:
         return args, kwargs
@@ -365,7 +372,19 @@ def _shard_args_for_node(node, strategy=None, rand_init=False):
     return args, kwargs
 
 
+def _is_flex_local_map_hop(node):
+    local_map_kwargs = node.meta.get("local_map_kwargs", {})
+    return (
+        node.op == "call_function"
+        and isinstance(node.target, torch._ops.HigherOrderOperator)
+        and local_map_kwargs.get("alternatives") is not None
+    )
+
+
 def _has_zero_cost(node):
+    if _is_flex_local_map_hop(node):
+        return False
+
     if node.op != "call_function":
         return True
 
@@ -443,6 +462,11 @@ def estimate_strategy_runtime_cost(node, strategy):
     inputs according to the strategy. It then uses the device
     specifications to estimate the runtime cost of the node.
     """
+    if _is_flex_local_map_hop(node):
+        raise RuntimeError(
+            f"local_map node {node.name} requires optimizer-owned body cost"
+        )
+
     if _has_zero_cost(node):
         return 0
 
@@ -493,6 +517,23 @@ def estimate_strategy_runtime_cost(node, strategy):
     return result
 
 
+def estimate_local_map_body_runtime_cost(body, mesh):
+    from .collective_runtime_estimation import estimate_local_map_collective_cost
+
+    cost = 0.0
+    for node in body.graph.nodes:
+        if node.op in ("placeholder", "get_attr", "output"):
+            continue
+        collective_cost = estimate_local_map_collective_cost(node, mesh)
+        if collective_cost is not None:
+            cost += collective_cost
+            continue
+        if isinstance(node.target, torch._ops.HigherOrderOperator):
+            raise RuntimeError(f"Unsupported local_map higher-order op {node.target}")
+        cost += estimate_strategy_runtime_cost(node, strategy=None)
+    return cost
+
+
 def benchmark_strategy_runtime_cost(node, strategy):
     """
     This is the counterpart for estimate_strategy_runtime_cost
@@ -500,6 +541,9 @@ def benchmark_strategy_runtime_cost(node, strategy):
     cost. This is useful for debugging the cost model and for
     cases where estimate_strategy_runtime_cost is not accurate.
     """
+    if _is_flex_local_map_hop(node):
+        raise RuntimeError(f"Cannot benchmark local_map node {node.name} directly")
+
     if _has_zero_cost(node):
         return 0
 

--- a/autoparallel/cost_models/compute_estimation.py
+++ b/autoparallel/cost_models/compute_estimation.py
@@ -8,6 +8,7 @@ from typing import Dict, Tuple
 
 import torch
 from torch._subclasses.fake_tensor import unset_fake_temporarily
+from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
 from torch.utils._mode_utils import no_dispatch
 from torch.utils._pytree import tree_flatten, tree_map_only
 from torch.utils.flop_counter import FlopCounterMode, register_flop_formula
@@ -42,6 +43,12 @@ def einsum_flop(equation, tensors, out=None, **kwargs) -> int:
         return batch_size * n * k * 2
     else:
         raise NotImplementedError(f"Unsupported einsum shapes: {a_shape} {b_shape}")
+
+
+@register_flop_formula(torch.ops.aten._grouped_mm, get_raw=True)
+def grouped_mm_flop(mat1, mat2, offs=None, bias=None, out_dtype=None, **kwargs) -> int:
+    groups = offs.shape[0] if mat1.ndim == mat2.ndim == 2 else 1
+    return 2 * groups * mat1.numel() * mat2.shape[-1]
 
 
 @dataclass
@@ -338,11 +345,65 @@ def _node_value(node):
     raise RuntimeError(f"FX node {node.name} has no example value")
 
 
-def _shard_args_for_node(node, strategy=None, rand_init=False):
+def _concretize_unbacked_dim(value, balanced_tokens):
+    if not isinstance(value, torch.SymInt) or value.node.hint is not None:
+        return value
+    symbols = free_unbacked_symbols(value)
+    if not symbols:
+        return value
+    per_symbol = (balanced_tokens + len(symbols) - 1) // len(symbols)
+    return value.node.shape_env.optimization_hint(value.node.expr, fallback=per_symbol)
+
+
+def _concretize_unbacked_tensor(value, balanced_tokens):
+    if not any(
+        isinstance(dim, torch.SymInt) and free_unbacked_symbols(dim)
+        for dim in value.shape
+    ):
+        return value
+    shape = tuple(_concretize_unbacked_dim(dim, balanced_tokens) for dim in value.shape)
+    return torch.empty(
+        shape,
+        dtype=value.dtype,
+        device=value.device,
+        requires_grad=value.requires_grad,
+    )
+
+
+def _concretize_unbacked_numel(value, balanced_tokens):
+    shape = (_concretize_unbacked_dim(dim, balanced_tokens) for dim in value.shape)
+    result = 1
+    for dim in shape:
+        result *= dim
+    return int(result)
+
+
+def _shard_args_for_node(node, strategy=None, rand_init=False, balanced_tokens=None):
     args = tree_map_only(torch.fx.Node, _node_value, node.args)
     kwargs = tree_map_only(torch.fx.Node, _node_value, node.kwargs)
 
     if strategy is None:
+        if balanced_tokens is not None:
+            args = tree_map_only(
+                torch.SymInt,
+                lambda value: _concretize_unbacked_dim(value, balanced_tokens),
+                args,
+            )
+            kwargs = tree_map_only(
+                torch.SymInt,
+                lambda value: _concretize_unbacked_dim(value, balanced_tokens),
+                kwargs,
+            )
+            args = tree_map_only(
+                torch.Tensor,
+                lambda value: _concretize_unbacked_tensor(value, balanced_tokens),
+                args,
+            )
+            kwargs = tree_map_only(
+                torch.Tensor,
+                lambda value: _concretize_unbacked_tensor(value, balanced_tokens),
+                kwargs,
+            )
         return args, kwargs
 
     # TODO: handle kwargs as well, for now we assume all tensors are
@@ -454,7 +515,7 @@ def _make_hashable(x):
     return x
 
 
-def estimate_strategy_runtime_cost(node, strategy):
+def estimate_strategy_runtime_cost(node, strategy, balanced_tokens=None):
     """
     This function estimates the runtime cost of a given strategy
     for a given node. It does this by computing the flop count
@@ -490,7 +551,7 @@ def estimate_strategy_runtime_cost(node, strategy):
             if cached is not None:
                 return cached
 
-    args, kwargs = _shard_args_for_node(node, strategy)
+    args, kwargs = _shard_args_for_node(node, strategy, balanced_tokens=balanced_tokens)
 
     flops, out = _compute_flops(node.target, *args, **kwargs)
 
@@ -517,20 +578,41 @@ def estimate_strategy_runtime_cost(node, strategy):
     return result
 
 
-def estimate_local_map_body_runtime_cost(body, mesh):
+def _local_map_body_balanced_tokens(body):
+    for node in body.graph.nodes:
+        if node.target != torch.ops._c10d_functional.all_to_all_single.default:
+            continue
+        output = _node_value(node)
+        if not any(
+            isinstance(dim, torch.SymInt) and free_unbacked_symbols(dim)
+            for dim in output.shape
+        ):
+            continue
+        tensor = _node_value(node.args[0])
+        if isinstance(tensor, torch.Tensor) and tensor.ndim:
+            return int(tensor.shape[0])
+    return None
+
+
+def estimate_local_map_body_runtime_cost(body, mesh, balanced_tokens=None):
     from .collective_runtime_estimation import estimate_local_map_collective_cost
+
+    if balanced_tokens is None:
+        balanced_tokens = _local_map_body_balanced_tokens(body)
 
     cost = 0.0
     for node in body.graph.nodes:
         if node.op in ("placeholder", "get_attr", "output"):
             continue
-        collective_cost = estimate_local_map_collective_cost(node, mesh)
+        collective_cost = estimate_local_map_collective_cost(
+            node, mesh, balanced_tokens=balanced_tokens
+        )
         if collective_cost is not None:
             cost += collective_cost
             continue
-        if isinstance(node.target, torch._ops.HigherOrderOperator):
-            raise RuntimeError(f"Unsupported local_map higher-order op {node.target}")
-        cost += estimate_strategy_runtime_cost(node, strategy=None)
+        cost += estimate_strategy_runtime_cost(
+            node, strategy=None, balanced_tokens=balanced_tokens
+        )
     return cost
 
 

--- a/autoparallel/optimize_sharding.py
+++ b/autoparallel/optimize_sharding.py
@@ -91,7 +91,7 @@ from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from torch.distributed.tensor.placement_types import Placement, Replicate, Shard
 from torch.utils._pytree import tree_map_only
 
-from ._flex_local_map import flex_local_map_pairs
+from ._flex_local_map import estimate_flex_local_map_costs, flex_local_map_pairs
 from .collectives import get_flex_local_map_alternatives
 from .cost_models.collective_runtime_estimation import estimate_strategy_comms_cost
 from .cost_models.compute_estimation import (
@@ -150,15 +150,6 @@ def concretize_args(args):
     return tree_map_only((torch.SymInt, FakeTensor), concretize, args)
 
 
-def _get_flex_local_map_cost_hint(node, out_idx):
-    alternatives = get_flex_local_map_alternatives(
-        node.meta.get("local_map_kwargs", {})
-    )
-    if alternatives is None:
-        return 0.0
-    return float(alternatives[out_idx].get("cost_hint", 0.0))
-
-
 def _freeze_flex_local_map_contract(value):
     if isinstance(value, (tuple, list)):
         return tuple(_freeze_flex_local_map_contract(item) for item in value)
@@ -176,7 +167,11 @@ def _get_flex_local_map_contract(node):
                 alternative.get("name"),
                 _freeze_flex_local_map_contract(alternative["in_placements"]),
                 _freeze_flex_local_map_contract(alternative["out_placements"]),
-                float(alternative.get("cost_hint", 0.0)),
+                (
+                    float(alternative["cost_hint"])
+                    if "cost_hint" in alternative
+                    else None
+                ),
             )
             for alternative in alternatives
         ),
@@ -285,6 +280,9 @@ class ShardingOptimizer:
         self._name_counters: dict[str, int] = {}
         t0 = time.perf_counter()
         self.strats = self.build_sharding_metadata()
+        self.flex_local_map_costs = estimate_flex_local_map_costs(
+            self.gm, self.strats, self.mesh
+        )
         # nodes/node_map are derived from strats (not graph.nodes) so that
         # shape-computation nodes skipped by build_sharding_metadata don't
         # appear and indices stay consistent.
@@ -406,6 +404,23 @@ class ShardingOptimizer:
                             f"flex alternatives: {n0} has {contract0}, {ni} has "
                             f"{contracti}"
                         )
+                    if any(
+                        (n0, index) in self.flex_local_map_costs
+                        for index in range(len(self.strats[n0].strategies))
+                    ):
+                        costs0 = tuple(
+                            self.flex_local_map_costs[(n0, index)]
+                            for index in range(len(self.strats[n0].strategies))
+                        )
+                        costsi = tuple(
+                            self.flex_local_map_costs[(ni, index)]
+                            for index in range(len(self.strats[ni].strategies))
+                        )
+                        if costs0 != costsi:
+                            raise RuntimeError(
+                                "Repeated subgraph local_map nodes must have the same "
+                                f"estimated costs: {n0} has {costs0}, {ni} has {costsi}"
+                            )
                     idx0 = self.node_map[n0]
                     idx1 = self.node_map[ni]
                     options_n0 = list(self.walk_over_options(n0))
@@ -441,6 +456,20 @@ class ShardingOptimizer:
                     f"missing from strats"
                 )
         return result
+
+    def _get_strategy_compute_cost(self, node, out_idx, strategy):
+        cost = self.flex_local_map_costs.get((node, out_idx))
+        if cost is not None:
+            return cost
+        if (
+            get_flex_local_map_alternatives(node.meta.get("local_map_kwargs", {}))
+            is not None
+        ):
+            raise RuntimeError(
+                f"Missing cost for flex_local_map node {node.name} "
+                f"alternative {out_idx}"
+            )
+        return estimate_strategy_runtime_cost(node, strategy)
 
     def walk_over_options(self, node, constrain_arg=None):
         """Yield (argi, out_idx, inp_idx) for all valid strategy combinations."""
@@ -555,8 +584,9 @@ class ShardingOptimizer:
 
             for out_idx, output_strategy in enumerate(op_strategy.strategies):
                 tc0 = time.perf_counter()
-                compute_cost = estimate_strategy_runtime_cost(node, output_strategy)
-                compute_cost += _get_flex_local_map_cost_hint(node, out_idx)
+                compute_cost = self._get_strategy_compute_cost(
+                    node, out_idx, output_strategy
+                )
                 tc1 = time.perf_counter()
                 t_compute += tc1 - tc0
                 per_arg_compute = compute_cost / num_args
@@ -1353,7 +1383,9 @@ class ShardingOptimizer:
                 continue
 
             chosen_placement_str = _pretty_print_spec(chosen_spec)
-            chosen_compute = estimate_strategy_runtime_cost(node, chosen_strategy)
+            chosen_compute = self._get_strategy_compute_cost(
+                node, out_idx, chosen_strategy
+            )
 
             # Compute communication cost for the chosen strategy: sum
             # redistribute_cost across all args using predecessors' chosen
@@ -1374,7 +1406,9 @@ class ShardingOptimizer:
 
             if target_out_idx is not None:
                 target_strategy = op_strategy.strategies[target_out_idx]
-                target_compute = estimate_strategy_runtime_cost(node, target_strategy)
+                target_compute = self._get_strategy_compute_cost(
+                    node, target_out_idx, target_strategy
+                )
 
                 # Compute communication cost for the target strategy:
                 # assume each predecessor also uses target_placement. If a

--- a/autoparallel/serialization.py
+++ b/autoparallel/serialization.py
@@ -329,6 +329,8 @@ def load_optimizer(cls, path):
         len(opt.decision_vars),
     )
 
+    opt.flex_local_map_costs = {}
+
     opt._root_to_linked = defaultdict(list)
     for linked_key, root_key in opt.cluster_links.items():
         opt._root_to_linked[root_key].append(linked_key)

--- a/docs/local_map_and_moe.md
+++ b/docs/local_map_and_moe.md
@@ -393,8 +393,11 @@ self.moe = flex_local_map(
 
 Each alternative is a dict with required `in_placements` and `out_placements`.
 `fn` defaults to the first argument, while `name` and the non-negative `cost_hint`
-are optional. The hint is added to the solver cost; it is not a measured runtime.
-AutoParallel emits one solver strategy per alternative.
+are optional. By default, AutoParallel traces each alternative with its local tensor
+shapes and estimates its compute and collective latency with the existing cost models.
+An explicitly provided `cost_hint`, including `0.0`, overrides that estimate for the
+alternative. Set `auto_cost=False` on `flex_local_map` to retain zero cost for
+alternatives without a hint. AutoParallel emits one solver strategy per alternative.
 
 Usage constraint: apply `flex_local_map` **outside** `forward` and pass an explicit
 `device_mesh`, then call the stored callable inside `forward`. The alternatives are
@@ -408,8 +411,10 @@ backward nodes to the same index. This is the only ILP solve. It then captures t
 selected `fn` through the normal `local_map` Dynamo/AOT path and replaces that callsite's
 forward body, saved activations, and backward body in place. After finalization the node
 is an ordinary single-strategy `local_map` and follows the existing apply path. Only the
-selected function is captured. Alternative functions must preserve the same user-visible
-tensor contract and differentiable outputs; their internal saved activations may differ.
+selected function is installed in the final graph; alternatives without explicit hints
+are also captured with FakeTensors during cost estimation. Alternative functions must
+preserve the same user-visible tensor contract and differentiable outputs; their internal
+saved activations may differ.
 
 ## `with_sharding_constraint` for simpler cases
 

--- a/examples/example_ds3_local_map.py
+++ b/examples/example_ds3_local_map.py
@@ -18,6 +18,7 @@ from torch.testing._internal.distributed.fake_pg import FakeStore
 from autoparallel._testing.models.dsv3 import (
     DeepSeekV3Model,
     MoE,
+    _local_mapped_region_no_ep,
     _moe_local_map_kwargs,
     local_mapped_region,
     make_dsv3_config,
@@ -37,6 +38,7 @@ _LOCAL_MAP_CASES = (
     "plain-replicated-counts",
     "flex-default",
     "flex-replicated-counts",
+    "flex-auto",
 )
 
 
@@ -102,6 +104,43 @@ def _moe_implementation_2(
     )
 
 
+def _moe_implementation_no_ep(
+    x,
+    selected_experts_indices,
+    top_scores,
+    experts_w1,
+    experts_w3,
+    experts_w2,
+    out,
+    *,
+    top_k,
+    num_experts,
+    score_before_experts,
+    axis_name,
+):
+    return _local_mapped_region_no_ep(
+        x,
+        selected_experts_indices,
+        top_scores,
+        experts_w1,
+        experts_w3,
+        experts_w2,
+        out,
+        top_k,
+        num_experts,
+        score_before_experts,
+        axis_name,
+    )
+
+
+def _moe_implementation_ep_output(*args, **kwargs):
+    return (_moe_implementation_2(*args, **kwargs)[0],)
+
+
+def _moe_implementation_no_ep_output(*args, **kwargs):
+    return (_moe_implementation_no_ep(*args, **kwargs),)
+
+
 def _unused_default_moe_implementation(*args):
     raise AssertionError("flex_local_map alternatives must provide their own fn")
 
@@ -117,7 +156,30 @@ def _replicated_counts_moe_local_map_kwargs(mesh):
     }
 
 
-class _FlexMoELocalMap(torch.nn.Module):
+def _no_ep_moe_local_map_kwargs(mesh):
+    kwargs = _moe_local_map_kwargs(mesh)
+    token_placements = (Shard(0), Replicate())
+    weight_placements = (Replicate(), Replicate())
+    return {
+        **kwargs,
+        "in_placements": (
+            token_placements,
+            token_placements,
+            token_placements,
+            weight_placements,
+            weight_placements,
+            weight_placements,
+            token_placements,
+            *kwargs["in_placements"][7:],
+        ),
+        "out_placements": (
+            token_placements,
+            (Partial(reduce_op="sum"), Replicate()),
+        ),
+    }
+
+
+class _ForcedFlexMoELocalMap(torch.nn.Module):
     def __init__(self, moe, mesh, selected_index):
         super().__init__()
         sharded_kwargs = _moe_local_map_kwargs(mesh)
@@ -176,10 +238,81 @@ class _FlexMoELocalMap(torch.nn.Module):
         )
 
 
-def _enable_flex_local_map(model, mesh, selected_index):
+class _FlexMoELocalMap(torch.nn.Module):
+    def __init__(self, moe, mesh):
+        super().__init__()
+        no_ep_kwargs = _no_ep_moe_local_map_kwargs(mesh)
+        ep_kwargs = _moe_local_map_kwargs(mesh)
+        static_kwargs = {
+            "top_k": moe.router.top_k,
+            "num_experts": moe.router.num_experts,
+            "score_before_experts": moe.score_before_experts,
+            "axis_name": moe.axis_name,
+        }
+        self.mapped_region = flex_local_map(
+            _unused_default_moe_implementation,
+            alternatives=[
+                {
+                    "name": "ep",
+                    "fn": partial(_moe_implementation_ep_output, **static_kwargs),
+                    "in_placements": ep_kwargs["in_placements"][:7],
+                    "out_placements": (ep_kwargs["out_placements"][0],),
+                },
+                {
+                    "name": "no_ep",
+                    "fn": partial(_moe_implementation_no_ep_output, **static_kwargs),
+                    "in_placements": no_ep_kwargs["in_placements"][:7],
+                    "out_placements": (no_ep_kwargs["out_placements"][0],),
+                },
+            ],
+            device_mesh=mesh,
+            redistribute_inputs=ep_kwargs["redistribute_inputs"],
+        )
+
+    def forward(
+        self,
+        x,
+        selected_experts_indices,
+        top_scores,
+        experts_w1,
+        experts_w3,
+        experts_w2,
+        out,
+        top_k,
+        num_experts,
+        score_before_experts,
+        axis_name,
+    ):
+        mapped_output = self.mapped_region(
+            x,
+            selected_experts_indices,
+            top_scores,
+            experts_w1,
+            experts_w3,
+            experts_w2,
+            out,
+        )
+        tokens_per_expert = torch.histc(
+            selected_experts_indices.flatten(),
+            bins=num_experts,
+            min=0,
+            max=num_experts,
+        )
+        return mapped_output[0], tokens_per_expert
+
+
+def _enable_forced_flex_local_map(model, mesh, selected_index):
     for module in list(model.modules()):
         if isinstance(module, MoE):
-            module.local_mapped_region = _FlexMoELocalMap(module, mesh, selected_index)
+            module.local_mapped_region = _ForcedFlexMoELocalMap(
+                module, mesh, selected_index
+            )
+
+
+def _enable_flex_local_map(model, mesh):
+    for module in list(model.modules()):
+        if isinstance(module, MoE):
+            module.local_mapped_region = _FlexMoELocalMap(module, mesh)
 
 
 def _enable_replicated_counts_local_map(model, mesh):
@@ -268,9 +401,11 @@ def run_test(
     if local_map_case == "plain-replicated-counts":
         _enable_replicated_counts_local_map(model, mesh)
     elif local_map_case == "flex-default":
-        _enable_flex_local_map(model, mesh, selected_index=0)
+        _enable_forced_flex_local_map(model, mesh, selected_index=0)
     elif local_map_case == "flex-replicated-counts":
-        _enable_flex_local_map(model, mesh, selected_index=1)
+        _enable_forced_flex_local_map(model, mesh, selected_index=1)
+    elif local_map_case == "flex-auto":
+        _enable_flex_local_map(model, mesh)
 
     def input_fn():
         return torch.randint(
@@ -297,17 +432,21 @@ def run_test(
         autop.add_input_constraints([x_sharding])
         autop.add_output_constraints([x_sharding])
 
-        flex_nodes = [
-            node
-            for node in autop.gm.graph.nodes
-            if get_flex_local_map_alternatives(node.meta.get("local_map_kwargs", {}))
-            is not None
-        ]
         selected_index = {
             "flex-default": 0,
             "flex-replicated-counts": 1,
         }.get(local_map_case)
-        assert bool(flex_nodes) == (selected_index is not None)
+        flex_nodes = []
+        if selected_index is not None:
+            flex_nodes = [
+                node
+                for node in autop.gm.graph.nodes
+                if get_flex_local_map_alternatives(
+                    node.meta.get("local_map_kwargs", {})
+                )
+                is not None
+            ]
+            assert flex_nodes
         sharding_placement = autop.optimize_placement(verbose=False)
         if selected_index is not None:
             for node in flex_nodes:
@@ -462,7 +601,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--flex-local-map",
         action="store_true",
-        help="Compatibility alias for --local-map-case flex-replicated-counts.",
+        help="Compatibility alias for --local-map-case flex-auto.",
     )
     parser.add_argument(
         "--local-map-case",
@@ -478,9 +617,7 @@ if __name__ == "__main__":
     if args.flex_local_map and args.local_map_case is not None:
         parser.error("--flex-local-map and --local-map-case cannot be used together")
     local_map_case = (
-        "flex-replicated-counts"
-        if args.flex_local_map
-        else (args.local_map_case or "plain-sharded")
+        "flex-auto" if args.flex_local_map else (args.local_map_case or "plain-sharded")
     )
 
     run_test(

--- a/tests/compare_flex_local_map_validation.py
+++ b/tests/compare_flex_local_map_validation.py
@@ -17,6 +17,7 @@ CASES = (
     "plain-replicated-counts",
     "flex-default",
     "flex-replicated-counts",
+    "flex-auto",
 )
 PYTEST_STAGES = (
     ("placement_options", "Public interface and placement"),
@@ -427,6 +428,20 @@ def main():
         _compare_pair(
             args.results_dir,
             "plain-replicated-counts",
+            "plain-sharded",
+            exact=False,
+            world_size=world_size,
+            component_names=(
+                "global_model_state",
+                "full_batch",
+                "outputs",
+                "global_gradients",
+                "global_final_buffers",
+            ),
+        ),
+        _compare_pair(
+            args.results_dir,
+            "flex-auto",
             "plain-sharded",
             exact=False,
             world_size=world_size,

--- a/tests/run_flex_local_map_full_validation.sh
+++ b/tests/run_flex_local_map_full_validation.sh
@@ -176,6 +176,7 @@ config = {
         "plain-replicated-counts",
         "flex-default",
         "flex-replicated-counts",
+        "flex-auto",
     ],
 }
 with open(sys.argv[1], "w") as output:
@@ -212,7 +213,7 @@ run_stage serialization \
 run_stage pointwise_4gpu \
   "$PYTHON_BIN" -m pytest -q tests/test_flex_local_map_e2e.py -v
 
-for case in plain-sharded plain-replicated-counts flex-default flex-replicated-counts; do
+for case in plain-sharded plain-replicated-counts flex-default flex-replicated-counts flex-auto; do
   run_stage "moe_${case}" \
     "$TORCHRUN_BIN" --standalone --nproc-per-node 4 \
     examples/example_ds3_local_map.py \

--- a/tests/test_optimize_placement.py
+++ b/tests/test_optimize_placement.py
@@ -13,6 +13,7 @@ from torch import nn
 from torch._functorch._aot_autograd.fx_utils import get_param_nodes
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
+from torch.distributed.tensor._collective_utils import MeshTopoInfo
 from torch.distributed.tensor.placement_types import (
     Partial,
     Placement,
@@ -21,12 +22,20 @@ from torch.distributed.tensor.placement_types import (
 )
 
 from autoparallel._flex_local_map import _body
+from autoparallel._testing.models.dsv3 import functional_feed_forward
 from autoparallel.api import AutoParallel, auto_parallel
 from autoparallel.collectives import (
+    all_gather,
+    all_reduce,
+    all_to_all,
+    axis_size,
     flex_local_map,
     get_flex_local_map_alternatives,
     local_map,
+    reduce_scatter,
 )
+from autoparallel.cost_models.collective_runtime_estimation import collective_comm_cost
+from autoparallel.cost_models.compute_estimation import estimate_strategy_runtime_cost
 
 
 class FFN(nn.Module):
@@ -519,32 +528,33 @@ def _make_flex_pointwise(
     *,
     names=("default", "alternative"),
     cost_hints=(100.0, 0.0),
+    auto_cost=True,
 ):
     in_placements = ((Replicate(),),)
+    default = {
+        "name": names[0],
+        "in_placements": in_placements,
+        "out_placements": out_placements,
+    }
+    alternative = {
+        "name": names[1],
+        "fn": alternative_fn,
+        "in_placements": in_placements,
+        "out_placements": out_placements,
+    }
+    if cost_hints is not None:
+        default["cost_hint"], alternative["cost_hint"] = cost_hints
     return flex_local_map(
         default_fn,
-        alternatives=[
-            {
-                "name": names[0],
-                "in_placements": in_placements,
-                "out_placements": out_placements,
-                "cost_hint": cost_hints[0],
-            },
-            {
-                "name": names[1],
-                "fn": alternative_fn,
-                "in_placements": in_placements,
-                "out_placements": out_placements,
-                "cost_hint": cost_hints[1],
-            },
-        ],
+        alternatives=[default, alternative],
         device_mesh=mesh,
         redistribute_inputs=True,
+        auto_cost=auto_cost,
     )
 
 
 class FlexLocalMapDifferentActivations(nn.Module):
-    def __init__(self, mesh, cost_hints=(100.0, 0.0)):
+    def __init__(self, mesh, cost_hints=(100.0, 0.0), auto_cost=True):
         super().__init__()
         self.scale = nn.Parameter(torch.empty(()))
         placements = ((Replicate(),),)
@@ -554,6 +564,7 @@ class FlexLocalMapDifferentActivations(nn.Module):
             _flex_where_identity_body,
             placements,
             cost_hints=cost_hints,
+            auto_cost=auto_cost,
         )
 
     def forward(self, x):
@@ -677,6 +688,131 @@ class FlexLocalMapDifferentPlacements(nn.Module):
 
     def forward(self, x):
         return self.pointwise(x)[0]
+
+
+def _flex_all_gather_body(x):
+    return (all_gather(x, 0, "dp"),)
+
+
+def _flex_reduce_scatter_body(x):
+    return (reduce_scatter(x, 0, "dp"),)
+
+
+def _flex_all_reduce_body(x):
+    return (all_reduce(x, "dp"),)
+
+
+def _flex_all_reduce_identity_body(x):
+    return (all_reduce(x, "dp") / axis_size("dp"),)
+
+
+def _flex_all_to_all_body(x):
+    return (all_to_all(x, None, None, "dp"),)
+
+
+class FlexLocalMapCollective(nn.Module):
+    def __init__(self, mesh, fn, in_placement, out_placement):
+        super().__init__()
+        self.mapped = flex_local_map(
+            fn,
+            alternatives=[
+                {
+                    "name": fn.__name__,
+                    "in_placements": (in_placement,),
+                    "out_placements": (out_placement,),
+                }
+            ],
+            device_mesh=mesh,
+        )
+
+    def forward(self, x):
+        return self.mapped(x)[0]
+
+
+class FlexLocalMapCollectiveChoice(nn.Module):
+    def __init__(self, mesh):
+        super().__init__()
+        placements = ((Replicate(),),)
+        self.mapped = flex_local_map(
+            _flex_clone_body,
+            alternatives=[
+                {
+                    "name": "clone",
+                    "in_placements": placements,
+                    "out_placements": placements,
+                },
+                {
+                    "name": "all_reduce",
+                    "fn": _flex_all_reduce_identity_body,
+                    "in_placements": placements,
+                    "out_placements": placements,
+                },
+            ],
+            device_mesh=mesh,
+        )
+
+    def forward(self, x):
+        return self.mapped(x)[0]
+
+
+def _flex_feed_forward_body(w1, w2, w3, x):
+    return (functional_feed_forward(w1, w2, w3, x),)
+
+
+class FlexLocalMapFeedForwardCostParity(nn.Module):
+    def __init__(self, mesh, data_placement):
+        super().__init__()
+        replicated = (Replicate(),)
+        self.mapped = flex_local_map(
+            _flex_feed_forward_body,
+            alternatives=[
+                {
+                    "name": "feed_forward",
+                    "in_placements": (
+                        replicated,
+                        replicated,
+                        replicated,
+                        data_placement,
+                    ),
+                    "out_placements": (data_placement,),
+                }
+            ],
+            device_mesh=mesh,
+        )
+
+    def forward(self, w1, w2, w3, x):
+        return self.mapped(w1, w2, w3, x)[0]
+
+
+class FeedForwardCostReference(nn.Module):
+    def forward(self, w1, w2, w3, x):
+        return functional_feed_forward(w1, w2, w3, x)
+
+
+class FlexLocalMapAttentionCostParity(nn.Module):
+    def __init__(self, mesh, in_placements, out_placement):
+        super().__init__()
+        self.mapped = flex_local_map(
+            _flex_attention_body,
+            alternatives=[
+                {
+                    "name": "attention",
+                    "in_placements": in_placements,
+                    "out_placements": (out_placement,),
+                }
+            ],
+            device_mesh=mesh,
+        )
+
+    def forward(self, query, key, value):
+        return self.mapped(query, key, value)[0]
+
+
+class AttentionCostReference(nn.Module):
+    def forward(self, query, key, value):
+        return F.scaled_dot_product_attention(
+            query=query, key=key, value=value, is_causal=False
+        )
 
 
 class PlainLocalMapReference(nn.Module):
@@ -984,6 +1120,372 @@ def test_flex_local_map_selected_body_forward_backward(
     torch.testing.assert_close(
         parallel_model.scale.grad.to_local(), expected_scale.grad
     )
+
+
+def _flatten_specs(value):
+    if isinstance(value, (tuple, list)):
+        return [spec for item in value for spec in _flatten_specs(item)]
+    return [value]
+
+
+def _is_replicated_strategy(strategy):
+    specs = _flatten_specs(strategy.input_specs) + _flatten_specs(strategy.output_specs)
+    return all(
+        spec is None
+        or all(isinstance(placement, Replicate) for placement in spec.placements)
+        for spec in specs
+    )
+
+
+def _reference_graph_cost(opt):
+    cost = 0.0
+    breakdown = []
+    for node in opt.strats:
+        if node.op != "call_function":
+            continue
+        strategies = [
+            strategy
+            for strategy in opt.strats[node].strategies
+            if _is_replicated_strategy(strategy)
+        ]
+        assert (
+            len(strategies) == 1
+        ), f"reference node {node} has {len(strategies)} replicated strategies"
+        node_cost = estimate_strategy_runtime_cost(node, strategies[0])
+        cost += node_cost
+        breakdown.append(
+            (
+                node.name,
+                str(node.target),
+                node.meta.get("partitioner_tag"),
+                node_cost,
+            )
+        )
+    return cost, breakdown
+
+
+def _local_shape(shape, placements, mesh_shape):
+    shape = list(shape)
+    for mesh_size, placement in zip(mesh_shape, placements):
+        if placement.is_shard():
+            shape[placement.dim] = (shape[placement.dim] + mesh_size - 1) // mesh_size
+    return tuple(shape)
+
+
+def _single_flex_forward(opt):
+    nodes = [
+        node
+        for node in opt.strats
+        if get_flex_local_map_alternatives(node.meta.get("local_map_kwargs", {}))
+        is not None
+        and node.meta.get("partitioner_tag") != "is_backward"
+    ]
+    assert len(nodes) == 1
+    return nodes[0]
+
+
+@apply_cuda_patches
+@pytest.mark.parametrize("data_placement", ((Replicate(),), (Shard(0),)))
+def test_flex_local_map_feed_forward_cost_matches_plain_region(
+    device_mesh_1d, data_placement, device="cuda"
+):
+    dim = 6144
+    hidden_dim = dim * 4
+    batch = 8 * device_mesh_1d.size()
+    seq_len = 256
+
+    def flex_input_fn():
+        return (
+            torch.randn(hidden_dim, dim, device=device, requires_grad=True),
+            torch.randn(dim, hidden_dim, device=device, requires_grad=True),
+            torch.randn(hidden_dim, dim, device=device, requires_grad=True),
+            torch.randn(batch, seq_len, dim, device=device, requires_grad=True),
+        )
+
+    local_batch = _local_shape(
+        (batch, seq_len, dim), data_placement, device_mesh_1d.shape
+    )[0]
+
+    def reference_input_fn():
+        return (
+            torch.randn(hidden_dim, dim, device=device, requires_grad=True),
+            torch.randn(dim, hidden_dim, device=device, requires_grad=True),
+            torch.randn(hidden_dim, dim, device=device, requires_grad=True),
+            torch.randn(local_batch, seq_len, dim, device=device, requires_grad=True),
+        )
+
+    with torch.device("meta"):
+        reference_model = FeedForwardCostReference()
+        flex_model = FlexLocalMapFeedForwardCostParity(device_mesh_1d, data_placement)
+
+    with AutoParallel(
+        reference_model, reference_input_fn, device_mesh_1d
+    ) as reference_autop:
+        expected, plain_breakdown = _reference_graph_cost(
+            reference_autop.sharding_optimizer
+        )
+
+    with AutoParallel(flex_model, flex_input_fn, device_mesh_1d) as flex_autop:
+        opt = flex_autop.sharding_optimizer
+        _single_flex_forward(opt)
+        assert len(opt.flex_local_map_costs) == 2
+        flex_breakdown = tuple(
+            (node.name, node.meta.get("partitioner_tag"), cost)
+            for (node, _), cost in opt.flex_local_map_costs.items()
+        )
+        actual = sum(opt.flex_local_map_costs.values())
+
+    assert actual == pytest.approx(
+        expected, rel=1e-9, abs=1e-9
+    ), f"plain={plain_breakdown}, flex={flex_breakdown}"
+
+
+@apply_cuda_patches
+@pytest.mark.parametrize(
+    ("in_placements", "out_placement"),
+    (
+        (
+            (
+                (Shard(0), Shard(2)),
+                (Shard(0), Replicate()),
+                (Shard(0), Replicate()),
+            ),
+            (Shard(0), Shard(2)),
+        ),
+        (
+            (
+                (Shard(0), Replicate()),
+                (Shard(0), Replicate()),
+                (Shard(0), Replicate()),
+            ),
+            (Shard(0), Replicate()),
+        ),
+    ),
+)
+def test_flex_local_map_attention_cost_matches_plain_region(
+    device_mesh_2d, in_placements, out_placement, device="cuda"
+):
+    batch = 8 * device_mesh_2d.shape[0]
+    nheads = 48
+    seq_len = 256
+    head_dim = 128
+
+    def flex_input_fn():
+        shape = (batch, nheads, seq_len, head_dim)
+        return tuple(
+            torch.randn(*shape, device=device, requires_grad=True) for _ in range(3)
+        )
+
+    global_shape = (batch, nheads, seq_len, head_dim)
+
+    def reference_input_fn():
+        return tuple(
+            torch.randn(
+                *_local_shape(global_shape, placements, device_mesh_2d.shape),
+                device=device,
+                requires_grad=True,
+            )
+            for placements in in_placements
+        )
+
+    with torch.device("meta"):
+        reference_model = AttentionCostReference()
+        flex_model = FlexLocalMapAttentionCostParity(
+            device_mesh_2d, in_placements, out_placement
+        )
+
+    with AutoParallel(
+        reference_model, reference_input_fn, device_mesh_2d
+    ) as reference_autop:
+        expected, plain_breakdown = _reference_graph_cost(
+            reference_autop.sharding_optimizer
+        )
+
+    with AutoParallel(flex_model, flex_input_fn, device_mesh_2d) as flex_autop:
+        opt = flex_autop.sharding_optimizer
+        _single_flex_forward(opt)
+        assert len(opt.flex_local_map_costs) == 2
+        flex_breakdown = tuple(
+            (node.name, node.meta.get("partitioner_tag"), cost)
+            for (node, _), cost in opt.flex_local_map_costs.items()
+        )
+        actual = sum(opt.flex_local_map_costs.values())
+
+    assert actual == pytest.approx(
+        expected, rel=1e-9, abs=1e-9
+    ), f"plain={plain_breakdown}, flex={flex_breakdown}"
+
+
+@apply_cuda_patches
+def test_flex_local_map_estimates_alternative_body_costs(device_mesh_1d, device="cuda"):
+    shape = (512, 128)
+
+    def input_fn():
+        return torch.randn(*shape, device=device, requires_grad=True)
+
+    with torch.device("meta"):
+        model = FlexLocalMapDifferentActivations(device_mesh_1d, cost_hints=None)
+
+    with AutoParallel(model, input_fn, device_mesh_1d) as autop:
+        replicated = (Replicate(),)
+        autop.add_input_constraints([replicated])
+        autop.add_output_constraints([replicated])
+        solution = autop.optimize_placement()
+        selected = {
+            spec.flex_local_map_alternative_index
+            for node, spec in solution.items()
+            if get_flex_local_map_alternatives(node.meta.get("local_map_kwargs", {}))
+            is not None
+        }
+
+        assert selected == {0}
+        flex_costs = autop.sharding_optimizer.flex_local_map_costs
+        forward, backward = _flex_fw_bw_nodes(list(autop.sharding_optimizer.strats))
+        alternatives = get_flex_local_map_alternatives(forward.meta["local_map_kwargs"])
+        assert all("cost_hint" not in alternative for alternative in alternatives)
+        assert flex_costs[(forward, 0)] == flex_costs[(backward, 0)]
+        assert flex_costs[(forward, 0)] < flex_costs[(forward, 1)]
+
+
+@apply_cuda_patches
+def test_flex_local_map_can_disable_automatic_cost(device_mesh_1d, device="cuda"):
+    def input_fn():
+        return torch.randn(512, 128, device=device, requires_grad=True)
+
+    with torch.device("meta"):
+        model = FlexLocalMapDifferentActivations(
+            device_mesh_1d, cost_hints=None, auto_cost=False
+        )
+
+    with AutoParallel(model, input_fn, device_mesh_1d) as autop:
+        forward, _ = _flex_fw_bw_nodes(list(autop.sharding_optimizer.strats))
+        alternatives = get_flex_local_map_alternatives(forward.meta["local_map_kwargs"])
+        assert {alternative["cost_hint"] for alternative in alternatives} == {0.0}
+        assert set(autop.sharding_optimizer.flex_local_map_costs.values()) == {0.0}
+
+
+@apply_cuda_patches
+@pytest.mark.parametrize(
+    ("fn", "in_placement", "out_placement"),
+    (
+        (_flex_all_gather_body, (Shard(0),), (Replicate(),)),
+        (_flex_reduce_scatter_body, (Replicate(),), (Shard(0),)),
+        (_flex_all_reduce_body, (Replicate(),), (Replicate(),)),
+        (_flex_all_to_all_body, (Replicate(),), (Replicate(),)),
+    ),
+)
+def test_flex_local_map_estimates_collective_cost(
+    device_mesh_1d, fn, in_placement, out_placement, device="cuda"
+):
+    def input_fn():
+        return torch.randn(512, 128, device=device, requires_grad=True)
+
+    with torch.device("meta"):
+        model = FlexLocalMapCollective(device_mesh_1d, fn, in_placement, out_placement)
+
+    with AutoParallel(model, input_fn, device_mesh_1d) as autop:
+        costs = autop.sharding_optimizer.flex_local_map_costs
+        assert len(costs) == 2
+        assert len(set(costs.values())) == 1
+        assert next(iter(costs.values())) > 0
+
+
+@apply_cuda_patches
+@pytest.mark.parametrize(
+    (
+        "fn",
+        "in_placement",
+        "out_placement",
+        "forward_collective",
+        "backward_collective",
+    ),
+    (
+        (
+            _flex_all_gather_body,
+            (Shard(0),),
+            (Replicate(),),
+            "allgather",
+            "reduce_scatter",
+        ),
+        (
+            _flex_reduce_scatter_body,
+            (Replicate(),),
+            (Shard(0),),
+            "reduce_scatter",
+            "allgather",
+        ),
+        (
+            _flex_all_reduce_body,
+            (Replicate(),),
+            (Replicate(),),
+            "allreduce",
+            "allreduce",
+        ),
+        (
+            _flex_all_to_all_body,
+            (Replicate(),),
+            (Replicate(),),
+            "all_to_all",
+            "all_to_all",
+        ),
+    ),
+)
+def test_flex_local_map_collective_cost_matches_cost_model(
+    device_mesh_1d,
+    fn,
+    in_placement,
+    out_placement,
+    forward_collective,
+    backward_collective,
+    device="cuda",
+):
+    shape = (512, 128)
+
+    def input_fn():
+        return torch.randn(*shape, device=device, requires_grad=True)
+
+    with torch.device("meta"):
+        model = FlexLocalMapCollective(device_mesh_1d, fn, in_placement, out_placement)
+
+    with AutoParallel(model, input_fn, device_mesh_1d) as autop:
+        costs = autop.sharding_optimizer.flex_local_map_costs
+        assert len(costs) == 2
+        actual = sum(costs.values())
+        comm_bytes = torch.Size(shape).numel() * torch.float32.itemsize
+        expected = sum(
+            collective_comm_cost(
+                collective,
+                comm_bytes,
+                tuple(device_mesh_1d.shape),
+                0,
+                MeshTopoInfo.build_from_mesh(device_mesh_1d),
+            )
+            for collective in (forward_collective, backward_collective)
+        )
+
+    assert actual == pytest.approx(expected, rel=1e-9, abs=1e-9)
+
+
+@apply_cuda_patches
+def test_flex_local_map_collective_cost_drives_choice(device_mesh_1d, device="cuda"):
+    def input_fn():
+        return torch.randn(512, 128, device=device, requires_grad=True)
+
+    with torch.device("meta"):
+        model = FlexLocalMapCollectiveChoice(device_mesh_1d)
+
+    with AutoParallel(model, input_fn, device_mesh_1d) as autop:
+        replicated = (Replicate(),)
+        autop.add_input_constraints([replicated])
+        autop.add_output_constraints([replicated])
+        solution = autop.optimize_placement()
+        selected = {
+            spec.flex_local_map_alternative_index
+            for node, spec in solution.items()
+            if get_flex_local_map_alternatives(node.meta.get("local_map_kwargs", {}))
+            is not None
+        }
+        assert selected == {0}
 
 
 @apply_cuda_patches

--- a/tests/test_optimize_placement.py
+++ b/tests/test_optimize_placement.py
@@ -22,7 +22,10 @@ from torch.distributed.tensor.placement_types import (
 )
 
 from autoparallel._flex_local_map import _body
-from autoparallel._testing.models.dsv3 import functional_feed_forward
+from autoparallel._testing.models.dsv3 import (
+    _run_experts_grouped_mm,
+    functional_feed_forward,
+)
 from autoparallel.api import AutoParallel, auto_parallel
 from autoparallel.collectives import (
     all_gather,
@@ -815,6 +818,86 @@ class AttentionCostReference(nn.Module):
         )
 
 
+def _balanced_expert_ffn(x, w1, w3, w2):
+    num_tokens = x.shape[1]
+    tokens_per_expert = torch.full(
+        (x.shape[0],), num_tokens, dtype=torch.int32, device=x.device
+    )
+    return _run_experts_grouped_mm(
+        w1,
+        w2,
+        w3,
+        x.flatten(0, 1),
+        tokens_per_expert,
+    ).view_as(x)
+
+
+def _balanced_moe_no_ep_body(x, w1, w3, w2):
+    return (_balanced_expert_ffn(x, w1, w3, w2),)
+
+
+def _balanced_moe_ep_local(x, w1, w3, w2, ep_size):
+    local_experts = w1.shape[0]
+    x = x.view(ep_size, local_experts, -1, x.shape[-1])
+    x = x.permute(1, 0, 2, 3).flatten(1, 2)
+    x = _balanced_expert_ffn(x, w1, w3, w2)
+    return x.unflatten(1, (ep_size, -1)).permute(1, 0, 2, 3).flatten(0, 2)
+
+
+def _balanced_moe_ep_body(x, w1, w3, w2):
+    original_shape = x.shape
+    ep_size = axis_size("tp")
+    x = all_to_all(x.flatten(0, 1), None, None, "tp")
+    x = _balanced_moe_ep_local(x, w1, w3, w2, ep_size)
+    x = all_to_all(x, None, None, "tp")
+    return (x.view(original_shape),)
+
+
+class FlexLocalMapBalancedMoECostParity(nn.Module):
+    def __init__(self, mesh):
+        super().__init__()
+        replicated = (Replicate(), Replicate())
+        no_ep_data = (Shard(1), Replicate())
+        ep_data = (Shard(1), Shard(1))
+        ep_weights = (Replicate(), Shard(0))
+        self.mapped = flex_local_map(
+            _balanced_moe_no_ep_body,
+            alternatives=[
+                {
+                    "name": "no_ep",
+                    "in_placements": (no_ep_data, replicated, replicated, replicated),
+                    "out_placements": (no_ep_data,),
+                },
+                {
+                    "name": "ep",
+                    "fn": _balanced_moe_ep_body,
+                    "in_placements": (ep_data, ep_weights, ep_weights, ep_weights),
+                    "out_placements": (ep_data,),
+                },
+            ],
+            device_mesh=mesh,
+        )
+
+    def forward(self, x, w1, w3, w2):
+        return self.mapped(x, w1, w3, w2)[0]
+
+
+class BalancedExpertFFNCostReference(nn.Module):
+    def forward(self, x, w1, w3, w2):
+        return _balanced_expert_ffn(x, w1, w3, w2)
+
+
+class BalancedExpertFFNEPCostReference(nn.Module):
+    def __init__(self, ep_size):
+        super().__init__()
+        self.ep_size = ep_size
+
+    def forward(self, x, w1, w3, w2):
+        original_shape = x.shape
+        x = _balanced_moe_ep_local(x.flatten(0, 1), w1, w3, w2, self.ep_size)
+        return x.view(original_shape)
+
+
 class PlainLocalMapReference(nn.Module):
     def __init__(
         self,
@@ -1164,6 +1247,23 @@ def _reference_graph_cost(opt):
     return cost, breakdown
 
 
+def _unsharded_graph_cost(model, input_fn, mesh):
+    autop = AutoParallel(model, input_fn, mesh)
+    try:
+        autop.build_model_graph()
+        cost = 0.0
+        breakdown = []
+        for node in autop.gm.graph.nodes:
+            if node.op != "call_function":
+                continue
+            node_cost = estimate_strategy_runtime_cost(node, strategy=None)
+            cost += node_cost
+            breakdown.append((node.name, str(node.target), node_cost))
+        return cost, breakdown
+    finally:
+        autop.stack.close()
+
+
 def _local_shape(shape, placements, mesh_shape):
     shape = list(shape)
     for mesh_size, placement in zip(mesh_shape, placements):
@@ -1314,6 +1414,93 @@ def test_flex_local_map_attention_cost_matches_plain_region(
     assert actual == pytest.approx(
         expected, rel=1e-9, abs=1e-9
     ), f"plain={plain_breakdown}, flex={flex_breakdown}"
+
+
+@apply_cuda_patches
+def test_flex_local_map_balanced_moe_cost_matches_plain_regions(
+    device_mesh_2d, device="cuda"
+):
+    num_experts = 64
+    tokens_per_expert = 196608
+    dim = 256
+    hidden_dim = 256
+    dtype = torch.bfloat16
+    dp_size, ep_size = device_mesh_2d.shape
+
+    def input_tensors(data_experts, tokens, weight_experts=None):
+        if weight_experts is None:
+            weight_experts = data_experts
+        shapes = (
+            (data_experts, tokens, dim),
+            (weight_experts, hidden_dim, dim),
+            (weight_experts, hidden_dim, dim),
+            (weight_experts, dim, hidden_dim),
+        )
+        return tuple(
+            torch.randn(*shape, dtype=dtype, device=device, requires_grad=True)
+            for shape in shapes
+        )
+
+    def flex_input_fn():
+        return input_tensors(num_experts, tokens_per_expert)
+
+    reference_costs = {}
+    reference_breakdowns = {}
+    reference_cases = (
+        (
+            "no_ep",
+            BalancedExpertFFNCostReference(),
+            tokens_per_expert // dp_size,
+            num_experts,
+        ),
+        (
+            "ep",
+            BalancedExpertFFNEPCostReference(ep_size),
+            tokens_per_expert // (dp_size * ep_size),
+            num_experts // ep_size,
+        ),
+    )
+    for name, reference_model, local_tokens, local_experts in reference_cases:
+
+        def reference_input_fn(local_tokens=local_tokens, local_experts=local_experts):
+            return input_tensors(num_experts, local_tokens, local_experts)
+
+        reference_costs[name], reference_breakdowns[name] = _unsharded_graph_cost(
+            reference_model, reference_input_fn, device_mesh_2d
+        )
+
+    with torch.device("meta"):
+        flex_model = FlexLocalMapBalancedMoECostParity(device_mesh_2d)
+    with AutoParallel(flex_model, flex_input_fn, device_mesh_2d) as flex_autop:
+        opt = flex_autop.sharding_optimizer
+        forward, backward = _flex_fw_bw_nodes(list(opt.strats))
+        costs = opt.flex_local_map_costs
+        actual = {
+            name: costs[(forward, index)] + costs[(backward, index)]
+            for index, name in enumerate(("no_ep", "ep"))
+        }
+        comm_bytes = (
+            num_experts
+            * (tokens_per_expert // (dp_size * ep_size))
+            * dim
+            * dtype.itemsize
+        )
+        communication = 4 * collective_comm_cost(
+            "all_to_all",
+            comm_bytes,
+            tuple(device_mesh_2d.shape),
+            1,
+            MeshTopoInfo.build_from_mesh(device_mesh_2d),
+        )
+
+    expected = {
+        "no_ep": reference_costs["no_ep"],
+        "ep": reference_costs["ep"] + communication,
+    }
+    assert communication > 0
+    assert actual == pytest.approx(
+        expected, rel=1e-9, abs=1e-9
+    ), f"plain={reference_breakdowns}, communication={communication}, flex={costs}"
 
 
 @apply_cuda_patches

--- a/tests/test_placement_options_utils.py
+++ b/tests/test_placement_options_utils.py
@@ -267,6 +267,20 @@ class TestFlexLocalMapPlacementOptions:
                 in_grad_placements=((Replicate(),),),
             )
 
+    def test_rejects_non_bool_auto_cost(self, device_mesh_1d):
+        with pytest.raises(TypeError, match="auto_cost must be a bool"):
+            flex_local_map(
+                call_local_map,
+                alternatives=[
+                    {
+                        "in_placements": ((Replicate(),),),
+                        "out_placements": ((Replicate(),),),
+                    }
+                ],
+                device_mesh=device_mesh_1d,
+                auto_cost="yes",
+            )
+
     def test_generates_one_strategy_per_alternative(self, device_mesh_1d):
         gm, local_map_node = _make_flex_local_map_graph(
             [


### PR DESCRIPTION
## Summary

This PR stacks on #518 and adds automatic analytical cost estimation for
`flex_local_map` alternatives that do not provide a `cost_hint`.

- Trace each alternative body with its declared placement-local tensor shapes.
- Export and normalize its joint graph through the same AutoParallel path.
- Reuse the existing per-op FLOPs/roofline and unified collective latency models.
- Add dynamic-shape support needed by the DeepSeek V3 MoE EP/no-EP alternatives.

An explicit finite, non-negative `cost_hint` continues to override automatic
estimation for that alternative. `auto_cost=False` preserves the zero-default
behavior from #518.

## Stack

- Base PR: #518
- Base commit: `b1f329f`
- Automatic estimation: `6a54a68`
- DSv3/MoE extension: `d5d9a69`

## Validation

Executed in the repository's `autop-ci-py312` conda environment:

```bash
PYTHONPATH=$PWD conda run -n autop-ci-py312 \
  python -m pytest -q tests/test_optimize_placement.py

PYTHONPATH=$PWD conda run -n autop-ci-py312 \
  python -m pytest -q tests/test_placement_options_utils.py
```

Results:

- `tests/test_optimize_placement.py`: `49 passed`
- `tests/test_placement_options_utils.py`: `30 passed`

These are analytical-model checks rather than hardware performance measurements.
No latency, throughput, memory, speedup, or measured model-accuracy claim is made.

Authored with Claude.
