### PR TITLE
Generalize ordered FSDP shard layouts to N-D

### DIFF
--- a/autoparallel/apply_sharding.py
+++ b/autoparallel/apply_sharding.py
@@ -19,7 +19,11 @@ from torch._functorch._aot_autograd.fx_utils import (
 from torch._inductor.decomposition import select_decomp_table
 from torch._subclasses.fake_tensor import FakeTensor, unset_fake_temporarily
 from torch.distributed.tensor import DTensor
-from torch.distributed.tensor._dtensor_spec import DTensorSpec, ShardOrderEntry
+from torch.distributed.tensor._dtensor_spec import (
+    DTensorSpec,
+    ShardOrder,
+    ShardOrderEntry,
+)
 from torch.distributed.tensor._redistribute import use_min_cost_redistribution_plan
 from torch.distributed.tensor.placement_types import Partial, Replicate, Shard  # noqa
 from torch.fx.experimental.proxy_tensor import make_fx
@@ -69,16 +73,40 @@ def _localize_shape_arg(node, shape_arg, output_spec):
     return local_shape
 
 
-def _compute_shard_order(shard_order, reverse: bool):
-    result = []
-    for tensor_dim, mesh_dims in shard_order:
-        default_order = sorted(mesh_dims)
-        if reverse:
-            default_order = default_order[::-1]
-        result.append(
-            ShardOrderEntry(tensor_dim=tensor_dim, mesh_dims=tuple(default_order))
-        )
-    return tuple(result)
+def _project_shard_order(
+    preferred_shard_order: ShardOrder,
+    spec: DTensorSpec,
+) -> ShardOrder:
+    """Project a parameter storage order onto the shards present in ``spec``."""
+    actual_shards = {
+        (placement.dim, mesh_dim)
+        for mesh_dim, placement in enumerate(spec.placements)
+        if isinstance(placement, Shard)
+    }
+    covered_shards: set[tuple[int, int]] = set()
+    projected_order = []
+
+    for entry in preferred_shard_order:
+        matching_mesh_dims = []
+        for mesh_dim in entry.mesh_dims:
+            if mesh_dim >= len(spec.placements):
+                continue
+            placement = spec.placements[mesh_dim]
+            if isinstance(placement, Shard) and placement.dim == entry.tensor_dim:
+                matching_mesh_dims.append(mesh_dim)
+        mesh_dims = tuple(matching_mesh_dims)
+        if mesh_dims:
+            projected_order.append(
+                ShardOrderEntry(tensor_dim=entry.tensor_dim, mesh_dims=mesh_dims)
+            )
+            covered_shards.update(
+                (entry.tensor_dim, mesh_dim) for mesh_dim in mesh_dims
+            )
+
+    if covered_shards != actual_shards:
+        assert spec.shard_order is not None
+        return spec.shard_order
+    return tuple(projected_order)
 
 
 class ApplyShardingInterpreter(torch.fx.Interpreter):
@@ -128,14 +156,14 @@ class ApplyShardingInterpreter(torch.fx.Interpreter):
         assert tgt_spec.shard_order is not None
         if node not in self.param_placement_order:
             return curr_spec.shard_order, tgt_spec.shard_order
-        is_target_reversed_order, need_reorder = self.param_placement_order[node]
-        curr_shard_order = _compute_shard_order(
-            curr_spec.shard_order,
-            reverse=not (is_target_reversed_order and need_reorder),
+        preferred_shard_order = self.param_placement_order[node].preferred_shard_order
+        curr_shard_order = _project_shard_order(
+            preferred_shard_order,
+            curr_spec,
         )
-        tgt_shard_order = _compute_shard_order(
-            tgt_spec.shard_order,
-            reverse=is_target_reversed_order,
+        tgt_shard_order = _project_shard_order(
+            preferred_shard_order,
+            tgt_spec,
         )
         return curr_shard_order, tgt_shard_order
 
@@ -144,8 +172,6 @@ class ApplyShardingInterpreter(torch.fx.Interpreter):
             p if not p.is_partial() else Replicate() for p in tgt_spec.placements
         )
         x = arg
-        if node in self.param_placement_order and self.param_placement_order[node][1]:
-            assert curr_spec.placements != tgt_spec.placements
         curr_shard_order, tgt_shard_order = self._compute_origin_and_target_shard_order(
             node, curr_spec, tgt_spec
         )
@@ -296,28 +322,26 @@ class ApplyShardingInterpreter(torch.fx.Interpreter):
 def _build_physical_placements(sharding_placement, param_placement_order):
     """Build a dict mapping each node to its physical DTensorSpec.
 
-    For reversed-order nodes in param_placement_order, converts to
-    _StridedShard placements so the physical layout matches the intended
-    shard order. For everything else, returns the solver-assigned spec.
+    For ordered parameter nodes, converts to _StridedShard placements when
+    needed so the physical layout matches the preferred storage order.
     """
     physical = {}
     for node, op_spec in sharding_placement.items():
         if op_spec.input_specs is None:
             continue
         tgt_spec = op_spec.input_specs[0]
-        if (
-            node in param_placement_order
-            and param_placement_order[node].is_target_reversed_order
-        ):
-            reversed_shard_order = _compute_shard_order(
-                tgt_spec.shard_order, reverse=True
+        if node in param_placement_order:
+            preferred_shard_order = _project_shard_order(
+                param_placement_order[node].preferred_shard_order,
+                tgt_spec,
             )
-            placements = DTensorSpec._convert_shard_order_to_StridedShard(
-                reversed_shard_order, tgt_spec.placements, tgt_spec.mesh
-            )
-            tgt_spec = DTensorSpec(
-                tgt_spec.mesh, placements, tensor_meta=tgt_spec.tensor_meta
-            )
+            if preferred_shard_order != tgt_spec.shard_order:
+                placements = DTensorSpec._convert_shard_order_to_StridedShard(
+                    preferred_shard_order, tgt_spec.placements, tgt_spec.mesh
+                )
+                tgt_spec = DTensorSpec(
+                    tgt_spec.mesh, placements, tensor_meta=tgt_spec.tensor_meta
+                )
         physical[node] = tgt_spec
     return physical
 

--- a/autoparallel/shardings/ordered_sharding.py
+++ b/autoparallel/shardings/ordered_sharding.py
@@ -4,12 +4,17 @@
 # LICENSE file in the root directory of this source tree.
 
 import operator
-from collections import namedtuple
+from collections import defaultdict
+from dataclasses import dataclass
 from typing import Optional, Union
 
 import torch
 from torch._functorch._aot_autograd.fx_utils import get_param_and_grad_nodes
-from torch.distributed._tensor.placement_types import DTensorSpec
+from torch.distributed.tensor._dtensor_spec import (
+    DTensorSpec,
+    ShardOrder,
+    ShardOrderEntry,
+)
 from torch.distributed.tensor._op_schema import OpSpec
 from torch.distributed.tensor._redistribute import redistribute_local_tensor
 from torch.distributed.tensor.placement_types import (  # noqa
@@ -20,14 +25,74 @@ from torch.distributed.tensor.placement_types import (  # noqa
 )
 from torch.utils._pytree import tree_flatten
 
-# Supported placement patterns for the ordered sharding optimization
-_PARAM_PLACEMENT = (Shard(0), Shard(0))
-_PARAM_TARGET_PLACEMENT = (Replicate(), Shard(0))
-_GRAD_PLACEMENT = (Partial(), Shard(0))
-_GRAD_TARGET_PLACEMENT = (Shard(0), Shard(0))
 
-# Stores ordering information for nodes that need redistribution
-OrderInfo = namedtuple("OrderInfo", ["is_target_reversed_order", "need_reorder"])
+@dataclass(frozen=True)
+class OrderInfo:
+    """Preferred physical shard order for a parameter and its gradient."""
+
+    preferred_shard_order: ShardOrder
+
+
+def _infer_fsdplike_storage_order(
+    source: tuple[Placement, ...],
+    target: tuple[Placement, ...],
+) -> Optional[ShardOrder]:
+    """Infer an order that keeps retained shards outside released shards."""
+    if len(source) != len(target):
+        return None
+
+    retained: dict[int, list[int]] = defaultdict(list)
+    released: dict[int, list[int]] = defaultdict(list)
+
+    for mesh_dim, (src, dst) in enumerate(zip(source, target)):
+        if isinstance(src, Shard) and isinstance(dst, Shard):
+            if src.dim != dst.dim:
+                return None
+            retained[src.dim].append(mesh_dim)
+        elif isinstance(src, Shard) and isinstance(dst, Replicate):
+            released[src.dim].append(mesh_dim)
+        elif isinstance(src, Replicate) and isinstance(dst, Replicate):
+            continue
+        else:
+            return None
+
+    if not released or any(not retained[tensor_dim] for tensor_dim in released):
+        return None
+
+    preferred_order = tuple(
+        ShardOrderEntry(
+            tensor_dim=tensor_dim,
+            mesh_dims=tuple(
+                sorted(retained[tensor_dim])
+                + sorted(released[tensor_dim], reverse=True)
+            ),
+        )
+        for tensor_dim in sorted(set(retained) | set(released))
+        if retained[tensor_dim] or released[tensor_dim]
+    )
+    default_order = DTensorSpec.compute_default_shard_order(source)
+    return preferred_order if preferred_order != default_order else None
+
+
+def _matches_inverse_gradient_pattern(
+    param_source: tuple[Placement, ...],
+    param_target: tuple[Placement, ...],
+    grad_source: tuple[Placement, ...],
+    grad_target: tuple[Placement, ...],
+) -> bool:
+    """Check that the gradient redistribution reverses the parameter gather."""
+    if grad_target != param_source:
+        return False
+
+    expected_grad_source = tuple(
+        (
+            Partial()
+            if isinstance(param_src, Shard) and isinstance(param_dst, Replicate)
+            else param_src
+        )
+        for param_src, param_dst in zip(param_source, param_target)
+    )
+    return grad_source == expected_grad_source
 
 
 def _optimize_same_nd_sharding_as_1d(
@@ -222,31 +287,24 @@ def build_param_grad_linear_chains(
 def _assign_order_info_to_chain(
     chain: list[torch.fx.Node],
     target_node: torch.fx.Node,
-    target_reversed_order: bool,
+    preferred_shard_order: ShardOrder,
     order_map: dict[torch.fx.Node, OrderInfo],
 ) -> None:
     """
     Assign OrderInfo to nodes in a chain up to and including the target node.
 
-    For nodes before the target, they maintain their current order (need_reorder=False).
-    The target node itself needs reordering (need_reorder=True).
-
     Args:
         chain: List of nodes in the dependency chain.
-        target_node: The node where reordering should occur.
-        target_reversed_order: The is_target_reversed_order value for the target node.
+        target_node: The redistribution boundary for this chain.
+        preferred_shard_order: Parameter storage order to preserve along the chain.
         order_map: Dictionary to populate with OrderInfo for each node.
     """
     for node in chain:
+        order_map[node] = OrderInfo(
+            preferred_shard_order=preferred_shard_order,
+        )
         if node == target_node:
-            order_map[node] = OrderInfo(
-                is_target_reversed_order=target_reversed_order, need_reorder=True
-            )
             break
-        else:
-            order_map[node] = OrderInfo(
-                is_target_reversed_order=True, need_reorder=False
-            )
 
 
 def compute_optimal_placement_order_for_parameters(
@@ -256,21 +314,15 @@ def compute_optimal_placement_order_for_parameters(
     """
     Compute the optimal placement order for parameters and gradients.
 
-    The optimal placement order minimizes the number of communication steps
-    by determining which nodes need their shard order reversed during
-    redistribution.
-
-    Currently only optimizes the case where:
-    - Parameters: S(0)S(0) -> RS(0) (forward pass)
-    - Gradients: PS(0) -> S(0)S(0) (backward pass)
+    The optimal placement order minimizes communication needed to remove a
+    subset of same-tensor-dimension parameter shards while retaining the rest.
 
     Args:
         module: The FX GraphModule containing parameter and gradient nodes.
         sharding_placement: Mapping from nodes to their sharding OpSpec.
 
     Returns:
-        Dictionary mapping nodes to their OrderInfo, indicating whether
-        they need reordering and their target order.
+        Dictionary mapping nodes to the preferred parameter storage order.
     """
     param_and_grad_nodes = list(get_param_and_grad_nodes(module.graph).values())
 
@@ -329,46 +381,43 @@ def compute_optimal_placement_order_for_parameters(
         if param_curr_plc != grad_tgt_plc:
             continue
 
-        # Only support S(0)S(0) -> RS(0) and PS(0) -> S(0)S(0) optimizations
-        is_supported_param_pattern = (
-            param_curr_plc == _PARAM_PLACEMENT
-            and param_tgt_plc == _PARAM_TARGET_PLACEMENT
+        preferred_shard_order = _infer_fsdplike_storage_order(
+            param_curr_plc, param_tgt_plc
         )
-        is_supported_grad_pattern = (
-            grad_curr_plc == _GRAD_PLACEMENT and grad_tgt_plc == _GRAD_TARGET_PLACEMENT
-        )
-
-        if not (is_supported_param_pattern and is_supported_grad_pattern):
+        if preferred_shard_order is None or not _matches_inverse_gradient_pattern(
+            param_curr_plc,
+            param_tgt_plc,
+            grad_curr_plc,
+            grad_tgt_plc,
+        ):
             continue
 
         # Get the user nodes where redistribution occurs
         param_redistrib_node = redistribution_map[param_node][0]
         grad_redistrib_node = redistribution_map[grad_node][0]
 
-        # Handle forward pass: assign order info to param chain
-        # Nodes need order reversed from (1,0) to (0,1) at the redistribution point
+        # Preserve the chosen storage order through the forward parameter chain.
         param_source = node_to_source[param_redistrib_node]
         param_chain = source_to_chain[param_source]
         _assign_order_info_to_chain(
             param_chain,
             target_node=param_redistrib_node,
-            target_reversed_order=False,
+            preferred_shard_order=preferred_shard_order,
             order_map=redistribute_node_order,
         )
 
-        # Handle backward pass: assign order info to grad chain
-        # Nodes need order reversed from (0,1) to (1,0) at the redistribution point
+        # Restore gradients to the same storage order in the backward chain.
         grad_source = node_to_source[grad_redistrib_node]
         grad_chain = source_to_chain[grad_source]
         _assign_order_info_to_chain(
             grad_chain,
             target_node=grad_redistrib_node,
-            target_reversed_order=True,
+            preferred_shard_order=preferred_shard_order,
             order_map=redistribute_node_order,
         )
 
     # Apply shard_order metadata to nodes
     for node, order_info in redistribute_node_order.items():
-        node.meta["shard_order"] = order_info.is_target_reversed_order
+        node.meta["shard_order"] = order_info.preferred_shard_order
 
     return redistribute_node_order

--- a/tests/test_apply_sharding.py
+++ b/tests/test_apply_sharding.py
@@ -4,48 +4,58 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
+from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor._dtensor_spec import (
     DTensorSpec,
     ShardOrderEntry,
     TensorMeta,
 )
+from torch.distributed.tensor._op_schema import OpSpec
 from torch.distributed.tensor.placement_types import Partial, Replicate, Shard
 from torch.fx.experimental.proxy_tensor import make_fx
 
-from autoparallel.apply_sharding import _compute_shard_order
-from autoparallel.shardings.ordered_sharding import ordered_redistribute_local_tensor
+from autoparallel.apply_sharding import (
+    ApplyShardingInterpreter,
+    _build_physical_placements,
+    _project_shard_order,
+)
+from autoparallel.shardings.ordered_sharding import (
+    OrderInfo,
+    ordered_redistribute_local_tensor,
+)
 
 
-class TestComputeShardOrder:
-    def test_sorted_order(self):
-        shard_order = (ShardOrderEntry(tensor_dim=0, mesh_dims=(2, 0, 1)),)
-        result = _compute_shard_order(shard_order, reverse=False)
-        assert result == (ShardOrderEntry(tensor_dim=0, mesh_dims=(0, 1, 2)),)
-
-    def test_reversed_order(self):
-        shard_order = (ShardOrderEntry(tensor_dim=0, mesh_dims=(2, 0, 1)),)
-        result = _compute_shard_order(shard_order, reverse=True)
-        assert result == (ShardOrderEntry(tensor_dim=0, mesh_dims=(2, 1, 0)),)
-
-    def test_multiple_entries(self):
-        shard_order = (
-            ShardOrderEntry(tensor_dim=0, mesh_dims=(3, 1)),
-            ShardOrderEntry(tensor_dim=1, mesh_dims=(2, 0)),
+class TestProjectShardOrder:
+    def test_projects_3d_storage_order(self):
+        mesh = DeviceMesh(
+            "cuda",
+            torch.arange(8).reshape(2, 2, 2),
+            mesh_dim_names=("dp", "cp", "tp"),
         )
-        result = _compute_shard_order(shard_order, reverse=False)
-        assert result == (
-            ShardOrderEntry(tensor_dim=0, mesh_dims=(1, 3)),
-            ShardOrderEntry(tensor_dim=1, mesh_dims=(0, 2)),
+        preferred = (ShardOrderEntry(tensor_dim=0, mesh_dims=(2, 1, 0)),)
+
+        storage = DTensorSpec(mesh, (Shard(0), Shard(0), Shard(0)))
+        compute = DTensorSpec(mesh, (Replicate(), Replicate(), Shard(0)))
+        grad_compute = DTensorSpec(mesh, (Partial(), Partial(), Shard(0)))
+
+        assert _project_shard_order(preferred, storage) == preferred
+        assert _project_shard_order(preferred, compute) == (
+            ShardOrderEntry(tensor_dim=0, mesh_dims=(2,)),
+        )
+        assert _project_shard_order(preferred, grad_compute) == (
+            ShardOrderEntry(tensor_dim=0, mesh_dims=(2,)),
         )
 
-    def test_already_sorted_is_idempotent(self):
-        shard_order = (ShardOrderEntry(tensor_dim=0, mesh_dims=(0, 1, 2)),)
-        result = _compute_shard_order(shard_order, reverse=False)
-        assert result == shard_order
+    def test_uncovered_shard_falls_back_to_spec_order(self):
+        mesh = DeviceMesh(
+            "cuda",
+            torch.arange(8).reshape(2, 2, 2),
+            mesh_dim_names=("dp", "cp", "tp"),
+        )
+        preferred = (ShardOrderEntry(tensor_dim=0, mesh_dims=(2, 0)),)
+        spec = DTensorSpec(mesh, (Shard(0), Shard(1), Shard(0)))
 
-    def test_empty(self):
-        assert _compute_shard_order((), reverse=False) == ()
-        assert _compute_shard_order((), reverse=True) == ()
+        assert _project_shard_order(preferred, spec) == spec.shard_order
 
 
 def _count_collectives(gm):
@@ -76,12 +86,12 @@ class TestOrderedRedistributeFusion:
     """Test that ordered_redistribute_local_tensor fuses multi-dim collectives
     into single flat-mesh operations when possible."""
 
-    def _make_specs(self, device_mesh_2d, src_plc, dst_plc, shape=(1024, 4096)):
+    def _make_specs(self, mesh, src_plc, dst_plc, shape=(1024, 4096)):
         tm = _make_tensor_meta(shape)
-        src = DTensorSpec(device_mesh_2d, src_plc, tensor_meta=tm)
-        dst = DTensorSpec(device_mesh_2d, dst_plc, tensor_meta=tm)
+        src = DTensorSpec(mesh, src_plc, tensor_meta=tm)
+        dst = DTensorSpec(mesh, dst_plc, tensor_meta=tm)
         local_shape = list(shape)
-        for mesh_size, p in zip(device_mesh_2d.shape, src_plc):
+        for mesh_size, p in zip(mesh.shape, src_plc):
             if p.is_shard():
                 local_shape[p.dim] //= mesh_size
         local = torch.randn(local_shape, device="meta")
@@ -176,6 +186,69 @@ class TestOrderedRedistributeFusion:
         counts = _count_collectives(gm)
         assert counts["all_gather"] >= 1
 
+    def test_3d_fsdplike_gather_has_no_alltoall(self):
+        mesh = DeviceMesh(
+            "cuda",
+            torch.arange(8).reshape(2, 2, 2),
+            mesh_dim_names=("dp", "cp", "tp"),
+        )
+        src, dst, local = self._make_specs(
+            mesh,
+            (Shard(0), Shard(0), Shard(0)),
+            (Replicate(), Replicate(), Shard(0)),
+            shape=(6144, 4096),
+        )
+        src.shard_order = (ShardOrderEntry(tensor_dim=0, mesh_dims=(2, 1, 0)),)
+
+        def trace_fn(x):
+            return ordered_redistribute_local_tensor(x, src, dst)
+
+        gm = make_fx(trace_fn, tracing_mode="real")(local)
+        counts = _count_collectives(gm)
+        assert counts == {"all_gather": 2, "reduce_scatter": 0, "alltoall": 0}
+
+    def test_3d_fsdplike_gradient_has_no_alltoall(self):
+        mesh = DeviceMesh(
+            "cuda",
+            torch.arange(8).reshape(2, 2, 2),
+            mesh_dim_names=("dp", "cp", "tp"),
+        )
+        src, dst, local = self._make_specs(
+            mesh,
+            (Partial(), Partial(), Shard(0)),
+            (Shard(0), Shard(0), Shard(0)),
+            shape=(6144, 4096),
+        )
+        dst.shard_order = (ShardOrderEntry(tensor_dim=0, mesh_dims=(2, 1, 0)),)
+
+        def trace_fn(x):
+            return ordered_redistribute_local_tensor(x, src, dst)
+
+        gm = make_fx(trace_fn, tracing_mode="real")(local)
+        counts = _count_collectives(gm)
+        assert counts == {"all_gather": 0, "reduce_scatter": 2, "alltoall": 0}
+
+    def test_4d_fsdplike_gather_has_no_alltoall(self):
+        mesh = DeviceMesh(
+            "cuda",
+            torch.arange(16).reshape(2, 2, 2, 2),
+            mesh_dim_names=("a", "b", "c", "d"),
+        )
+        src, dst, local = self._make_specs(
+            mesh,
+            (Shard(0), Shard(0), Shard(0), Shard(0)),
+            (Replicate(), Shard(0), Replicate(), Shard(0)),
+            shape=(4096, 1024),
+        )
+        src.shard_order = (ShardOrderEntry(tensor_dim=0, mesh_dims=(1, 3, 2, 0)),)
+
+        def trace_fn(x):
+            return ordered_redistribute_local_tensor(x, src, dst)
+
+        gm = make_fx(trace_fn, tracing_mode="real")(local)
+        counts = _count_collectives(gm)
+        assert counts == {"all_gather": 2, "reduce_scatter": 0, "alltoall": 0}
+
 
 class TestShardOrderSpecIsolation:
     """Test that shard_order modifications don't leak between shared DTensorSpec
@@ -184,9 +257,6 @@ class TestShardOrderSpecIsolation:
     def test_redistribute_does_not_mutate_input_specs(self, device_mesh_2d):
         """redistribute_tensor must not modify the shard_order on the specs
         it receives, since those specs may be shared across clustered nodes."""
-        from autoparallel.apply_sharding import ApplyShardingInterpreter
-        from autoparallel.shardings.ordered_sharding import OrderInfo
-
         tm = _make_tensor_meta([64, 64])
 
         # Two params sharing the same DTensorSpec objects (simulates clustering)
@@ -218,7 +288,11 @@ class TestShardOrderSpecIsolation:
             gm,
             sharding_placement,
             param_placement_order={
-                t: OrderInfo(is_target_reversed_order=False, need_reorder=True),
+                t: OrderInfo(
+                    preferred_shard_order=(
+                        ShardOrderEntry(tensor_dim=0, mesh_dims=(1, 0)),
+                    )
+                ),
             },
         )
 
@@ -240,3 +314,48 @@ class TestShardOrderSpecIsolation:
             f"tgt_spec.shard_order was mutated: "
             f"{shared_tgt_spec.shard_order} != {original_tgt_order}"
         )
+
+
+def test_build_physical_placements_3d_uses_strided_shards():
+    mesh = DeviceMesh(
+        "cuda",
+        torch.arange(8).reshape(2, 2, 2),
+        mesh_dim_names=("dp", "cp", "tp"),
+    )
+    tm = _make_tensor_meta([6144, 4096])
+    storage = DTensorSpec(
+        mesh,
+        (Shard(0), Shard(0), Shard(0)),
+        tensor_meta=tm,
+    )
+    graph = torch.fx.Graph()
+    param = graph.placeholder("param")
+    sharding_placement = {
+        param: OpSpec(
+            output_specs=storage,
+            input_specs=[storage],
+        )
+    }
+    physical = _build_physical_placements(
+        sharding_placement,
+        {
+            param: OrderInfo(
+                preferred_shard_order=(
+                    ShardOrderEntry(tensor_dim=0, mesh_dims=(2, 1, 0)),
+                )
+            )
+        },
+    )[param]
+
+    from torch.distributed.tensor.placement_types import _StridedShard
+
+    assert isinstance(physical.placements[0], _StridedShard)
+    assert physical.placements[0].split_factor == 4
+    assert isinstance(physical.placements[1], _StridedShard)
+    assert physical.placements[1].split_factor == 2
+    assert type(physical.placements[2]) is Shard
+    _, decoded_order = DTensorSpec._normalize_placements_into_shard_order(
+        physical.placements,
+        physical.mesh,
+    )
+    assert decoded_order == (ShardOrderEntry(tensor_dim=0, mesh_dims=(2, 1, 0)),)

--- a/tests/test_dcp_ordered_sharding.py
+++ b/tests/test_dcp_ordered_sharding.py
@@ -20,7 +20,7 @@ import torch
 from torch.distributed._local_tensor import LocalTensor, LocalTensorMode
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.tensor import DTensor
-from torch.distributed.tensor._dtensor_spec import DTensorSpec
+from torch.distributed.tensor._dtensor_spec import DTensorSpec, ShardOrderEntry
 from torch.distributed.tensor._utils import _compute_local_shape_and_global_offset
 from torch.distributed.tensor.placement_types import (
     Partial,
@@ -28,8 +28,6 @@ from torch.distributed.tensor.placement_types import (
     Shard,
     _StridedShard,
 )
-
-from autoparallel.apply_sharding import _compute_shard_order
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -69,8 +67,7 @@ class TestStridedShardFromReversedOrder:
     """Verify that reversed shard_order produces _StridedShard placements."""
 
     def test_reversed_order_produces_strided_shard(self, device_mesh_2d):
-        default_order = DTensorSpec.compute_default_shard_order((Shard(0), Shard(0)))
-        reversed_order = _compute_shard_order(default_order, reverse=True)
+        reversed_order = (ShardOrderEntry(tensor_dim=0, mesh_dims=(1, 0)),)
 
         strided = DTensorSpec._convert_shard_order_to_StridedShard(
             reversed_order, (Shard(0), Shard(0)), device_mesh_2d
@@ -519,9 +516,11 @@ class TestShardParamsWithOrderedSharding:
             param_node,
         ) = _build_linear_graph_and_placements(device_mesh_2d)
 
-        # Verify the param node is in placement_order with reversed flag.
+        # Verify the parameter carries the reversed 2D storage order.
         assert param_node in param_placement_order
-        assert param_placement_order[param_node].is_target_reversed_order is True
+        assert param_placement_order[param_node].preferred_shard_order == (
+            ShardOrderEntry(tensor_dim=0, mesh_dims=(1, 0)),
+        )
 
         fqn_to_param = get_named_param_nodes(gm.graph)
         params_spec = {fqn: None for fqn in fqn_to_param}

--- a/tests/test_ordered_sharding.py
+++ b/tests/test_ordered_sharding.py
@@ -10,12 +10,14 @@ from conftest import apply_cuda_patches
 from torch import nn
 from torch._functorch._aot_autograd.fx_utils import get_param_and_grad_nodes
 from torch._functorch.aot_autograd import aot_export_joint_with_descriptors
-from torch.distributed._tensor.placement_types import DTensorSpec
+from torch.distributed.tensor._dtensor_spec import DTensorSpec, ShardOrderEntry
 from torch.distributed.tensor._op_schema import OpSpec
 from torch.distributed.tensor.placement_types import Partial, Replicate, Shard
 
 from autoparallel.api import AutoParallel
 from autoparallel.shardings.ordered_sharding import (
+    _infer_fsdplike_storage_order,
+    _matches_inverse_gradient_pattern,
     build_param_grad_linear_chains,
     compute_optimal_placement_order_for_parameters,
     get_redistributed_input_placements,
@@ -572,25 +574,13 @@ def test_compute_optimal_placement_order_ss_to_rs(device_mesh_2d):
     assert param in placement_order
     assert grad in placement_order
 
-    # Verify OrderInfo values for param chain nodes
-    # param: first in chain, before target → is_target_reversed_order=True, need_reorder=False
-    assert placement_order[param].is_target_reversed_order is True
-    assert placement_order[param].need_reorder is False
+    expected_order = (ShardOrderEntry(tensor_dim=0, mesh_dims=(1, 0)),)
 
-    # t_node: target of param chain → is_target_reversed_order=False, need_reorder=True
-    assert placement_order[t_node].is_target_reversed_order is False
-    assert placement_order[t_node].need_reorder is True
-
-    # Verify OrderInfo values for grad chain nodes
-    # The last node in the grad chain is where redistribution happens (need_reorder=True)
-    grad_redistrib_target = grad_chain[-1]
-    assert placement_order[grad_redistrib_target].is_target_reversed_order is True
-    assert placement_order[grad_redistrib_target].need_reorder is True
-
-    # All earlier nodes in grad chain should have need_reorder=False
-    for node in grad_chain[:-1]:
-        assert placement_order[node].is_target_reversed_order is True
-        assert placement_order[node].need_reorder is False
+    # Forward and backward chains preserve the same parameter storage order.
+    assert placement_order[param].preferred_shard_order == expected_order
+    assert placement_order[t_node].preferred_shard_order == expected_order
+    for node in grad_chain:
+        assert placement_order[node].preferred_shard_order == expected_order
 
     # All nodes in placement_order should have shard_order metadata
     for node in placement_order:
@@ -673,14 +663,142 @@ def test_compute_optimal_placement_order_ss_to_rs_with_grad_chain_redistribution
     )
     assert grad_alias in placement_order
 
-    # Verify forward chain ordering
-    assert placement_order[param].need_reorder is False
-    assert placement_order[dtype_cast_fwd].need_reorder is False
-    assert placement_order[permute_fwd].need_reorder is True
+    expected_order = (ShardOrderEntry(tensor_dim=0, mesh_dims=(1, 0)),)
+    assert placement_order[param].preferred_shard_order == expected_order
+    assert placement_order[dtype_cast_fwd].preferred_shard_order == expected_order
+    assert placement_order[permute_fwd].preferred_shard_order == expected_order
+    assert placement_order[grad_alias].preferred_shard_order == expected_order
 
-    # Verify backward chain ordering
-    assert placement_order[grad_alias].need_reorder is True
-    assert placement_order[grad_alias].is_target_reversed_order is True
+
+def test_infer_fsdplike_storage_order_3d():
+    source = (Shard(0), Shard(0), Shard(0))
+    target = (Replicate(), Replicate(), Shard(0))
+
+    assert _infer_fsdplike_storage_order(source, target) == (
+        ShardOrderEntry(tensor_dim=0, mesh_dims=(2, 1, 0)),
+    )
+
+
+def test_infer_fsdplike_storage_order_4d():
+    source = (Shard(0), Shard(0), Shard(0), Shard(0))
+    target = (Replicate(), Shard(0), Replicate(), Shard(0))
+
+    assert _infer_fsdplike_storage_order(source, target) == (
+        ShardOrderEntry(tensor_dim=0, mesh_dims=(1, 3, 2, 0)),
+    )
+
+
+def test_infer_fsdplike_storage_order_multiple_tensor_dims():
+    source = (Shard(0), Shard(1), Shard(0), Shard(1))
+    target = (Replicate(), Shard(1), Shard(0), Replicate())
+
+    assert _infer_fsdplike_storage_order(source, target) == (
+        ShardOrderEntry(tensor_dim=0, mesh_dims=(2, 0)),
+        ShardOrderEntry(tensor_dim=1, mesh_dims=(1, 3)),
+    )
+
+
+def test_infer_fsdplike_storage_order_rejects_unsupported_patterns():
+    assert (
+        _infer_fsdplike_storage_order(
+            (Shard(0), Shard(0)),
+            (Replicate(), Replicate()),
+        )
+        is None
+    )
+    assert (
+        _infer_fsdplike_storage_order(
+            (Shard(0), Replicate()),
+            (Replicate(), Shard(0)),
+        )
+        is None
+    )
+    assert (
+        _infer_fsdplike_storage_order(
+            (Shard(0), Shard(0)),
+            (Replicate(), Shard(1)),
+        )
+        is None
+    )
+    assert (
+        _infer_fsdplike_storage_order(
+            (Partial(), Shard(0)),
+            (Replicate(), Shard(0)),
+        )
+        is None
+    )
+
+
+def test_matches_inverse_gradient_pattern_3d():
+    param_source = (Shard(0), Shard(0), Shard(0))
+    param_target = (Replicate(), Replicate(), Shard(0))
+
+    assert _matches_inverse_gradient_pattern(
+        param_source,
+        param_target,
+        (Partial(), Partial(), Shard(0)),
+        param_source,
+    )
+    assert not _matches_inverse_gradient_pattern(
+        param_source,
+        param_target,
+        (Partial(), Replicate(), Shard(0)),
+        param_source,
+    )
+    assert not _matches_inverse_gradient_pattern(
+        param_source,
+        param_target,
+        (Partial(), Partial(), Shard(0)),
+        (Replicate(), Shard(0), Shard(0)),
+    )
+
+
+def test_compute_optimal_placement_order_3d(device_mesh_3d):
+    graph = torch.fx.Graph()
+    param = graph.placeholder("param")
+    x = graph.placeholder("x")
+    dtype_cast_fwd = graph.call_function(torch.ops.aten.clone.default, (param,))
+    permute_fwd = graph.call_function(torch.ops.aten.t.default, (dtype_cast_fwd,))
+    mm_fwd = graph.call_function(torch.ops.aten.mm.default, (x, permute_fwd))
+
+    grad_out = graph.placeholder("grad_out")
+    mm_bwd = graph.call_function(torch.ops.aten.mm.default, (x, grad_out))
+    permute_bwd = graph.call_function(torch.ops.aten.t.default, (mm_bwd,))
+    dtype_cast_bwd = graph.call_function(torch.ops.aten.clone.default, (permute_bwd,))
+    grad_alias = graph.call_function(torch.ops.aten.clone.default, (dtype_cast_bwd,))
+    graph.output((mm_fwd, grad_alias))
+    gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+    storage = DTensorSpec(device_mesh_3d, (Shard(0), Shard(0), Shard(0)))
+    compute = DTensorSpec(device_mesh_3d, (Replicate(), Replicate(), Shard(0)))
+    grad_compute = DTensorSpec(device_mesh_3d, (Partial(), Partial(), Shard(0)))
+
+    sharding_placement = {
+        param: OpSpec(output_specs=storage, input_specs=[storage]),
+        x: OpSpec(output_specs=compute),
+        dtype_cast_fwd: OpSpec(output_specs=storage, input_specs=[storage]),
+        permute_fwd: OpSpec(output_specs=compute, input_specs=[compute]),
+        mm_fwd: OpSpec(output_specs=compute, input_specs=[compute, compute]),
+        grad_out: OpSpec(output_specs=compute),
+        mm_bwd: OpSpec(output_specs=compute, input_specs=[compute, compute]),
+        permute_bwd: OpSpec(output_specs=grad_compute, input_specs=[grad_compute]),
+        dtype_cast_bwd: OpSpec(output_specs=grad_compute, input_specs=[grad_compute]),
+        grad_alias: OpSpec(output_specs=storage, input_specs=[storage]),
+    }
+
+    import unittest.mock as mock
+
+    with mock.patch(
+        "autoparallel.shardings.ordered_sharding.get_param_and_grad_nodes"
+    ) as get_pairs:
+        get_pairs.return_value = {0: (param, grad_alias)}
+        placement_order = compute_optimal_placement_order_for_parameters(
+            gm, sharding_placement
+        )
+
+    expected_order = (ShardOrderEntry(tensor_dim=0, mesh_dims=(2, 1, 0)),)
+    assert placement_order[permute_fwd].preferred_shard_order == expected_order
+    assert placement_order[grad_alias].preferred_shard_order == expected_order
 
 
 def test_compute_optimal_placement_order_verifies_redistribution_map(device_mesh_2d):


### PR DESCRIPTION
## Summary

Generalize the existing ordered-sharding optimization from the hard-coded 2-D `S(0)S(0) -> RS(0)` case to N-D FSDP-like parameter layouts.

The implementation derives a preferred physical shard order from the selected source and target placements, verifies that the gradient redistribution is the adjoint of the forward parameter redistribution, propagates that order through the parameter and gradient chains, and projects it onto each concrete DTensor spec.

## Why

For a 3-D `[dp_shard, cp, tp]` placement such as `S(0)S(0)S(0) -> RRS(0)`, the retained TP shard is innermost in the default layout. Removing the outer DP and CP shards without carrying an explicit physical order can make DTensor lower the redistribution through shard-dimension permutations instead of the intended two all-gathers.

This change stores the retained shard outside the released shards. For the example above the preferred mesh-axis order is `[tp, cp, dp]`, so lowering is:

```
[768, 4096]
  -> size-2 all-gather
  -> [1536, 4096]
  -> size-2 all-gather
  -> [3072, 4096]
```

There is no parameter-chain all-to-all.

## Changes

- infer FSDP-like storage order for arbitrary mesh dimensionality;
- require the matching adjoint gradient redistribution before applying it;
- carry one preferred order through forward parameter and backward gradient chains;
- project that order onto source and target DTensor specs;
- construct matching physical `_StridedShard` placements;
- use the flattened same-sharding fast path only for default device order;
- add 3-D, 4-D, gradient, physical-layout, and DCP regression coverage.

This does not change the sharding solver, cost model, attention implementation, or collective APIs.

## Stack

This is a stacked draft based on `kaijian/pr523-cp-integration` at `ec819dbe`. That base combines the PR 520-523 solver stack with the PR 516 context-parallel stack used by the integration validation. This PR itself contains one commit.

## Validation

Current head:

- `python -m pytest -q tests/test_ordered_sharding.py tests/test_apply_sharding.py tests/test_dcp_ordered_sharding.py`
  - 48 passed
- AST, merge-conflict, added-large-file, black, flake8, and isort hooks pass on all changed files.
- The changed files introduce no mypy errors. The repository-wide invocation still reaches 14 pre-existing errors in `_context_parallel.py` and `module_construction.py` from the stacked base.

Distributed validation was run on the pre-typing-cleanup version of this commit (`4b6c31b`) with LLaMA 3 8B, sequence length 8192, and `dp_shard=2, cp=2, tp=2` on eight H100 GPUs:

- the target `S(0)S(0)S(0) -> RRS(0)` parameter path contains two all-gathers and no all-to-all;
- one-step loss relative difference: `4.99e-6`;
- one-step gradient-norm relative difference: `2.36e-6`;
- both arms used identical Flash-attention forward/backward contracts;
- a same-allocation 5-warmup/20-measured-step AB run was at throughput parity (`+0.322%` for AutoParallel; descriptive single-order result).

The current head only replaces a comprehension with an explicitly typed loop in `_project_shard_order`; the complete 48-test suite above was rerun afterward.
