### PR TITLE
Fix main CI breakages from torch nightly changes

### DIFF
--- a/autoparallel/shardings/placement_options.py
+++ b/autoparallel/shardings/placement_options.py
@@ -13,6 +13,7 @@ from typing import Any, Iterable
 
 import torch
 import torch.utils._pytree as pytree
+from torch._higher_order_ops.local_map import local_map_hop
 from torch.distributed._tensor.placement_types import Placement, TensorMeta
 from torch.distributed.device_mesh import _get_device_handle
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
@@ -397,9 +398,7 @@ def get_local_map_placement_option(
         mesh,
         None,
     ), "Not yet implemented"
-    assert "call_local_map" in str(node.target) or "call_local_map_backward" in str(
-        node.target
-    )
+    assert node.target is local_map_hop
     in_specs = []
     num_activation_inputs = len(user_args) - len(in_placements)
     # activations are always replicated

--- a/autoparallel/tools/overlap_simulator/run.py
+++ b/autoparallel/tools/overlap_simulator/run.py
@@ -252,7 +252,8 @@ class NodeEstimator:
         if isinstance(x, int):
             return x
         if hasattr(x, "node") and hasattr(x.node, "hint"):
-            return x.node.hint
+            hint = x.node.hint
+            return hint if isinstance(hint, int) else None
         return None
 
     @staticmethod
@@ -399,7 +400,9 @@ class ExperimentRunner:
             if info["size"] == world_size:
                 pgs[name] = default_pg
             else:
-                pgs[name] = dist.new_group(list(range(info["size"])))
+                pg = dist.new_group(list(range(info["size"])))
+                assert isinstance(pg, dist.ProcessGroup)
+                pgs[name] = pg
 
         # Re-register under the desired names
         torch._C._distributed_c10d._unregister_all_process_groups()


### PR DESCRIPTION
pytorch/pytorch#186647 changed the local_map HOP's FX target from a nested `call_local_map` closure to the `local_map_hop` object itself, with the body GraphModule passed as a get_attr submodule argument. That broke the string-based target assert in get_local_map_placement_option, and with it every local_map test and example on main. Check identity against local_map_hop instead; the get_attr body argument was already handled.

Also fix two mypy errors in the overlap simulator caused by tightened upstream annotations: SymNode.hint is now a wide union, and dist.new_group may return the non-member sentinel.

Authored with Claude Code.